### PR TITLE
Phase 3: reader

### DIFF
--- a/lib/schooner/reader.ex
+++ b/lib/schooner/reader.ex
@@ -1,0 +1,232 @@
+defmodule Schooner.Reader do
+  @moduledoc """
+  Token stream → datum AST.
+
+  Consumes the flat token stream from `Schooner.Lexer` and produces a list
+  of `Schooner.Value` terms, one per top-level datum. Reader macros are
+  desugared into the canonical cons-cell forms so the rest of the
+  pipeline only ever deals with core data:
+
+      'x   → (quote x)
+      `x   → (quasiquote x)
+      ,x   → (unquote x)
+      ,@x  → (unquote-splicing x)
+
+  Dotted pairs, vector literals, and bytevector literals are recognised.
+  Datum comments (`#;`) skip exactly one following datum and may stack.
+
+  Errors are raised as `Schooner.Reader.Error` with a structured reason
+  and source position so downstream tooling can quote the offending input
+  back to the user.
+  """
+
+  alias Schooner.Lexer
+  alias Schooner.Reader.Error
+  alias Schooner.Value
+
+  @doc "Read a binary of source into a list of top-level datums."
+  @spec read_string(binary()) :: [Value.t()]
+  def read_string(source) when is_binary(source) do
+    source |> Lexer.tokenise() |> read_tokens()
+  end
+
+  @doc "Read a list of lexer tokens into a list of top-level datums."
+  @spec read_tokens([Lexer.token()]) :: [Value.t()]
+  def read_tokens(tokens) when is_list(tokens) do
+    do_read_all(tokens, [])
+  end
+
+  # ---------------------------------------------------------------------------
+  # Top-level driver
+  # ---------------------------------------------------------------------------
+
+  defp do_read_all(tokens, acc) do
+    case read_one(tokens) do
+      :eof -> Enum.reverse(acc)
+      {:ok, datum, rest} -> do_read_all(rest, [datum | acc])
+    end
+  end
+
+  # `read_one/1` is the only place that yields `:eof`. Every interior context
+  # (inside a list, after a quote marker) treats `:eof` as a structured
+  # error specific to that context.
+  defp read_one(tokens) do
+    case skip_datum_comments(tokens) do
+      [] ->
+        :eof
+
+      tokens ->
+        {datum, rest} = read_datum(tokens)
+        {:ok, datum, rest}
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Datum comments — `#;` consumes the next datum
+  # ---------------------------------------------------------------------------
+
+  defp skip_datum_comments([{:datum_comment, _, pos} | rest]) do
+    case read_one(rest) do
+      :eof -> raise Error, reason: :datum_comment_at_eof, position: pos
+      {:ok, _skipped, rest} -> skip_datum_comments(rest)
+    end
+  end
+
+  defp skip_datum_comments(tokens), do: tokens
+
+  # ---------------------------------------------------------------------------
+  # Single-datum dispatch
+  # ---------------------------------------------------------------------------
+
+  defp read_datum([{:integer, n, _} | rest]), do: {n, rest}
+  defp read_datum([{:float, f, _} | rest]), do: {f, rest}
+  defp read_datum([{:bool, b, _} | rest]), do: {Value.bool(b), rest}
+  defp read_datum([{:string, s, _} | rest]), do: {Value.string(s), rest}
+  defp read_datum([{:char, cp, _} | rest]), do: {Value.char(cp), rest}
+  defp read_datum([{:ident, name, _} | rest]), do: {Value.symbol(name), rest}
+
+  defp read_datum([{:quote, _, pos} | rest]), do: read_quoted("quote", rest, pos)
+  defp read_datum([{:quasiquote, _, pos} | rest]), do: read_quoted("quasiquote", rest, pos)
+  defp read_datum([{:unquote, _, pos} | rest]), do: read_quoted("unquote", rest, pos)
+
+  defp read_datum([{:unquote_splicing, _, pos} | rest]) do
+    read_quoted("unquote-splicing", rest, pos)
+  end
+
+  defp read_datum([{:lparen, _, pos} | rest]), do: read_list(rest, pos)
+  defp read_datum([{:vector_open, _, pos} | rest]), do: read_vector(rest, pos)
+  defp read_datum([{:bytevector_open, _, pos} | rest]), do: read_bytevector(rest, pos)
+
+  defp read_datum([{:rparen, _, pos} | _]) do
+    raise Error, reason: :unexpected_close_paren, position: pos
+  end
+
+  defp read_datum([{:dot, _, pos} | _]) do
+    raise Error, reason: :unexpected_dot, position: pos
+  end
+
+  # ---------------------------------------------------------------------------
+  # Quote forms — desugar to `(<sym> <datum>)`
+  # ---------------------------------------------------------------------------
+
+  defp read_quoted(sym_name, tokens, pos) do
+    case read_one(tokens) do
+      :eof ->
+        raise Error, reason: {:unexpected_eof_after, sym_name}, position: pos
+
+      {:ok, datum, rest} ->
+        {Value.list([Value.symbol(sym_name), datum]), rest}
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Lists — proper `(a b c)` and dotted `(a b . c)`
+  # ---------------------------------------------------------------------------
+
+  defp read_list(tokens, start) do
+    case skip_datum_comments(tokens) do
+      [{:rparen, _, _} | rest] ->
+        {:null, rest}
+
+      [{:dot, _, pos} | _] ->
+        raise Error, reason: :dot_at_list_start, position: pos
+
+      [] ->
+        raise Error, reason: :unterminated_list, position: start
+
+      tokens ->
+        {datum, rest} = read_datum(tokens)
+        read_list_tail(rest, [datum], start)
+    end
+  end
+
+  defp read_list_tail(tokens, acc, start) do
+    case skip_datum_comments(tokens) do
+      [{:rparen, _, _} | rest] ->
+        {Value.list(Enum.reverse(acc)), rest}
+
+      [{:dot, _, dot_pos} | rest] ->
+        finish_dotted_list(rest, acc, dot_pos, start)
+
+      [] ->
+        raise Error, reason: :unterminated_list, position: start
+
+      tokens ->
+        {datum, rest} = read_datum(tokens)
+        read_list_tail(rest, [datum | acc], start)
+    end
+  end
+
+  defp finish_dotted_list(tokens, acc, dot_pos, start) do
+    case skip_datum_comments(tokens) do
+      [{:rparen, _, _} | _] ->
+        raise Error, reason: :missing_tail_after_dot, position: dot_pos
+
+      [] ->
+        raise Error, reason: :missing_tail_after_dot, position: dot_pos
+
+      tail_tokens ->
+        {tail, rest} = read_datum(tail_tokens)
+
+        case skip_datum_comments(rest) do
+          [{:rparen, _, _} | rest2] ->
+            {Value.improper_list(Enum.reverse(acc), tail), rest2}
+
+          [{_, _, pos} | _] ->
+            raise Error, reason: :extra_after_dot, position: pos
+
+          [] ->
+            raise Error, reason: :unterminated_list, position: start
+        end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Vectors — `#(...)`
+  # ---------------------------------------------------------------------------
+
+  defp read_vector(tokens, start), do: do_read_vector(tokens, [], start)
+
+  defp do_read_vector(tokens, acc, start) do
+    case skip_datum_comments(tokens) do
+      [{:rparen, _, _} | rest] ->
+        {Value.vector(Enum.reverse(acc)), rest}
+
+      [{:dot, _, pos} | _] ->
+        raise Error, reason: :dot_in_vector, position: pos
+
+      [] ->
+        raise Error, reason: :unterminated_vector, position: start
+
+      tokens ->
+        {datum, rest} = read_datum(tokens)
+        do_read_vector(rest, [datum | acc], start)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Bytevectors — `#u8(...)`, only integer tokens in 0..255
+  # ---------------------------------------------------------------------------
+
+  defp read_bytevector(tokens, start), do: do_read_bytevector(tokens, [], start)
+
+  defp do_read_bytevector(tokens, acc, start) do
+    case skip_datum_comments(tokens) do
+      [{:rparen, _, _} | rest] ->
+        {Value.bytevector(Enum.reverse(acc)), rest}
+
+      [{:integer, n, pos} | rest] ->
+        if n in 0..255 do
+          do_read_bytevector(rest, [n | acc], start)
+        else
+          raise Error, reason: {:invalid_byte, n}, position: pos
+        end
+
+      [] ->
+        raise Error, reason: :unterminated_bytevector, position: start
+
+      [{tag, _, pos} | _] ->
+        raise Error, reason: {:invalid_in_bytevector, tag}, position: pos
+    end
+  end
+end

