### PR TITLE
Phase 2: lexer

### DIFF
--- a/lib/schooner/lexer.ex
+++ b/lib/schooner/lexer.ex
@@ -1,0 +1,702 @@
+defmodule Schooner.Lexer do
+  @moduledoc """
+  Hand-rolled lexer turning Scheme source text into a flat token stream.
+
+  Every token carries the `{line, column}` of its first character so the
+  reader, expander, and error reporters downstream can quote source
+  locations back to the user without keeping the original string around.
+
+  ## Token shape
+
+  Tokens are 3-tuples `{tag, value, position}` where:
+
+    * `tag` is one of the atoms enumerated in `t:tag/0`
+    * `value` is `nil` for tokens whose tag is self-describing (parens,
+      quote markers, dot, vector opens) and the parsed payload for the rest
+    * `position` is `{line, column}`, both 1-based
+
+  ## Errors
+
+  Lexer errors are raised as `Schooner.Lexer.Error` with a structured
+  reason and the source position at which the offending input begins.
+  Errors are exceptions rather than tagged tuples because every caller
+  in the pipeline (reader, embedding API) treats a lex failure as fatal
+  for the current source unit.
+  """
+
+  alias Schooner.Lexer.Error
+
+  @type position :: {pos_integer(), pos_integer()}
+
+  @type tag ::
+          :lparen
+          | :rparen
+          | :vector_open
+          | :bytevector_open
+          | :quote
+          | :quasiquote
+          | :unquote
+          | :unquote_splicing
+          | :dot
+          | :ident
+          | :integer
+          | :float
+          | :string
+          | :char
+          | :bool
+          | :datum_comment
+
+  @type token :: {tag(), term(), position()}
+
+  # Characters that terminate an "atom" (an identifier or numeric literal).
+  @terminators [?\s, ?\t, ?\r, ?\n, ?(, ?), ?[, ?], ?{, ?}, ?", ?;, ?|, ?', ?`, ?,]
+
+  @doc """
+  Tokenise a Scheme source binary into a list of tokens.
+
+  Whitespace, line comments (`;`), nested block comments (`#| ... |#`)
+  and datum comments (`#;`) are recognised. Whitespace and the comment
+  bodies are dropped; `#;` is preserved as a sentinel `:datum_comment`
+  token because the lexer cannot know how much of the following stream
+  forms the next datum — that is the reader's job.
+
+  Raises `Schooner.Lexer.Error` on malformed input.
+  """
+  @spec tokenise(binary()) :: [token()]
+  def tokenise(source) when is_binary(source) do
+    scan(source, 1, 1, [])
+  end
+
+  # ---------------------------------------------------------------------------
+  # Top-level scanner
+  # ---------------------------------------------------------------------------
+
+  defp scan(<<>>, _line, _col, acc), do: Enum.reverse(acc)
+
+  # newlines
+  defp scan(<<?\r, ?\n, rest::binary>>, line, _col, acc), do: scan(rest, line + 1, 1, acc)
+  defp scan(<<?\n, rest::binary>>, line, _col, acc), do: scan(rest, line + 1, 1, acc)
+  defp scan(<<?\r, rest::binary>>, line, _col, acc), do: scan(rest, line + 1, 1, acc)
+
+  # spaces / tabs
+  defp scan(<<c, rest::binary>>, line, col, acc) when c in [?\s, ?\t] do
+    scan(rest, line, col + 1, acc)
+  end
+
+  # line comment
+  defp scan(<<?;, rest::binary>>, line, col, acc) do
+    {rest, line, col} = skip_line(rest, line, col + 1)
+    scan(rest, line, col, acc)
+  end
+
+  # block comment / datum comment / hash forms
+  defp scan(<<?#, ?|, rest::binary>>, line, col, acc) do
+    {rest, line, col} = skip_block(rest, line, col + 2, 1, {line, col})
+    scan(rest, line, col, acc)
+  end
+
+  defp scan(<<?#, ?;, rest::binary>>, line, col, acc) do
+    scan(rest, line, col + 2, [{:datum_comment, nil, {line, col}} | acc])
+  end
+
+  defp scan(<<?#, ?u, ?8, ?(, rest::binary>>, line, col, acc) do
+    scan(rest, line, col + 4, [{:bytevector_open, nil, {line, col}} | acc])
+  end
+
+  defp scan(<<?#, ?(, rest::binary>>, line, col, acc) do
+    scan(rest, line, col + 2, [{:vector_open, nil, {line, col}} | acc])
+  end
+
+  defp scan(<<?#, ?\\, rest::binary>>, line, col, acc) do
+    {token, rest, col2} = read_char(rest, line, col + 2, {line, col})
+    scan(rest, line, col2, [token | acc])
+  end
+
+  defp scan(<<?#, c, _::binary>> = src, line, col, acc)
+       when c in [?e, ?i, ?b, ?o, ?d, ?x, ?E, ?I, ?B, ?D, ?O, ?X] do
+    {token, rest, col2} = read_prefixed_number(src, line, col)
+    scan(rest, line, col2, [token | acc])
+  end
+
+  defp scan(<<?#, ?t, ?r, ?u, ?e, rest::binary>>, line, col, acc) do
+    finish_bool(rest, line, col, 5, true, acc)
+  end
+
+  defp scan(<<?#, ?f, ?a, ?l, ?s, ?e, rest::binary>>, line, col, acc) do
+    finish_bool(rest, line, col, 6, false, acc)
+  end
+
+  defp scan(<<?#, ?t, rest::binary>>, line, col, acc) do
+    finish_bool(rest, line, col, 2, true, acc)
+  end
+
+  defp scan(<<?#, ?f, rest::binary>>, line, col, acc) do
+    finish_bool(rest, line, col, 2, false, acc)
+  end
+
+  defp scan(<<?#, c, _::binary>>, line, col, _acc) do
+    raise Error, reason: {:invalid_hash_form, c}, position: {line, col}
+  end
+
+  # punctuation
+  defp scan(<<?(, rest::binary>>, line, col, acc) do
+    scan(rest, line, col + 1, [{:lparen, nil, {line, col}} | acc])
+  end
+
+  defp scan(<<?), rest::binary>>, line, col, acc) do
+    scan(rest, line, col + 1, [{:rparen, nil, {line, col}} | acc])
+  end
+
+  defp scan(<<?', rest::binary>>, line, col, acc) do
+    scan(rest, line, col + 1, [{:quote, nil, {line, col}} | acc])
+  end
+
+  defp scan(<<?`, rest::binary>>, line, col, acc) do
+    scan(rest, line, col + 1, [{:quasiquote, nil, {line, col}} | acc])
+  end
+
+  defp scan(<<?,, ?@, rest::binary>>, line, col, acc) do
+    scan(rest, line, col + 2, [{:unquote_splicing, nil, {line, col}} | acc])
+  end
+
+  defp scan(<<?,, rest::binary>>, line, col, acc) do
+    scan(rest, line, col + 1, [{:unquote, nil, {line, col}} | acc])
+  end
+
+  # vertical-bar identifier
+  defp scan(<<?|, rest::binary>>, line, col, acc) do
+    {name, rest, line2, col2} = read_bar_ident(rest, line, col + 1, {line, col}, [])
+    scan(rest, line2, col2, [{:ident, name, {line, col}} | acc])
+  end
+
+  # string literal
+  defp scan(<<?", rest::binary>>, line, col, acc) do
+    {str, rest, line2, col2} = read_string(rest, line, col + 1, {line, col}, [])
+    scan(rest, line2, col2, [{:string, str, {line, col}} | acc])
+  end
+
+  # numbers, peculiar identifiers, dots, identifiers
+  defp scan(<<c, _::binary>> = src, line, col, acc) do
+    cond do
+      c in ?0..?9 ->
+        {token, rest, col2} = read_atom_token(src, line, col, :auto, false)
+        scan(rest, line, col2, [token | acc])
+
+      c in [?+, ?-] ->
+        {token, rest, col2} = read_atom_token(src, line, col, :auto, true)
+        scan(rest, line, col2, [token | acc])
+
+      c == ?. ->
+        {token, rest, col2} = read_dot_token(src, line, col)
+        scan(rest, line, col2, [token | acc])
+
+      identifier_start?(c) ->
+        {token, rest, col2} = read_atom_token(src, line, col, :auto, false)
+        scan(rest, line, col2, [token | acc])
+
+      true ->
+        raise Error, reason: {:unexpected_char, c}, position: {line, col}
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Comments
+  # ---------------------------------------------------------------------------
+
+  defp skip_line(<<>>, line, col), do: {<<>>, line, col}
+  defp skip_line(<<?\r, ?\n, rest::binary>>, line, _col), do: {rest, line + 1, 1}
+  defp skip_line(<<?\n, rest::binary>>, line, _col), do: {rest, line + 1, 1}
+  defp skip_line(<<?\r, rest::binary>>, line, _col), do: {rest, line + 1, 1}
+
+  defp skip_line(<<_c::utf8, rest::binary>>, line, col) do
+    skip_line(rest, line, col + 1)
+  end
+
+  defp skip_block(<<>>, _line, _col, _depth, start) do
+    raise Error, reason: :unterminated_block_comment, position: start
+  end
+
+  defp skip_block(<<?|, ?#, rest::binary>>, line, col, 1, _start) do
+    {rest, line, col + 2}
+  end
+
+  defp skip_block(<<?|, ?#, rest::binary>>, line, col, depth, start) do
+    skip_block(rest, line, col + 2, depth - 1, start)
+  end
+
+  defp skip_block(<<?#, ?|, rest::binary>>, line, col, depth, start) do
+    skip_block(rest, line, col + 2, depth + 1, start)
+  end
+
+  defp skip_block(<<?\r, ?\n, rest::binary>>, line, _col, depth, start) do
+    skip_block(rest, line + 1, 1, depth, start)
+  end
+
+  defp skip_block(<<?\n, rest::binary>>, line, _col, depth, start) do
+    skip_block(rest, line + 1, 1, depth, start)
+  end
+
+  defp skip_block(<<?\r, rest::binary>>, line, _col, depth, start) do
+    skip_block(rest, line + 1, 1, depth, start)
+  end
+
+  defp skip_block(<<_c::utf8, rest::binary>>, line, col, depth, start) do
+    skip_block(rest, line, col + 1, depth, start)
+  end
+
+  # ---------------------------------------------------------------------------
+  # Booleans
+  # ---------------------------------------------------------------------------
+
+  defp finish_bool(rest, line, col, consumed, value, acc) do
+    case rest do
+      <<c, _::binary>> when c not in @terminators ->
+        raise Error, reason: {:invalid_boolean, c}, position: {line, col}
+
+      _ ->
+        scan(rest, line, col + consumed, [{:bool, value, {line, col}} | acc])
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Characters
+  # ---------------------------------------------------------------------------
+
+  @char_names %{
+    "alarm" => 7,
+    "backspace" => 8,
+    "delete" => 127,
+    "escape" => 27,
+    "newline" => 10,
+    "null" => 0,
+    "return" => 13,
+    "space" => 32,
+    "tab" => 9
+  }
+
+  # `#\` already consumed.
+  defp read_char(src, _line, col, start) do
+    case scan_char_run(src, []) do
+      {[], <<cp::utf8, rest::binary>>} -> {{:char, cp, start}, rest, col + 1}
+      {[], <<>>} -> raise Error, reason: :unterminated_char_literal, position: start
+      {[only], rest} -> {{:char, only, start}, rest, col + 1}
+      {chars, rest} -> read_named_or_hex_char(chars, rest, col, start)
+    end
+  end
+
+  defp read_named_or_hex_char(chars, rest, col, start) do
+    body = chars |> Enum.reverse() |> List.to_string()
+    cp = decode_named_or_hex_char(body, start)
+    {{:char, cp, start}, rest, col + String.length(body)}
+  end
+
+  defp scan_char_run(<<c::utf8, rest::binary>>, acc) do
+    if char_run?(c) do
+      scan_char_run(rest, [c | acc])
+    else
+      {acc, <<c::utf8, rest::binary>>}
+    end
+  end
+
+  defp scan_char_run(<<>>, acc), do: {acc, <<>>}
+
+  defp char_run?(c), do: c not in @terminators
+
+  defp decode_named_or_hex_char(<<?x, rest::binary>>, start) when byte_size(rest) > 0 do
+    if all_hex_digits?(rest) do
+      String.to_integer(rest, 16)
+    else
+      named_char(<<?x, rest::binary>>, start)
+    end
+  end
+
+  defp decode_named_or_hex_char(name, start), do: named_char(name, start)
+
+  defp named_char(name, start) do
+    case Map.fetch(@char_names, name) do
+      {:ok, cp} -> cp
+      :error -> raise Error, reason: {:unknown_char_name, name}, position: start
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Strings
+  # ---------------------------------------------------------------------------
+
+  defp read_string(<<>>, _line, _col, start, _acc) do
+    raise Error, reason: :unterminated_string, position: start
+  end
+
+  defp read_string(<<?", rest::binary>>, line, col, _start, acc) do
+    body = acc |> Enum.reverse() |> IO.iodata_to_binary()
+    {body, rest, line, col + 1}
+  end
+
+  defp read_string(<<?\\, rest::binary>>, line, col, start, acc) do
+    {chunk, rest, line, col} = string_escape(rest, line, col + 1, start)
+    read_string(rest, line, col, start, [chunk | acc])
+  end
+
+  defp read_string(<<?\r, ?\n, rest::binary>>, line, _col, start, acc) do
+    read_string(rest, line + 1, 1, start, [?\n | acc])
+  end
+
+  defp read_string(<<?\n, rest::binary>>, line, _col, start, acc) do
+    read_string(rest, line + 1, 1, start, [?\n | acc])
+  end
+
+  defp read_string(<<?\r, rest::binary>>, line, _col, start, acc) do
+    read_string(rest, line + 1, 1, start, [?\n | acc])
+  end
+
+  defp read_string(<<c::utf8, rest::binary>>, line, col, start, acc) do
+    read_string(rest, line, col + 1, start, [<<c::utf8>> | acc])
+  end
+
+  defp string_escape(<<>>, _line, _col, start) do
+    raise Error, reason: :unterminated_string, position: start
+  end
+
+  defp string_escape(<<?n, rest::binary>>, line, col, _s), do: {?\n, rest, line, col + 1}
+  defp string_escape(<<?t, rest::binary>>, line, col, _s), do: {?\t, rest, line, col + 1}
+  defp string_escape(<<?r, rest::binary>>, line, col, _s), do: {?\r, rest, line, col + 1}
+  defp string_escape(<<?b, rest::binary>>, line, col, _s), do: {?\b, rest, line, col + 1}
+  defp string_escape(<<?a, rest::binary>>, line, col, _s), do: {7, rest, line, col + 1}
+  defp string_escape(<<?", rest::binary>>, line, col, _s), do: {?", rest, line, col + 1}
+  defp string_escape(<<?\\, rest::binary>>, line, col, _s), do: {?\\, rest, line, col + 1}
+  defp string_escape(<<?|, rest::binary>>, line, col, _s), do: {?|, rest, line, col + 1}
+
+  defp string_escape(<<?x, rest::binary>>, line, col, _start) do
+    {cp, rest, taken} = read_hex_escape(rest, {line, col - 1})
+    {<<cp::utf8>>, rest, line, col + 1 + taken}
+  end
+
+  defp string_escape(<<c, _::binary>>, line, col, _start) do
+    raise Error, reason: {:invalid_escape, c}, position: {line, col - 1}
+  end
+
+  defp read_hex_escape(rest, start), do: read_hex_escape(rest, start, [])
+
+  defp read_hex_escape(<<?;, _rest::binary>>, start, []) do
+    raise Error, reason: :empty_hex_escape, position: start
+  end
+
+  defp read_hex_escape(<<?;, rest::binary>>, _start, acc) do
+    digits = acc |> Enum.reverse() |> List.to_string()
+    {String.to_integer(digits, 16), rest, byte_size(digits) + 1}
+  end
+
+  defp read_hex_escape(<<c, rest::binary>>, start, acc)
+       when c in ?0..?9 or c in ?a..?f or c in ?A..?F do
+    read_hex_escape(rest, start, [c | acc])
+  end
+
+  defp read_hex_escape(_rest, start, _acc) do
+    raise Error, reason: :unterminated_hex_escape, position: start
+  end
+
+  # ---------------------------------------------------------------------------
+  # Bar-quoted identifiers
+  # ---------------------------------------------------------------------------
+
+  defp read_bar_ident(<<>>, _line, _col, start, _acc) do
+    raise Error, reason: :unterminated_bar_identifier, position: start
+  end
+
+  defp read_bar_ident(<<?|, rest::binary>>, line, col, _start, acc) do
+    {acc |> Enum.reverse() |> IO.iodata_to_binary(), rest, line, col + 1}
+  end
+
+  defp read_bar_ident(<<?\\, ?|, rest::binary>>, line, col, start, acc) do
+    read_bar_ident(rest, line, col + 2, start, [?| | acc])
+  end
+
+  defp read_bar_ident(<<?\\, ?\\, rest::binary>>, line, col, start, acc) do
+    read_bar_ident(rest, line, col + 2, start, [?\\ | acc])
+  end
+
+  defp read_bar_ident(<<?\\, ?n, rest::binary>>, line, col, start, acc) do
+    read_bar_ident(rest, line, col + 2, start, [?\n | acc])
+  end
+
+  defp read_bar_ident(<<?\\, ?t, rest::binary>>, line, col, start, acc) do
+    read_bar_ident(rest, line, col + 2, start, [?\t | acc])
+  end
+
+  defp read_bar_ident(<<?\\, ?x, rest::binary>>, line, col, start, acc) do
+    {cp, rest, taken} = read_hex_escape(rest, start)
+    read_bar_ident(rest, line, col + 2 + taken, start, [<<cp::utf8>> | acc])
+  end
+
+  defp read_bar_ident(<<?\r, ?\n, rest::binary>>, line, _col, start, acc) do
+    read_bar_ident(rest, line + 1, 1, start, [?\n | acc])
+  end
+
+  defp read_bar_ident(<<?\n, rest::binary>>, line, _col, start, acc) do
+    read_bar_ident(rest, line + 1, 1, start, [?\n | acc])
+  end
+
+  defp read_bar_ident(<<c::utf8, rest::binary>>, line, col, start, acc) do
+    read_bar_ident(rest, line, col + 1, start, [<<c::utf8>> | acc])
+  end
+
+  # ---------------------------------------------------------------------------
+  # Numbers (with `#`-prefixes)
+  # ---------------------------------------------------------------------------
+
+  defp read_prefixed_number(src, line, col) do
+    {flags, rest, taken} = consume_prefixes(src, [], 0)
+    {radix, exactness} = resolve_prefix_flags(flags, line, col)
+    {raw, rest, atom_len} = scan_atom(rest, [])
+
+    if raw == "" do
+      raise Error, reason: :invalid_numeric_literal, position: {line, col}
+    end
+
+    case parse_number(raw, radix, exactness) do
+      {:ok, n} when is_integer(n) ->
+        {{:integer, n, {line, col}}, rest, col + taken + atom_len}
+
+      {:ok, f} when is_float(f) ->
+        {{:float, f, {line, col}}, rest, col + taken + atom_len}
+
+      :error ->
+        raise Error, reason: {:invalid_numeric_literal, raw}, position: {line, col}
+    end
+  end
+
+  @radix_flags %{?b => 2, ?B => 2, ?o => 8, ?O => 8, ?d => 10, ?D => 10, ?x => 16, ?X => 16}
+  @exactness_flags %{?e => :exact, ?E => :exact, ?i => :inexact, ?I => :inexact}
+
+  defp consume_prefixes(<<?#, c, rest::binary>>, acc, taken)
+       when is_map_key(@radix_flags, c) or is_map_key(@exactness_flags, c) do
+    consume_prefixes(rest, [c | acc], taken + 2)
+  end
+
+  defp consume_prefixes(rest, acc, taken), do: {Enum.reverse(acc), rest, taken}
+
+  defp resolve_prefix_flags(flags, line, col) do
+    Enum.reduce(flags, {nil, nil}, fn flag, {r, e} ->
+      case {Map.get(@radix_flags, flag), Map.get(@exactness_flags, flag)} do
+        {nil, exact} -> {r, set_once(e, exact, :exactness, line, col)}
+        {radix, nil} -> {set_once(r, radix, :radix, line, col), e}
+      end
+    end)
+    |> then(fn {r, e} -> {r || 10, e || :auto} end)
+  end
+
+  defp set_once(nil, value, _which, _line, _col), do: value
+
+  defp set_once(_existing, _value, which, line, col) do
+    raise Error, reason: {:duplicate_number_prefix, which}, position: {line, col}
+  end
+
+  # ---------------------------------------------------------------------------
+  # Atom scanning (numbers, peculiar identifiers, plain identifiers)
+  # ---------------------------------------------------------------------------
+
+  defp read_atom_token(src, line, col, exactness, allow_sign?) do
+    {raw, rest, taken} = scan_atom(src, [])
+    token = classify_atom(raw, line, col, exactness, allow_sign?)
+    {token, rest, col + taken}
+  end
+
+  defp scan_atom(<<>>, acc), do: build_atom(acc, <<>>)
+
+  defp scan_atom(<<c, rest::binary>>, acc) when c in @terminators do
+    build_atom(acc, <<c, rest::binary>>)
+  end
+
+  defp scan_atom(<<c::utf8, rest::binary>>, acc) do
+    scan_atom(rest, [<<c::utf8>> | acc])
+  end
+
+  defp build_atom(acc, rest) do
+    body = acc |> Enum.reverse() |> IO.iodata_to_binary()
+    {body, rest, String.length(body)}
+  end
+
+  defp classify_atom(raw, line, col, exactness, allow_sign?) do
+    case atom_kind(raw, allow_sign?) do
+      :empty -> raise Error, reason: :empty_atom, position: {line, col}
+      :ident -> {:ident, raw, {line, col}}
+      {:float_special, value} -> {:float, value, {line, col}}
+      :numeric -> numeric_token(raw, line, col, exactness)
+      :invalid -> raise Error, reason: {:invalid_token, raw}, position: {line, col}
+    end
+  end
+
+  defp atom_kind("", _allow_sign?), do: :empty
+  defp atom_kind(raw, _allow_sign?) when raw in ["...", "->"], do: :ident
+  defp atom_kind(raw, true) when raw in ["+", "-"], do: :ident
+  defp atom_kind("+inf.0", _), do: {:float_special, special_float("+inf.0")}
+  defp atom_kind("-inf.0", _), do: {:float_special, special_float("-inf.0")}
+  defp atom_kind("+nan.0", _), do: {:float_special, special_float("+nan.0")}
+  defp atom_kind("-nan.0", _), do: {:float_special, special_float("-nan.0")}
+
+  defp atom_kind(raw, _allow_sign?) do
+    cond do
+      starts_with_arrow?(raw) -> :ident
+      numeric_lookalike?(raw) -> :numeric
+      identifier?(raw) -> :ident
+      true -> :invalid
+    end
+  end
+
+  defp numeric_token(raw, line, col, exactness) do
+    case parse_number(raw, 10, exactness) do
+      {:ok, n} when is_integer(n) -> {:integer, n, {line, col}}
+      {:ok, f} when is_float(f) -> {:float, f, {line, col}}
+      :error -> raise Error, reason: {:invalid_numeric_literal, raw}, position: {line, col}
+    end
+  end
+
+  defp starts_with_arrow?(<<?-, ?>, _::binary>>), do: true
+  defp starts_with_arrow?(_), do: false
+
+  # An atom "looks numeric" if its first non-sign byte is a digit or '.'.
+  defp numeric_lookalike?(<<c, _::binary>>) when c in ?0..?9, do: true
+  defp numeric_lookalike?(<<?., c, _::binary>>) when c in ?0..?9, do: true
+  defp numeric_lookalike?(<<s, c, _::binary>>) when s in [?+, ?-] and c in ?0..?9, do: true
+
+  defp numeric_lookalike?(<<s, ?., c, _::binary>>) when s in [?+, ?-] and c in ?0..?9, do: true
+
+  defp numeric_lookalike?(_), do: false
+
+  # ---------------------------------------------------------------------------
+  # Dot
+  # ---------------------------------------------------------------------------
+
+  defp read_dot_token(<<?., rest::binary>> = src, line, col) do
+    if dot_alone?(rest) do
+      {{:dot, nil, {line, col}}, rest, col + 1}
+    else
+      {raw, rest, taken} = scan_atom(src, [])
+      {classify_dot_atom(raw, line, col), rest, col + taken}
+    end
+  end
+
+  defp dot_alone?(<<>>), do: true
+  defp dot_alone?(<<c, _::binary>>) when c in @terminators, do: true
+  defp dot_alone?(_), do: false
+
+  defp classify_dot_atom("...", line, col), do: {:ident, "...", {line, col}}
+
+  defp classify_dot_atom(raw, line, col) do
+    cond do
+      numeric_lookalike?(raw) -> numeric_token(raw, line, col, :auto)
+      identifier?(raw) -> {:ident, raw, {line, col}}
+      true -> raise Error, reason: {:invalid_token, raw}, position: {line, col}
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Number parsing
+  # ---------------------------------------------------------------------------
+
+  defp parse_number(raw, radix, exactness) do
+    {sign, body} = strip_sign(raw)
+
+    case body == "" or classify_body(body) do
+      true -> :error
+      :rational -> :error
+      :real when radix != 10 -> :error
+      :real -> parse_float_literal(sign, body, exactness)
+      :integer -> parse_integer_literal(sign, body, radix, exactness)
+    end
+  end
+
+  defp strip_sign(<<?+, rest::binary>>), do: {1, rest}
+  defp strip_sign(<<?-, rest::binary>>), do: {-1, rest}
+  defp strip_sign(rest), do: {1, rest}
+
+  defp classify_body(<<>>), do: :integer
+  defp classify_body(<<?/, _::binary>>), do: :rational
+  defp classify_body(<<?., _::binary>>), do: :real
+  defp classify_body(<<c, _::binary>>) when c in [?e, ?E], do: :real
+  defp classify_body(<<_, rest::binary>>), do: classify_body(rest)
+
+  defp parse_integer_literal(sign, body, radix, exactness) do
+    if digits_in_radix?(body, radix) do
+      n = sign * String.to_integer(body, radix)
+
+      case exactness do
+        :inexact -> {:ok, n / 1}
+        _ -> {:ok, n}
+      end
+    else
+      :error
+    end
+  end
+
+  defp parse_float_literal(sign, body, exactness) do
+    body =
+      cond do
+        String.starts_with?(body, ".") -> "0" <> body
+        String.ends_with?(body, ".") -> body <> "0"
+        true -> body
+      end
+
+    case Float.parse(body) do
+      {f, ""} ->
+        v = sign * f
+
+        case exactness do
+          :exact -> {:ok, trunc(v)}
+          _ -> {:ok, v}
+        end
+
+      _ ->
+        :error
+    end
+  end
+
+  defp digits_in_radix?(<<>>, _radix), do: false
+  defp digits_in_radix?(s, radix), do: every_byte?(s, &digit_in_radix?(&1, radix))
+
+  defp every_byte?(<<>>, _f), do: true
+  defp every_byte?(<<c, rest::binary>>, f), do: f.(c) and every_byte?(rest, f)
+
+  defp digit_in_radix?(c, 2), do: c in ?0..?1
+  defp digit_in_radix?(c, 8), do: c in ?0..?7
+  defp digit_in_radix?(c, 10), do: c in ?0..?9
+  defp digit_in_radix?(c, 16), do: c in ?0..?9 or c in ?a..?f or c in ?A..?F
+
+  defp all_hex_digits?(s), do: every_byte?(s, &digit_in_radix?(&1, 16))
+
+  defp special_float("+inf.0"), do: positive_infinity()
+  defp special_float("-inf.0"), do: negative_infinity()
+  defp special_float("+nan.0"), do: nan()
+  defp special_float("-nan.0"), do: nan()
+
+  # `0/0`-style construction risks compile-time evaluation; pin them to
+  # values built by the BEAM at runtime via well-known IEEE-754 bytes.
+  defp positive_infinity, do: :erlang.binary_to_term(<<131, 70, 127, 240, 0, 0, 0, 0, 0, 0>>)
+  defp negative_infinity, do: :erlang.binary_to_term(<<131, 70, 255, 240, 0, 0, 0, 0, 0, 0>>)
+  defp nan, do: :erlang.binary_to_term(<<131, 70, 127, 248, 0, 0, 0, 0, 0, 0>>)
+
+  # ---------------------------------------------------------------------------
+  # Identifier classification
+  # ---------------------------------------------------------------------------
+
+  defp identifier?(""), do: false
+
+  defp identifier?(<<c::utf8, rest::binary>>) do
+    identifier_start?(c) and identifier_subsequents?(rest)
+  end
+
+  defp identifier_subsequents?(<<>>), do: true
+
+  defp identifier_subsequents?(<<c::utf8, rest::binary>>) do
+    identifier_continue?(c) and identifier_subsequents?(rest)
+  end
+
+  defp identifier_start?(c) do
+    c in ?a..?z or c in ?A..?Z or c >= 0x80 or
+      c in [?!, ?$, ?%, ?&, ?*, ?/, ?:, ?<, ?=, ?>, ??, ?^, ?_, ?~]
+  end
+
+  defp identifier_continue?(c) do
+    identifier_start?(c) or c in ?0..?9 or c in [?+, ?-, ?., ?@]
+  end
+end

--- a/lib/schooner/lexer/error.ex
+++ b/lib/schooner/lexer/error.ex
@@ -1,0 +1,52 @@
+defmodule Schooner.Lexer.Error do
+  @moduledoc """
+  Exception raised by `Schooner.Lexer` on malformed source.
+
+  Each error carries:
+
+    * `:reason` — a structured term identifying the failure mode (atom or
+      tagged tuple); meant to be machine-matchable in tests
+    * `:position` — `{line, column}` of the offending input
+
+  The pretty `:message` is generated lazily so tests can assert on
+  `:reason` and `:position` without coupling to wording.
+  """
+
+  defexception [:reason, :position, :message]
+
+  @impl true
+  def exception(opts) do
+    reason = Keyword.fetch!(opts, :reason)
+    position = Keyword.fetch!(opts, :position)
+    %__MODULE__{reason: reason, position: position, message: format(reason, position)}
+  end
+
+  defp format(reason, {line, col}) do
+    "#{describe(reason)} at line #{line}, column #{col}"
+  end
+
+  defp describe(:unterminated_string), do: "unterminated string literal"
+  defp describe(:unterminated_block_comment), do: "unterminated block comment"
+  defp describe(:unterminated_bar_identifier), do: "unterminated |identifier|"
+  defp describe(:unterminated_char_literal), do: "unterminated character literal"
+  defp describe(:unterminated_hex_escape), do: "unterminated hex escape"
+  defp describe(:empty_hex_escape), do: "empty hex escape `\\x;`"
+  defp describe(:invalid_numeric_literal), do: "invalid numeric literal"
+  defp describe(:empty_atom), do: "empty token"
+  defp describe(:rationals_unsupported), do: "rationals are not supported"
+  defp describe({:invalid_numeric_literal, raw}), do: "invalid numeric literal #{inspect(raw)}"
+  defp describe({:invalid_token, raw}), do: "invalid token #{inspect(raw)}"
+  defp describe({:invalid_identifier, raw}), do: "invalid identifier #{inspect(raw)}"
+  defp describe({:invalid_hash_form, c}), do: "invalid `#` form `#{<<c>>}`"
+
+  defp describe({:invalid_boolean, c}),
+    do: "invalid character after boolean literal: #{inspect(<<c>>)}"
+
+  defp describe({:invalid_escape, c}), do: "invalid string escape `\\#{<<c>>}`"
+  defp describe({:unknown_char_name, name}), do: "unknown character name `#\\#{name}`"
+
+  defp describe({:duplicate_number_prefix, kind}),
+    do: "duplicate #{kind} prefix in numeric literal"
+
+  defp describe({:unexpected_char, c}), do: "unexpected character #{inspect(<<c>>)}"
+end

--- a/test/schooner/lexer_property_test.exs
+++ b/test/schooner/lexer_property_test.exs
@@ -1,0 +1,55 @@
+defmodule Schooner.LexerPropertyTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Schooner.Lexer
+
+  property "integers round-trip through the lexer" do
+    check all(n <- integer()) do
+      src = Integer.to_string(n)
+      assert [{:integer, ^n, {1, 1}}] = Lexer.tokenise(src)
+    end
+  end
+
+  property "plain identifiers round-trip" do
+    check all(name <- plain_identifier()) do
+      assert [{:ident, ^name, {1, 1}}] = Lexer.tokenise(name)
+    end
+  end
+
+  property "decimal floats round-trip when re-emitted via short form" do
+    check all(f <- bounded_float()) do
+      src = :erlang.float_to_binary(f, [:short])
+
+      case Lexer.tokenise(src) do
+        [{:float, parsed, {1, 1}}] -> assert parsed == f
+      end
+    end
+  end
+
+  defp plain_identifier do
+    initial =
+      one_of([
+        member_of(?a..?z |> Enum.to_list()),
+        member_of(?A..?Z |> Enum.to_list())
+      ])
+
+    subseq =
+      one_of([
+        member_of(?a..?z |> Enum.to_list()),
+        member_of(?A..?Z |> Enum.to_list()),
+        member_of(?0..?9 |> Enum.to_list()),
+        member_of(~c"-_!?")
+      ])
+
+    bind(initial, fn first ->
+      bind(list_of(subseq, max_length: 8), fn rest ->
+        constant(IO.iodata_to_binary([first | rest]))
+      end)
+    end)
+  end
+
+  defp bounded_float do
+    map(integer(-1_000_000..1_000_000), fn n -> n / 1.0 end)
+  end
+end

--- a/test/schooner/lexer_test.exs
+++ b/test/schooner/lexer_test.exs
@@ -1,0 +1,309 @@
+defmodule Schooner.LexerTest do
+  use ExUnit.Case, async: true
+
+  alias Schooner.Lexer
+  alias Schooner.Lexer.Error
+
+  describe "punctuation and quote forms" do
+    test "parens and quote markers" do
+      assert Lexer.tokenise("()") == [
+               {:lparen, nil, {1, 1}},
+               {:rparen, nil, {1, 2}}
+             ]
+
+      assert Lexer.tokenise("'`,@,") == [
+               {:quote, nil, {1, 1}},
+               {:quasiquote, nil, {1, 2}},
+               {:unquote_splicing, nil, {1, 3}},
+               {:unquote, nil, {1, 5}}
+             ]
+    end
+
+    test "vector and bytevector openers" do
+      assert Lexer.tokenise("#( ") == [{:vector_open, nil, {1, 1}}]
+      assert Lexer.tokenise("#u8(") == [{:bytevector_open, nil, {1, 1}}]
+    end
+
+    test "dot is its own token only with surrounding whitespace" do
+      assert [
+               {:lparen, _, _},
+               {:ident, "a", _},
+               {:dot, nil, _},
+               {:ident, "b", _},
+               {:rparen, _, _}
+             ] = Lexer.tokenise("(a . b)")
+    end
+
+    test "ellipsis identifier is distinct from dot" do
+      assert [{:ident, "...", {1, 1}}] = Lexer.tokenise("...")
+    end
+  end
+
+  describe "booleans" do
+    test "short and long forms" do
+      assert [{:bool, true, {1, 1}}] = Lexer.tokenise("#t")
+      assert [{:bool, false, {1, 1}}] = Lexer.tokenise("#f")
+      assert [{:bool, true, {1, 1}}] = Lexer.tokenise("#true")
+      assert [{:bool, false, {1, 1}}] = Lexer.tokenise("#false")
+    end
+
+    test "must be terminated by whitespace, paren, or other token boundary" do
+      assert_raise Error, fn -> Lexer.tokenise("#tx") end
+      assert_raise Error, fn -> Lexer.tokenise("#trues") end
+    end
+  end
+
+  describe "characters" do
+    test "single ascii char" do
+      assert [{:char, ?a, {1, 1}}] = Lexer.tokenise(~S(#\a))
+      assert [{:char, ?A, {1, 1}}] = Lexer.tokenise(~S(#\A))
+      assert [{:char, ?0, {1, 1}}] = Lexer.tokenise(~S(#\0))
+      assert [{:char, ?(, {1, 1}}] = Lexer.tokenise(~S(#\())
+    end
+
+    test "named characters" do
+      assert [{:char, ?\s, _}] = Lexer.tokenise(~S(#\space))
+      assert [{:char, ?\n, _}] = Lexer.tokenise(~S(#\newline))
+      assert [{:char, ?\t, _}] = Lexer.tokenise(~S(#\tab))
+      assert [{:char, 0, _}] = Lexer.tokenise(~S(#\null))
+      assert [{:char, 0x1B, _}] = Lexer.tokenise(~S(#\escape))
+    end
+
+    test "hex characters" do
+      assert [{:char, 0x41, _}] = Lexer.tokenise(~S(#\x41))
+      assert [{:char, 0x10FFFF, _}] = Lexer.tokenise(~S(#\x10FFFF))
+    end
+
+    test "unknown char name raises" do
+      assert_raise Error, fn -> Lexer.tokenise(~S(#\notachar)) end
+    end
+  end
+
+  describe "strings" do
+    test "simple literal" do
+      assert [{:string, "hello", {1, 1}}] = Lexer.tokenise(~s("hello"))
+    end
+
+    test "common escape sequences" do
+      assert [{:string, "a\nb", _}] = Lexer.tokenise(~S("a\nb"))
+      assert [{:string, "a\tb", _}] = Lexer.tokenise(~S("a\tb"))
+      assert [{:string, "a\rb", _}] = Lexer.tokenise(~S("a\rb"))
+      assert [{:string, ~s(a"b), _}] = Lexer.tokenise(~S("a\"b"))
+      assert [{:string, "a\\b", _}] = Lexer.tokenise(~S("a\\b"))
+    end
+
+    test "hex escape" do
+      assert [{:string, "A", _}] = Lexer.tokenise(~S("\x41;"))
+      # multi-byte codepoint
+      assert [{:string, "λ", _}] = Lexer.tokenise(~S("\x3BB;"))
+    end
+
+    test "raw newline inside string is preserved as \\n" do
+      assert [{:string, "a\nb", _}] = Lexer.tokenise("\"a\nb\"")
+    end
+
+    test "unterminated string raises with start position" do
+      err =
+        assert_raise Error, fn -> Lexer.tokenise(~s("abc)) end
+
+      assert err.reason == :unterminated_string
+      assert err.position == {1, 1}
+    end
+
+    test "invalid escape raises" do
+      err =
+        assert_raise Error, fn -> Lexer.tokenise(~S("a\q")) end
+
+      assert match?({:invalid_escape, ?q}, err.reason)
+    end
+
+    test "empty hex escape raises" do
+      err =
+        assert_raise Error, fn -> Lexer.tokenise(~S("\x;")) end
+
+      assert err.reason == :empty_hex_escape
+    end
+  end
+
+  describe "identifiers" do
+    test "simple identifier" do
+      assert [{:ident, "foo", {1, 1}}] = Lexer.tokenise("foo")
+      assert [{:ident, "foo-bar", _}] = Lexer.tokenise("foo-bar")
+      assert [{:ident, "list->vector", _}] = Lexer.tokenise("list->vector")
+      assert [{:ident, "set!", _}] = Lexer.tokenise("set!")
+      assert [{:ident, "x?", _}] = Lexer.tokenise("x?")
+      assert [{:ident, "<=", _}] = Lexer.tokenise("<=")
+    end
+
+    test "peculiar identifiers" do
+      assert [{:ident, "+", _}] = Lexer.tokenise("+")
+      assert [{:ident, "-", _}] = Lexer.tokenise("-")
+      assert [{:ident, "...", _}] = Lexer.tokenise("...")
+      assert [{:ident, "->", _}] = Lexer.tokenise("->")
+      assert [{:ident, "->foo", _}] = Lexer.tokenise("->foo")
+    end
+
+    test "vertical-bar quoted identifier" do
+      assert [{:ident, "hello world", {1, 1}}] = Lexer.tokenise("|hello world|")
+      assert [{:ident, "a|b", _}] = Lexer.tokenise(~S(|a\|b|))
+      assert [{:ident, "a\\b", _}] = Lexer.tokenise(~S(|a\\b|))
+      assert [{:ident, "", _}] = Lexer.tokenise("||")
+    end
+
+    test "unterminated bar identifier raises" do
+      err =
+        assert_raise Error, fn -> Lexer.tokenise("|hello") end
+
+      assert err.reason == :unterminated_bar_identifier
+    end
+
+    test "unicode identifiers" do
+      assert [{:ident, "λ", _}] = Lexer.tokenise("λ")
+      assert [{:ident, "α-β", _}] = Lexer.tokenise("α-β")
+    end
+  end
+
+  describe "numbers" do
+    test "exact integers" do
+      assert [{:integer, 0, _}] = Lexer.tokenise("0")
+      assert [{:integer, 42, _}] = Lexer.tokenise("42")
+      assert [{:integer, -7, _}] = Lexer.tokenise("-7")
+      assert [{:integer, 7, _}] = Lexer.tokenise("+7")
+    end
+
+    test "inexact reals" do
+      assert [{:float, 1.5, _}] = Lexer.tokenise("1.5")
+      assert [{:float, -1.5, _}] = Lexer.tokenise("-1.5")
+      assert [{:float, 0.5, _}] = Lexer.tokenise(".5")
+      assert [{:float, -0.5, _}] = Lexer.tokenise("-.5")
+      assert [{:float, 1.0, _}] = Lexer.tokenise("1.")
+      assert [{:float, 150.0, _}] = Lexer.tokenise("1.5e2")
+      assert [{:float, 100.0, _}] = Lexer.tokenise("1e2")
+    end
+
+    test "radix prefixes" do
+      assert [{:integer, 5, _}] = Lexer.tokenise("#b101")
+      assert [{:integer, 15, _}] = Lexer.tokenise("#o17")
+      assert [{:integer, 255, _}] = Lexer.tokenise("#xff")
+      assert [{:integer, 12, _}] = Lexer.tokenise("#d12")
+      assert [{:integer, -5, _}] = Lexer.tokenise("#b-101")
+      assert [{:integer, 31, _}] = Lexer.tokenise("#x1F")
+    end
+
+    test "exactness prefixes" do
+      assert [{:integer, 1, _}] = Lexer.tokenise("#e1.5") |> Enum.map(&clamp/1)
+      # #e on a float truncates / converts to integer
+      assert [{:integer, 1, _}] = Lexer.tokenise("#e1.5")
+      # #i on an integer makes it inexact
+      assert [{:float, 3.0, _}] = Lexer.tokenise("#i3")
+    end
+
+    test "stacked radix + exactness prefixes" do
+      assert [{:float, 255.0, _}] = Lexer.tokenise("#i#xff")
+      assert [{:float, 255.0, _}] = Lexer.tokenise("#x#iff")
+    end
+
+    test "duplicate prefix is an error" do
+      err = assert_raise Error, fn -> Lexer.tokenise("#x#x10") end
+      assert match?({:duplicate_number_prefix, _}, err.reason)
+    end
+
+    test "rationals raise" do
+      assert_raise Error, fn -> Lexer.tokenise("1/2") end
+    end
+
+    test "non-decimal radix forbids fractional point" do
+      assert_raise Error, fn -> Lexer.tokenise("#x1.5") end
+    end
+
+    test "arbitrary-precision integers" do
+      big = String.duplicate("9", 80)
+      assert [{:integer, n, _}] = Lexer.tokenise(big)
+      assert n == String.to_integer(big)
+    end
+
+    test "garbage after digits is an error" do
+      err = assert_raise Error, fn -> Lexer.tokenise("10abc") end
+      assert match?({:invalid_numeric_literal, "10abc"}, err.reason)
+    end
+
+    defp clamp({:integer, n, _}) when n in -1..1, do: {:integer, n, nil}
+    defp clamp(t), do: t
+  end
+
+  describe "comments" do
+    test "line comment terminates at newline" do
+      tokens = Lexer.tokenise("; ignored\n42")
+      assert [{:integer, 42, {2, 1}}] = tokens
+    end
+
+    test "line comment to EOF" do
+      assert [] = Lexer.tokenise("; just a comment")
+    end
+
+    test "block comment, including nested" do
+      assert [{:integer, 1, _}] = Lexer.tokenise("#| outer #| inner |# outer |# 1")
+    end
+
+    test "block comment can span lines" do
+      assert [{:integer, 1, {3, 3}}] = Lexer.tokenise("#| a\nb\n|#1")
+    end
+
+    test "unterminated block comment raises with opening position" do
+      err = assert_raise Error, fn -> Lexer.tokenise("#| oops") end
+      assert err.reason == :unterminated_block_comment
+      assert err.position == {1, 1}
+    end
+
+    test "datum-comment marker is preserved" do
+      assert [
+               {:datum_comment, nil, {1, 1}},
+               {:integer, 7, _}
+             ] = Lexer.tokenise("#; 7")
+    end
+  end
+
+  describe "source positions" do
+    test "tracks line and column across multi-line input" do
+      src = """
+      (define x 1)
+      (define y 2)
+      """
+
+      tokens = Lexer.tokenise(src)
+
+      assert [
+               {:lparen, nil, {1, 1}},
+               {:ident, "define", {1, 2}},
+               {:ident, "x", {1, 9}},
+               {:integer, 1, {1, 11}},
+               {:rparen, nil, {1, 12}},
+               {:lparen, nil, {2, 1}},
+               {:ident, "define", {2, 2}},
+               {:ident, "y", {2, 9}},
+               {:integer, 2, {2, 11}},
+               {:rparen, nil, {2, 12}}
+             ] = tokens
+    end
+
+    test "tabs count as one column for now" do
+      assert [{:ident, "x", {1, 2}}] = Lexer.tokenise("\tx")
+    end
+
+    test "CRLF and lone CR are both newlines" do
+      assert [{:integer, 1, {2, 1}}] = Lexer.tokenise("\r\n1")
+      assert [{:integer, 1, {2, 1}}] = Lexer.tokenise("\r1")
+    end
+  end
+
+  describe "negative cases" do
+    test "stray closing bracket-style char is an unexpected character" do
+      err = assert_raise Error, fn -> Lexer.tokenise("@") end
+      assert match?({:unexpected_char, ?@}, err.reason)
+    end
+
+    test "lone hash is an error" do
+      assert_raise Error, fn -> Lexer.tokenise("#") end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Hand-rolled `Schooner.Lexer` over a binary cursor producing a flat token stream of `{tag, value, {line, column}}` 3-tuples — every token is position-aware so downstream stages can report source locations without keeping the original string.
- Covers parens, vector/bytevector openers, all four quote forms, dot-vs-ellipsis, booleans (short and long), characters (named/hex/literal), strings (standard escapes plus `\xHH;`), bar-quoted identifiers, peculiar identifiers (`+`, `-`, `...`, `->foo`), numeric literals across `#b/#o/#d/#x` radixes and `#e/#i` exactness, line comments, nested block comments, and a `:datum_comment` sentinel for `#;` that the reader will resolve.
- Lex failures raise `Schooner.Lexer.Error` with a structured `:reason` and `:position`, so tests can match on them without coupling to wording.

## Test plan

- [x] 43 unit tests covering positive + negative cases for every token type, escape sequence, comment form, and a multi-line source-position assertion
- [x] 3 round-trip property tests (integers, plain identifiers, decimal floats via `:erlang.float_to_binary/2` short form)
- [x] `mix precommit` green: `compile --warnings-as-errors`, `format`, `credo --strict`, `test` (71 tests / 8 properties / 0 failures / 1 phase-3 stub skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)