--- a/lib/schooner/reader/error.ex
+++ b/lib/schooner/reader/error.ex
@@ -1,0 +1,45 @@
+defmodule Schooner.Reader.Error do
+  @moduledoc """
+  Exception raised by `Schooner.Reader` on malformed source.
+
+  Each error carries:
+
+    * `:reason` — a structured term identifying the failure mode (atom or
+      tagged tuple); meant to be machine-matchable in tests
+    * `:position` — `{line, column}` of the offending input
+
+  The pretty `:message` is generated lazily so tests can assert on
+  `:reason` and `:position` without coupling to wording.
+  """
+
+  defexception [:reason, :position, :message]
+
+  @impl true
+  def exception(opts) do
+    reason = Keyword.fetch!(opts, :reason)
+    position = Keyword.fetch!(opts, :position)
+    %__MODULE__{reason: reason, position: position, message: format(reason, position)}
+  end
+
+  defp format(reason, {line, col}) do
+    "#{describe(reason)} at line #{line}, column #{col}"
+  end
+
+  defp describe(:unterminated_list), do: "unterminated list"
+  defp describe(:unterminated_vector), do: "unterminated vector"
+  defp describe(:unterminated_bytevector), do: "unterminated bytevector"
+  defp describe(:unexpected_close_paren), do: "unexpected `)`"
+  defp describe(:unexpected_dot), do: "unexpected `.` outside list context"
+  defp describe(:dot_at_list_start), do: "`.` must follow at least one datum in a list"
+  defp describe(:dot_in_vector), do: "`.` is not allowed in a vector literal"
+  defp describe(:missing_tail_after_dot), do: "missing tail datum after `.`"
+  defp describe(:extra_after_dot), do: "more than one datum after `.` in a list"
+  defp describe(:datum_comment_at_eof), do: "datum comment `#;` with no following datum"
+  defp describe({:invalid_byte, n}), do: "invalid byte in bytevector: #{inspect(n)}"
+
+  defp describe({:invalid_in_bytevector, tag}),
+    do: "non-byte token #{inspect(tag)} in bytevector"
+
+  defp describe({:unexpected_eof_after, name}),
+    do: "unexpected end of input after `#{name}`"
+end

--- a/test/schooner/reader_property_test.exs
+++ b/test/schooner/reader_property_test.exs
@@ -1,0 +1,25 @@
+defmodule Schooner.ReaderPropertyTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Schooner.Reader
+  alias Schooner.Test.ValueGenerators
+  alias Schooner.Value
+
+  property "write/read round-trip on readable values" do
+    check all(v <- ValueGenerators.readable_value()) do
+      written = Value.write(v)
+      assert [read_back] = Reader.read_string(written)
+      assert Value.equal?(v, read_back)
+    end
+  end
+
+  property "wrapping a readable value in a list still round-trips" do
+    check all(v <- ValueGenerators.readable_value(2)) do
+      list = Value.list([v])
+      written = Value.write(list)
+      assert [read_back] = Reader.read_string(written)
+      assert Value.equal?(list, read_back)
+    end
+  end
+end

--- a/test/schooner/reader_test.exs
+++ b/test/schooner/reader_test.exs
@@ -1,0 +1,328 @@
+defmodule Schooner.ReaderTest do
+  use ExUnit.Case, async: true
+
+  alias Schooner.Reader
+  alias Schooner.Reader.Error
+  alias Schooner.Value
+
+  describe "atoms" do
+    test "integer literal reads to a bare Elixir integer" do
+      assert Reader.read_string("42") == [42]
+      assert Reader.read_string("-7") == [-7]
+      assert Reader.read_string("0") == [0]
+    end
+
+    test "float literal reads to a bare Elixir float" do
+      assert Reader.read_string("1.5") == [1.5]
+      assert Reader.read_string("-0.5") == [-0.5]
+    end
+
+    test "boolean literal reads to {:bool, _}" do
+      assert Reader.read_string("#t") == [Value.bool(true)]
+      assert Reader.read_string("#false") == [Value.bool(false)]
+    end
+
+    test "string literal reads to {:string, _}" do
+      assert Reader.read_string(~S("hello")) == [Value.string("hello")]
+    end
+
+    test "char literal reads to {:char, _}" do
+      assert Reader.read_string(~S(#\a)) == [Value.char(?a)]
+      assert Reader.read_string(~S(#\space)) == [Value.char(?\s)]
+    end
+
+    test "identifier reads to a tagged symbol" do
+      assert Reader.read_string("foo") == [Value.symbol("foo")]
+      assert Reader.read_string("|hello world|") == [Value.symbol("hello world")]
+      assert Reader.read_string("...") == [Value.symbol("...")]
+    end
+
+    test "empty input yields no datums" do
+      assert Reader.read_string("") == []
+      assert Reader.read_string("   \n\t  ") == []
+      assert Reader.read_string("; just a comment\n") == []
+    end
+  end
+
+  describe "lists" do
+    test "empty list reads to :null" do
+      assert Reader.read_string("()") == [:null]
+    end
+
+    test "proper list reads to nested pairs" do
+      assert Reader.read_string("(1 2 3)") == [Value.list([1, 2, 3])]
+    end
+
+    test "list with mixed atoms" do
+      datum = Reader.read_string("(define x 1)") |> hd()
+
+      assert datum ==
+               Value.list([Value.symbol("define"), Value.symbol("x"), 1])
+    end
+
+    test "dotted pair" do
+      assert Reader.read_string("(1 . 2)") == [Value.pair(1, 2)]
+    end
+
+    test "improper list with multiple lead elements" do
+      assert Reader.read_string("(1 2 . 3)") == [Value.improper_list([1, 2], 3)]
+    end
+
+    test "nested lists" do
+      datum = Reader.read_string("(1 (2 3) 4)") |> hd()
+
+      assert datum ==
+               Value.list([1, Value.list([2, 3]), 4])
+    end
+
+    test "deeply nested" do
+      datum = Reader.read_string("(((())))") |> hd()
+      expected = Value.list([Value.list([Value.list([:null])])])
+      assert datum == expected
+    end
+  end
+
+  describe "vectors" do
+    test "empty vector" do
+      assert Reader.read_string("#()") == [Value.vector([])]
+    end
+
+    test "vector of integers" do
+      assert Reader.read_string("#(1 2 3)") == [Value.vector([1, 2, 3])]
+    end
+
+    test "vector of mixed atoms" do
+      datum = Reader.read_string(~S[#(1 "hi" foo)]) |> hd()
+
+      assert datum ==
+               Value.vector([1, Value.string("hi"), Value.symbol("foo")])
+    end
+
+    test "vectors may nest in lists" do
+      datum = Reader.read_string("(a #(1 2) b)") |> hd()
+
+      assert datum ==
+               Value.list([
+                 Value.symbol("a"),
+                 Value.vector([1, 2]),
+                 Value.symbol("b")
+               ])
+    end
+  end
+
+  describe "bytevectors" do
+    test "empty bytevector" do
+      assert Reader.read_string("#u8()") == [Value.bytevector([])]
+    end
+
+    test "bytevector of bytes" do
+      assert Reader.read_string("#u8(1 2 255)") == [Value.bytevector([1, 2, 255])]
+    end
+  end
+
+  describe "quote forms desugar" do
+    test "'x → (quote x)" do
+      assert Reader.read_string("'x") ==
+               [Value.list([Value.symbol("quote"), Value.symbol("x")])]
+    end
+
+    test "`x → (quasiquote x)" do
+      assert Reader.read_string("`x") ==
+               [Value.list([Value.symbol("quasiquote"), Value.symbol("x")])]
+    end
+
+    test ",x → (unquote x)" do
+      assert Reader.read_string(",x") ==
+               [Value.list([Value.symbol("unquote"), Value.symbol("x")])]
+    end
+
+    test ",@x → (unquote-splicing x)" do
+      assert Reader.read_string(",@x") ==
+               [Value.list([Value.symbol("unquote-splicing"), Value.symbol("x")])]
+    end
+
+    test "stacked quotes" do
+      datum = Reader.read_string("''x") |> hd()
+
+      expected =
+        Value.list([
+          Value.symbol("quote"),
+          Value.list([Value.symbol("quote"), Value.symbol("x")])
+        ])
+
+      assert datum == expected
+    end
+
+    test "quasiquote with unquote-splicing inside a list" do
+      datum = Reader.read_string("`(a ,b ,@c)") |> hd()
+
+      expected =
+        Value.list([
+          Value.symbol("quasiquote"),
+          Value.list([
+            Value.symbol("a"),
+            Value.list([Value.symbol("unquote"), Value.symbol("b")]),
+            Value.list([Value.symbol("unquote-splicing"), Value.symbol("c")])
+          ])
+        ])
+
+      assert datum == expected
+    end
+  end
+
+  describe "datum comments" do
+    test "skip top-level datum" do
+      assert Reader.read_string("#; foo bar") == [Value.symbol("bar")]
+    end
+
+    test "skip datum inside a list" do
+      assert Reader.read_string("(a #; b c)") ==
+               [Value.list([Value.symbol("a"), Value.symbol("c")])]
+    end
+
+    test "skip datum inside a vector" do
+      assert Reader.read_string("#(1 #; 2 3)") == [Value.vector([1, 3])]
+    end
+
+    test "stacked datum comments skip multiple datums" do
+      assert Reader.read_string("#; #; a b c") == [Value.symbol("c")]
+    end
+
+    test "datum comment at end of input is an error" do
+      err = assert_raise Error, fn -> Reader.read_string("5 #;") end
+      assert err.reason == :datum_comment_at_eof
+    end
+  end
+
+  describe "multiple top-level datums" do
+    test "two datums separated by whitespace" do
+      assert Reader.read_string("1 2") == [1, 2]
+    end
+
+    test "definition followed by expression" do
+      ds = Reader.read_string("(define x 1) (+ x 2)")
+
+      assert ds == [
+               Value.list([Value.symbol("define"), Value.symbol("x"), 1]),
+               Value.list([Value.symbol("+"), Value.symbol("x"), 2])
+             ]
+    end
+  end
+
+  describe "nested data round-trips end-to-end" do
+    test "vectors inside lists inside quasiquote inside lists" do
+      src = "(begin `(a #(1 ,b) (c d)))"
+      datum = Reader.read_string(src) |> hd()
+
+      expected =
+        Value.list([
+          Value.symbol("begin"),
+          Value.list([
+            Value.symbol("quasiquote"),
+            Value.list([
+              Value.symbol("a"),
+              Value.vector([1, Value.list([Value.symbol("unquote"), Value.symbol("b")])]),
+              Value.list([Value.symbol("c"), Value.symbol("d")])
+            ])
+          ])
+        ])
+
+      assert datum == expected
+    end
+  end
+
+  describe "errors carry source positions" do
+    test "unmatched closing paren" do
+      err = assert_raise Error, fn -> Reader.read_string("  )") end
+      assert err.reason == :unexpected_close_paren
+      assert err.position == {1, 3}
+    end
+
+    test "unterminated list points at the opening paren" do
+      err = assert_raise Error, fn -> Reader.read_string("\n  (1 2 3") end
+      assert err.reason == :unterminated_list
+      assert err.position == {2, 3}
+    end
+
+    test "unterminated vector points at the opener" do
+      err = assert_raise Error, fn -> Reader.read_string("#(1 2") end
+      assert err.reason == :unterminated_vector
+      assert err.position == {1, 1}
+    end
+
+    test "unterminated bytevector points at the opener" do
+      err = assert_raise Error, fn -> Reader.read_string("#u8(1 2") end
+      assert err.reason == :unterminated_bytevector
+      assert err.position == {1, 1}
+    end
+
+    test "dot in wrong position — at list start" do
+      err = assert_raise Error, fn -> Reader.read_string("(. 1)") end
+      assert err.reason == :dot_at_list_start
+      assert err.position == {1, 2}
+    end
+
+    test "dot at top level is unexpected" do
+      err = assert_raise Error, fn -> Reader.read_string(" . ") end
+      assert err.reason == :unexpected_dot
+      assert err.position == {1, 2}
+    end
+
+    test "dot inside vector is rejected" do
+      err = assert_raise Error, fn -> Reader.read_string("#(1 . 2)") end
+      assert err.reason == :dot_in_vector
+      assert err.position == {1, 5}
+    end
+
+    test "missing tail after dot" do
+      err = assert_raise Error, fn -> Reader.read_string("(1 . )") end
+      assert err.reason == :missing_tail_after_dot
+      assert err.position == {1, 4}
+    end
+
+    test "more than one datum after dot" do
+      err = assert_raise Error, fn -> Reader.read_string("(1 . 2 3)") end
+      assert err.reason == :extra_after_dot
+      assert err.position == {1, 8}
+    end
+
+    test "non-byte integer in bytevector" do
+      err = assert_raise Error, fn -> Reader.read_string("#u8(1 256 3)") end
+      assert err.reason == {:invalid_byte, 256}
+      assert err.position == {1, 7}
+    end
+
+    test "non-integer token in bytevector" do
+      err = assert_raise Error, fn -> Reader.read_string("#u8(1 foo 3)") end
+      assert err.reason == {:invalid_in_bytevector, :ident}
+      assert err.position == {1, 7}
+    end
+
+    test "quote with nothing following" do
+      err = assert_raise Error, fn -> Reader.read_string("'") end
+      assert err.reason == {:unexpected_eof_after, "quote"}
+      assert err.position == {1, 1}
+    end
+
+    test "unquote-splicing with nothing following" do
+      err = assert_raise Error, fn -> Reader.read_string(",@") end
+      assert err.reason == {:unexpected_eof_after, "unquote-splicing"}
+      assert err.position == {1, 1}
+    end
+
+    test "unterminated string surfaces the lexer error" do
+      assert_raise Schooner.Lexer.Error, fn -> Reader.read_string(~s("abc)) end
+    end
+
+    test "unterminated block comment surfaces the lexer error" do
+      assert_raise Schooner.Lexer.Error, fn -> Reader.read_string("#| oops") end
+    end
+
+    test "invalid #u8 byte at lex time surfaces the lexer error" do
+      # `#u8(garbage)` reaches the reader as a bytevector_open then an
+      # identifier, which is the reader's invalid_in_bytevector path.
+      err = assert_raise Error, fn -> Reader.read_string("#u8(garbage)") end
+      assert err.reason == {:invalid_in_bytevector, :ident}
+    end
+  end
+end

--- a/test/schooner/value_property_test.exs
+++ b/test/schooner/value_property_test.exs
@@ -2,6 +2,7 @@ defmodule Schooner.ValuePropertyTest do
   use ExUnit.Case, async: true
   use ExUnitProperties
 
+  alias Schooner.Reader
   alias Schooner.Test.ValueGenerators
   alias Schooner.Value
 
@@ -33,13 +34,11 @@ defmodule Schooner.ValuePropertyTest do
     end
   end
 
-  @tag :skip
-  property "write/read round-trip preserves equal? — unskips after the reader lands in phase 3" do
-    check all(v <- ValueGenerators.value()) do
+  property "write/read round-trip preserves equal?" do
+    check all(v <- ValueGenerators.readable_value()) do
       written = Value.write(v)
-      # Schooner.Reader.read_string(written) — to be wired up in phase 3
-      _ = written
-      assert true
+      assert [read_back] = Reader.read_string(written)
+      assert Value.equal?(v, read_back)
     end
   end
 end

--- a/test/support/value_generators.ex
+++ b/test/support/value_generators.ex
@@ -26,6 +26,25 @@ defmodule Schooner.Test.ValueGenerators do
     |> compound_value(depth)
   end
 
+  @doc """
+  Generator for any reader-readable Schooner value, depth-bounded.
+
+  Excludes `:eof` and `:unspecified`, which have no Scheme source syntax
+  and therefore cannot survive a `write`/`read` round-trip.
+  """
+  def readable_value(depth \\ 3) do
+    one_of([
+      readable_atom_value(),
+      integer_value(),
+      float_value(),
+      char_value(),
+      string_value(),
+      bytevector_value(),
+      symbol_value()
+    ])
+    |> compound_value(depth)
+  end
+
   defp compound_value(leaf, 0), do: leaf
 
   defp compound_value(leaf, depth) do
@@ -44,6 +63,14 @@ defmodule Schooner.Test.ValueGenerators do
       constant(:null),
       constant(:eof),
       constant(:unspecified)
+    ])
+  end
+
+  def readable_atom_value do
+    one_of([
+      constant({:bool, true}),
+      constant({:bool, false}),
+      constant(:null)
     ])
   end
 


### PR DESCRIPTION
## Summary
- New `Schooner.Reader` turns the lexer's token stream into a datum AST built from `Schooner.Value` cons cells. Desugars `'`, `` ` ``, `,`, `,@` into `(quote ...)` / `(quasiquote ...)` / `(unquote ...)` / `(unquote-splicing ...)`. Handles dotted pairs, vector literals, bytevector literals (with byte-range validation), and stacked `#;` datum comments.
- New `Schooner.Reader.Error` carries a structured `:reason` and `:position`, mirroring the lexer's exception shape so downstream tooling can quote source locations back to the user.
- Closes the lex/read layer: the previously-skipped write/read round-trip property test is now wired through `Reader.read_string`, running against a new `readable_value` generator that excludes `:eof`/`:unspecified` (the only value tags with no source syntax).

## Test plan
- [x] `mix precommit` green (compile-warnings-as-errors, format, credo --strict, test) — 10 properties / 121 tests, 0 failures
- [x] Unit coverage in `test/schooner/reader_test.exs`: every datum kind (atoms, lists, dotted pairs, vectors, bytevectors, all four quote forms, every literal type), nested data (vectors-in-lists-in-quasiquote-in-lists), datum-comment skipping at top level / inside list / inside vector / stacked, multi-datum input
- [x] Parse-error suite asserts `:reason` *and* `:position` for: unmatched `)`, unterminated list/vector/bytevector, dot at list start / outside list / inside vector / with no tail / with extra tail, non-byte and non-integer in bytevector, trailing `'` and `,@`, datum-comment at EOF
- [x] `test/schooner/reader_property_test.exs` and the unskipped property in `test/schooner/value_property_test.exs` exercise `Value.write` → `Reader.read_string` → `Value.equal?` round-trip on the readable subset of the value model

🤖 Generated with [Claude Code](https://claude.com/claude-code)