### PR TITLE
Phase 4: core evaluator MVP

### DIFF
--- a/lib/schooner.ex
+++ b/lib/schooner.ex
@@ -3,8 +3,34 @@ defmodule Schooner do
   An embeddable, sandboxed Scheme interpreter for the BEAM, targeting the
   r7rs-small language minus its mutable operations.
 
-  This module re-exports the public embedding API. The interpreter itself
-  is built up across `Schooner.Value`, `Schooner.Lexer`, `Schooner.Reader`,
-  `Schooner.Expander`, `Schooner.Env`, and `Schooner.Eval`.
+  The pipeline is `Schooner.Lexer` → `Schooner.Reader` → `Schooner.Eval`,
+  with `Schooner.Value` providing the tagged-term value model and
+  `Schooner.Env` the immutable-with-mutable-globals environment.
+
+  This module exposes the convenience entry points used by tests and by
+  early embeddings. The full embedding API arrives in a later phase.
   """
+
+  alias Schooner.Env
+  alias Schooner.Eval
+  alias Schooner.Reader
+  alias Schooner.Value
+
+  @doc """
+  Read and evaluate `source` in a fresh environment. Returns the value
+  of the last datum, or `:unspecified` for empty input.
+  """
+  @spec run(binary()) :: Value.t()
+  def run(source) when is_binary(source), do: eval(source, Env.new())
+
+  @doc """
+  Read and evaluate `source` in the given environment, threading
+  top-level definitions into it. Returns the value of the last datum.
+  """
+  @spec eval(binary(), Env.t()) :: Value.t()
+  def eval(source, %Env{} = env) when is_binary(source) do
+    source
+    |> Reader.read_string()
+    |> Enum.reduce(:unspecified, fn form, _acc -> Eval.eval(form, env) end)
+  end
 end

--- a/lib/schooner/env.ex
+++ b/lib/schooner/env.ex
@@ -1,0 +1,73 @@
+defmodule Schooner.Env do
+  @moduledoc """
+  Immutable-ish environment for the Scheme evaluator.
+
+  An environment is a chain of lexical frames innermost-first plus a
+  *globals* table identified by an `:ets` table id. Lexical frames are
+  immutable maps; new frames are pushed by `extend/2`. The globals
+  table is mutable in the strict sense — `define/3` writes to it — so
+  closures that captured an env see top-level definitions added after
+  they were created. This is the standard `letrec`-style knot-tying
+  applied to the top-level frame: closures reference the frame by
+  identity, not by value-at-bind-time.
+
+  The globals table is owned by the process that calls `new/0` and is
+  GC'd when that process exits, so per-execution sandboxing falls out
+  of the BEAM's process model.
+  """
+
+  alias Schooner.Value
+
+  @enforce_keys [:globals, :lex]
+  defstruct [:globals, :lex]
+
+  @type frame :: %{optional(binary()) => Value.t()}
+  @type t :: %__MODULE__{globals: :ets.tid(), lex: [frame()]}
+
+  @spec new() :: t()
+  def new do
+    table = :ets.new(:schooner_globals, [:set, :protected])
+    %__MODULE__{globals: table, lex: []}
+  end
+
+  @doc "Look up `name`. Walks lexical frames innermost-first, then globals."
+  @spec lookup(t(), binary()) :: {:ok, Value.t()} | :error
+  def lookup(%__MODULE__{lex: lex, globals: globals}, name) when is_binary(name) do
+    case lex_lookup(lex, name) do
+      {:ok, _} = ok -> ok
+      :error -> globals_lookup(globals, name)
+    end
+  end
+
+  defp lex_lookup([], _name), do: :error
+
+  defp lex_lookup([frame | rest], name) do
+    case Map.fetch(frame, name) do
+      {:ok, _} = ok -> ok
+      :error -> lex_lookup(rest, name)
+    end
+  end
+
+  defp globals_lookup(table, name) do
+    case :ets.lookup(table, name) do
+      [{^name, value}] -> {:ok, value}
+      [] -> :error
+    end
+  end
+
+  @doc """
+  Add or replace a top-level binding. Visible to every closure that
+  captured this env, regardless of when it was created.
+  """
+  @spec define(t(), binary(), Value.t()) :: t()
+  def define(%__MODULE__{globals: globals} = env, name, value) when is_binary(name) do
+    :ets.insert(globals, {name, value})
+    env
+  end
+
+  @doc "Push a new lexical frame on top of `env`."
+  @spec extend(t(), [{binary(), Value.t()}]) :: t()
+  def extend(%__MODULE__{lex: lex} = env, bindings) do
+    %{env | lex: [Map.new(bindings) | lex]}
+  end
+end

--- a/lib/schooner/eval.ex
+++ b/lib/schooner/eval.ex
@@ -1,0 +1,204 @@
+defmodule Schooner.Eval do
+  @moduledoc """
+  Tail-recursive direct evaluator for the core Scheme language.
+
+  ## Tail-call invariant
+
+  Every branch of `eval/2`, `apply_proc/2`, and `eval_sequence/2`
+  finishes with a direct tail call to one of those three. Nothing
+  wraps these calls in a `try`, a tuple constructor, a `with`, or any
+  expression that would knock them out of tail position. This is what
+  makes Scheme's proper-tail-call requirement fall out of BEAM's
+  last-call optimisation. **Adding a wrapper around any of these
+  calls breaks the invariant — see `eval_tco_test.exs`.**
+
+  Phase 4 recognises only the core forms: `quote`, `if`, `lambda`,
+  top-level `define`, `begin`, application, and variable reference.
+  Everything else is either self-evaluating or an error.
+  """
+
+  alias Schooner.Env
+  alias Schooner.Eval.Error
+  alias Schooner.Value
+
+  @spec eval(Value.t(), Env.t()) :: Value.t()
+
+  def eval({:sym, name}, env) do
+    case Env.lookup(env, name) do
+      {:ok, value} -> value
+      :error -> raise Error, reason: {:unbound, name}
+    end
+  end
+
+  def eval(:null, _env), do: raise(Error, reason: :empty_application)
+
+  def eval({:pair, head, tail}, env) do
+    case head do
+      {:sym, "quote"} -> eval_quote(tail)
+      {:sym, "if"} -> eval_if(tail, env)
+      {:sym, "lambda"} -> eval_lambda(tail, env)
+      {:sym, "define"} -> eval_define(tail, env)
+      {:sym, "begin"} -> eval_sequence(tail, env)
+      _ -> eval_apply(head, tail, env)
+    end
+  end
+
+  def eval(value, _env), do: value
+
+  # ---------------------------------------------------------------------------
+  # quote
+  # ---------------------------------------------------------------------------
+
+  defp eval_quote({:pair, datum, :null}), do: datum
+  defp eval_quote(_), do: raise(Error, reason: {:bad_special_form, "quote"})
+
+  # ---------------------------------------------------------------------------
+  # if
+  # ---------------------------------------------------------------------------
+
+  defp eval_if({:pair, test, {:pair, then_e, :null}}, env) do
+    if Value.truthy?(eval(test, env)) do
+      eval(then_e, env)
+    else
+      :unspecified
+    end
+  end
+
+  defp eval_if({:pair, test, {:pair, then_e, {:pair, else_e, :null}}}, env) do
+    if Value.truthy?(eval(test, env)) do
+      eval(then_e, env)
+    else
+      eval(else_e, env)
+    end
+  end
+
+  defp eval_if(_, _env), do: raise(Error, reason: {:bad_special_form, "if"})
+
+  # ---------------------------------------------------------------------------
+  # lambda
+  # ---------------------------------------------------------------------------
+
+  defp eval_lambda({:pair, _params_form, :null}, _env) do
+    raise(Error, reason: {:bad_special_form, "lambda"})
+  end
+
+  defp eval_lambda({:pair, params_form, body}, env) do
+    Value.closure(parse_params(params_form), body, env, nil)
+  end
+
+  defp eval_lambda(_, _env), do: raise(Error, reason: {:bad_special_form, "lambda"})
+
+  defp parse_params({:sym, name}), do: {:any, name}
+  defp parse_params(:null), do: {:fixed, 0, []}
+  defp parse_params({:pair, _, _} = list), do: collect_params(list, [], 0)
+  defp parse_params(_), do: raise(Error, reason: :invalid_params)
+
+  defp collect_params(:null, acc, n), do: {:fixed, n, Enum.reverse(acc)}
+
+  defp collect_params({:sym, rest_name}, acc, n) do
+    {:fixed_rest, n, Enum.reverse(acc), rest_name}
+  end
+
+  defp collect_params({:pair, {:sym, name}, t}, acc, n) do
+    collect_params(t, [name | acc], n + 1)
+  end
+
+  defp collect_params(_, _, _), do: raise(Error, reason: :invalid_params)
+
+  # ---------------------------------------------------------------------------
+  # define — top-level only at MVP; not enforced syntactically yet
+  # ---------------------------------------------------------------------------
+
+  defp eval_define({:pair, {:sym, name}, {:pair, expr, :null}}, env) do
+    Env.define(env, name, eval(expr, env))
+    :unspecified
+  end
+
+  defp eval_define({:pair, {:pair, {:sym, _name}, _params}, :null}, _env) do
+    raise(Error, reason: {:bad_special_form, "define"})
+  end
+
+  defp eval_define({:pair, {:pair, {:sym, name}, params_form}, body}, env) do
+    closure = Value.closure(parse_params(params_form), body, env, name)
+    Env.define(env, name, closure)
+    :unspecified
+  end
+
+  defp eval_define(_, _env), do: raise(Error, reason: {:bad_special_form, "define"})
+
+  # ---------------------------------------------------------------------------
+  # sequence — body of begin / lambda / define-fn
+  # ---------------------------------------------------------------------------
+
+  defp eval_sequence({:pair, last, :null}, env), do: eval(last, env)
+
+  defp eval_sequence({:pair, head, rest}, env) do
+    _ = eval(head, env)
+    eval_sequence(rest, env)
+  end
+
+  defp eval_sequence(:null, _env), do: :unspecified
+
+  # ---------------------------------------------------------------------------
+  # application
+  # ---------------------------------------------------------------------------
+
+  defp eval_apply(head_expr, args_form, env) do
+    proc = eval(head_expr, env)
+    args = eval_args(args_form, env, [])
+    apply_proc(proc, args)
+  end
+
+  defp eval_args(:null, _env, acc), do: Enum.reverse(acc)
+  defp eval_args({:pair, h, t}, env, acc), do: eval_args(t, env, [eval(h, env) | acc])
+  defp eval_args(_, _env, _acc), do: raise(Error, reason: :improper_application)
+
+  @spec apply_proc(Value.t(), [Value.t()]) :: Value.t()
+  def apply_proc({:closure, params, body, env, name}, args) do
+    new_env = Env.extend(env, bind_params(params, args, name))
+    eval_sequence(body, new_env)
+  end
+
+  def apply_proc({:primitive, name, arity, fun}, args) do
+    check_primitive_arity!(arity, args, name)
+    fun.(args)
+  end
+
+  def apply_proc(other, _args), do: raise(Error, reason: {:not_a_procedure, other})
+
+  defp bind_params({:fixed, n, names}, args, fname) do
+    case length(args) do
+      ^n -> Enum.zip(names, args)
+      got -> raise(Error, reason: {:arity_mismatch, fname, {:exact, n}, got})
+    end
+  end
+
+  defp bind_params({:any, name}, args, _fname), do: [{name, Value.list(args)}]
+
+  defp bind_params({:fixed_rest, n, names, rest_name}, args, fname) do
+    case length(args) do
+      got when got >= n ->
+        {head, tail} = Enum.split(args, n)
+        Enum.zip(names, head) ++ [{rest_name, Value.list(tail)}]
+
+      got ->
+        raise(Error, reason: {:arity_mismatch, fname, {:at_least, n}, got})
+    end
+  end
+
+  defp check_primitive_arity!(n, args, name) when is_integer(n) do
+    got = length(args)
+
+    if got != n do
+      raise(Error, reason: {:arity_mismatch, name, {:exact, n}, got})
+    end
+  end
+
+  defp check_primitive_arity!({:at_least, n}, args, name) do
+    got = length(args)
+
+    if got < n do
+      raise(Error, reason: {:arity_mismatch, name, {:at_least, n}, got})
+    end
+  end
+end

--- a/lib/schooner/eval/error.ex
+++ b/lib/schooner/eval/error.ex
@@ -1,0 +1,35 @@
+defmodule Schooner.Eval.Error do
+  @moduledoc """
+  Exception raised by `Schooner.Eval` for runtime and syntactic failures.
+
+  The `:reason` field is a structured term — atom or tagged tuple — meant
+  to be machine-matchable in tests. The pretty `:message` is generated
+  lazily so assertions can pin behaviour without coupling to wording.
+  """
+
+  defexception [:reason, :message]
+
+  @impl true
+  def exception(opts) do
+    reason = Keyword.fetch!(opts, :reason)
+    %__MODULE__{reason: reason, message: format(reason)}
+  end
+
+  defp format({:unbound, name}), do: "unbound variable: #{name}"
+  defp format(:empty_application), do: "() is not a valid expression"
+  defp format({:not_a_procedure, value}), do: "not a procedure: #{inspect(value)}"
+  defp format({:bad_special_form, name}), do: "malformed `#{name}` form"
+  defp format(:invalid_params), do: "invalid lambda parameter list"
+  defp format(:improper_application), do: "improper application form"
+
+  defp format({:arity_mismatch, name, {:exact, expected}, got}) do
+    "arity mismatch in #{name_str(name)}: expected #{expected}, got #{got}"
+  end
+
+  defp format({:arity_mismatch, name, {:at_least, expected}, got}) do
+    "arity mismatch in #{name_str(name)}: expected at least #{expected}, got #{got}"
+  end
+
+  defp name_str(nil), do: "anonymous procedure"
+  defp name_str(name) when is_binary(name), do: "`#{name}`"
+end

--- a/test/schooner/env_test.exs
+++ b/test/schooner/env_test.exs
@@ -1,0 +1,60 @@
+defmodule Schooner.EnvTest do
+  use ExUnit.Case, async: true
+
+  alias Schooner.Env
+  alias Schooner.Value
+
+  test "new/0 returns an env with no lexical frames" do
+    env = Env.new()
+    assert env.lex == []
+    assert is_reference(env.globals) or is_integer(env.globals)
+  end
+
+  test "lookup of an unbound name returns :error" do
+    assert Env.lookup(Env.new(), "nope") == :error
+  end
+
+  test "define/3 + lookup roundtrip on globals" do
+    env = Env.new() |> Env.define("x", 1) |> Env.define("y", Value.symbol("y"))
+    assert Env.lookup(env, "x") == {:ok, 1}
+    assert Env.lookup(env, "y") == {:ok, Value.symbol("y")}
+  end
+
+  test "define/3 overwrites a previous global binding" do
+    env = Env.new() |> Env.define("x", 1) |> Env.define("x", 2)
+    assert Env.lookup(env, "x") == {:ok, 2}
+  end
+
+  test "extend/2 pushes a lexical frame; lookup walks innermost-first" do
+    env =
+      Env.new()
+      |> Env.define("x", :outer_global)
+      |> Env.extend([{"x", :outer_lex}])
+      |> Env.extend([{"x", :inner_lex}])
+
+    assert Env.lookup(env, "x") == {:ok, :inner_lex}
+  end
+
+  test "lex frame falls through to global when name is absent locally" do
+    env =
+      Env.new()
+      |> Env.define("g", 99)
+      |> Env.extend([{"local", 1}])
+
+    assert Env.lookup(env, "g") == {:ok, 99}
+    assert Env.lookup(env, "local") == {:ok, 1}
+  end
+
+  test "global define is visible through previously-pushed lex frames" do
+    base = Env.new() |> Env.extend([{"a", 1}])
+    Env.define(base, "later", 42)
+    assert Env.lookup(base, "later") == {:ok, 42}
+  end
+
+  test "two envs created independently do not share globals" do
+    a = Env.new() |> Env.define("k", 1)
+    b = Env.new()
+    assert Env.lookup(a, "k") == {:ok, 1}
+    assert Env.lookup(b, "k") == :error
+  end
+end

--- a/test/schooner/eval_tco_test.exs
+++ b/test/schooner/eval_tco_test.exs
@@ -1,0 +1,102 @@
+defmodule Schooner.EvalTcoTest do
+  @moduledoc """
+  Regression tests for proper-tail-call behaviour. Each test recurses
+  100 000 calls deep and asserts both that the call returns and that
+  the process heap stays bounded — i.e. the tail calls really did
+  collapse rather than each pushing a frame.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Schooner.Env
+  alias Schooner.Value
+
+  @depth 100_000
+
+  defp depth, do: @depth
+
+  defp env_with_int_prims do
+    Env.new()
+    |> Env.define(
+      "zero-int?",
+      Value.primitive("zero-int?", 1, fn [n] -> Value.bool(n === 0) end)
+    )
+    |> Env.define("sub1", Value.primitive("sub1", 1, fn [n] -> n - 1 end))
+  end
+
+  defp run!(source), do: Schooner.eval(source, env_with_int_prims())
+
+  defp assert_bounded_heap(fun) do
+    fun.()
+    {:total_heap_size, heap} = Process.info(self(), :total_heap_size)
+    # 100k stacked frames would blow well past this; ~5M words is generous.
+    assert heap < 5_000_000, "heap grew to #{heap} words — TCO likely broken"
+  end
+
+  test "tail call as the entire lambda body" do
+    assert_bounded_heap(fn ->
+      assert run!("""
+             (define (loop n)
+               (if (zero-int? n) 'done (loop (sub1 n))))
+             (loop #{depth()})
+             """) == Value.symbol("done")
+    end)
+  end
+
+  test "tail call in if then-branch" do
+    assert_bounded_heap(fn ->
+      assert run!("""
+             (define (loop n)
+               (if (zero-int? n)
+                   'done
+                   (loop (sub1 n))))
+             (loop #{depth()})
+             """) == Value.symbol("done")
+    end)
+  end
+
+  test "tail call in if else-branch (inverted predicate)" do
+    env =
+      env_with_int_prims()
+      |> Env.define(
+        "nonzero-int?",
+        Value.primitive("nonzero-int?", 1, fn [n] -> Value.bool(n !== 0) end)
+      )
+
+    source = """
+    (define (loop n)
+      (if (nonzero-int? n)
+          (loop (sub1 n))
+          'done))
+    (loop #{depth()})
+    """
+
+    assert_bounded_heap(fn ->
+      assert Schooner.eval(source, env) == Value.symbol("done")
+    end)
+  end
+
+  test "tail call as the last form of begin" do
+    assert_bounded_heap(fn ->
+      assert run!("""
+             (define (loop n)
+               (begin
+                 'discard
+                 (if (zero-int? n) 'done (loop (sub1 n)))))
+             (loop #{depth()})
+             """) == Value.symbol("done")
+    end)
+  end
+
+  test "mutually tail-recursive even?/odd? at depth" do
+    assert_bounded_heap(fn ->
+      assert run!("""
+             (define (even? n)
+               (if (zero-int? n) #t (odd? (sub1 n))))
+             (define (odd? n)
+               (if (zero-int? n) #f (even? (sub1 n))))
+             (even? #{depth()})
+             """) == Value.bool(true)
+    end)
+  end
+end

--- a/test/schooner/eval_test.exs
+++ b/test/schooner/eval_test.exs
@@ -1,0 +1,237 @@
+defmodule Schooner.EvalTest do
+  use ExUnit.Case, async: true
+
+  alias Schooner.Env
+  alias Schooner.Eval.Error
+  alias Schooner.Value
+
+  defp run(source), do: Schooner.run(source)
+
+  describe "self-evaluating literals" do
+    test "integers, floats, booleans, strings, chars, vectors, bytevectors" do
+      assert run("42") == 42
+      assert run("-7") == -7
+      assert run("1.5") == 1.5
+      assert run("#t") == Value.bool(true)
+      assert run("#f") == Value.bool(false)
+      assert run(~S("hello")) == Value.string("hello")
+      assert run(~S(#\a)) == Value.char(?a)
+      assert run("#(1 2 3)") == Value.vector([1, 2, 3])
+      assert run("#u8(0 1 255)") == Value.bytevector([0, 1, 255])
+    end
+
+    test "empty input returns :unspecified" do
+      assert run("") == :unspecified
+    end
+
+    test "() raises empty_application" do
+      assert_raise Error, fn -> run("()") end
+    end
+  end
+
+  describe "variable reference" do
+    test "resolves a top-level binding" do
+      assert run("(define x 10) x") == 10
+    end
+
+    test "unbound variable raises {:unbound, name}" do
+      e = assert_raise Error, fn -> run("nope") end
+      assert e.reason == {:unbound, "nope"}
+    end
+  end
+
+  describe "quote" do
+    test "returns the datum unchanged" do
+      assert run("(quote 5)") == 5
+      assert run("'5") == 5
+      assert run("'foo") == Value.symbol("foo")
+      assert run("'()") == :null
+      assert run("'(1 2 3)") == Value.list([1, 2, 3])
+    end
+
+    test "quote with wrong arity raises" do
+      e = assert_raise Error, fn -> run("(quote)") end
+      assert e.reason == {:bad_special_form, "quote"}
+    end
+  end
+
+  describe "if" do
+    test "selects the then-branch when test is truthy" do
+      assert run("(if #t 1 2)") == 1
+      assert run("(if 0 1 2)") == 1
+      assert run("(if '() 1 2)") == 1
+      assert run(~S|(if "str" 1 2)|) == 1
+    end
+
+    test "only #f is falsy" do
+      assert run("(if #f 1 2)") == 2
+    end
+
+    test "if without an else branch returns :unspecified on falsy test" do
+      assert run("(if #f 1)") == :unspecified
+    end
+
+    test "if without an else branch returns then on truthy test" do
+      assert run("(if #t 1)") == 1
+    end
+
+    test "malformed if raises" do
+      e = assert_raise Error, fn -> run("(if)") end
+      assert e.reason == {:bad_special_form, "if"}
+    end
+  end
+
+  describe "lambda" do
+    test "evaluates to a closure value" do
+      v = run("(lambda (x) x)")
+      assert match?({:closure, {:fixed, 1, ["x"]}, _, _, nil}, v)
+    end
+
+    test "fixed-arity application" do
+      assert run("((lambda (x y) x) 1 2)") == 1
+      assert run("((lambda (x y) y) 1 2)") == 2
+    end
+
+    test "variadic lambda binds all args to a list" do
+      assert run("((lambda args args) 1 2 3)") == Value.list([1, 2, 3])
+      assert run("((lambda args args))") == :null
+    end
+
+    test "dotted-rest lambda binds head fixed and rest as a list" do
+      assert run("((lambda (a . rest) rest) 1 2 3)") == Value.list([2, 3])
+      assert run("((lambda (a b . rest) rest) 1 2)") == :null
+    end
+
+    test "arity mismatch on fixed lambda raises" do
+      e = assert_raise Error, fn -> run("((lambda (x y) x) 1)") end
+      assert match?({:arity_mismatch, _, {:exact, 2}, 1}, e.reason)
+    end
+
+    test "arity mismatch on dotted-rest lambda raises" do
+      e = assert_raise Error, fn -> run("((lambda (a b . r) r) 1)") end
+      assert match?({:arity_mismatch, _, {:at_least, 2}, 1}, e.reason)
+    end
+
+    test "lambda with empty body raises" do
+      e = assert_raise Error, fn -> run("(lambda (x))") end
+      assert e.reason == {:bad_special_form, "lambda"}
+    end
+  end
+
+  describe "define" do
+    test "simple define returns :unspecified and binds globally" do
+      env = Env.new()
+      assert Schooner.eval("(define x 7)", env) == :unspecified
+      assert Env.lookup(env, "x") == {:ok, 7}
+    end
+
+    test "function-form define binds a named closure" do
+      env = Env.new()
+      Schooner.eval("(define (f x) x)", env)
+      assert {:ok, {:closure, {:fixed, 1, ["x"]}, _, _, "f"}} = Env.lookup(env, "f")
+    end
+
+    test "function-form with empty body raises" do
+      e = assert_raise Error, fn -> run("(define (f x))") end
+      assert e.reason == {:bad_special_form, "define"}
+    end
+
+    test "redefining a name overwrites it" do
+      assert run("(define x 1) (define x 2) x") == 2
+    end
+  end
+
+  describe "begin" do
+    test "returns the value of the last form" do
+      assert run("(begin 1 2 3)") == 3
+    end
+
+    test "intermediate forms are evaluated for side effect" do
+      assert run("(begin (define x 5) x)") == 5
+    end
+
+    test "empty begin returns :unspecified" do
+      assert run("(begin)") == :unspecified
+    end
+  end
+
+  describe "application" do
+    test "primitive procedure" do
+      env = Env.new() |> Env.define("inc", primitive_inc())
+      assert Schooner.eval("(inc 41)", env) == 42
+    end
+
+    test "calling a non-procedure raises" do
+      e = assert_raise Error, fn -> run("(5 1 2)") end
+      assert match?({:not_a_procedure, 5}, e.reason)
+    end
+
+    test "primitive arity mismatch raises" do
+      env = Env.new() |> Env.define("inc", primitive_inc())
+      e = assert_raise Error, fn -> Schooner.eval("(inc 1 2)", env) end
+      assert match?({:arity_mismatch, "inc", {:exact, 1}, 2}, e.reason)
+    end
+  end
+
+  describe "lexical scoping" do
+    test "inner binding shadows outer" do
+      assert run("""
+             (define x 1)
+             ((lambda (x) x) 99)
+             """) == 99
+    end
+
+    test "outer binding is restored after inner scope" do
+      assert run("""
+             (define x 1)
+             ((lambda (x) x) 99)
+             x
+             """) == 1
+    end
+
+    test "closure captures its defining environment, not the calling one" do
+      assert run("""
+             (define x 1)
+             (define get-x (lambda () x))
+             ((lambda (x) (get-x)) 99)
+             """) == 1
+    end
+
+    test "nested lambdas access enclosing parameters" do
+      assert run("(((lambda (x) (lambda (y) x)) 1) 2)") == 1
+    end
+  end
+
+  describe "mutual recursion via top-level defines" do
+    test "even?/odd? at small depth" do
+      source = """
+      (define (even? n)
+        (if (zero-int? n) #t (odd? (sub1 n))))
+      (define (odd? n)
+        (if (zero-int? n) #f (even? (sub1 n))))
+      """
+
+      assert run_with_int_prims(source <> "(even? 10)") == Value.bool(true)
+      assert run_with_int_prims(source <> "(odd? 10)") == Value.bool(false)
+      assert run_with_int_prims(source <> "(even? 7)") == Value.bool(false)
+    end
+  end
+
+  # --- helpers ----------------------------------------------------------------
+
+  defp primitive_inc do
+    Value.primitive("inc", 1, fn [n] when is_integer(n) -> n + 1 end)
+  end
+
+  defp run_with_int_prims(source) do
+    env =
+      Env.new()
+      |> Env.define(
+        "zero-int?",
+        Value.primitive("zero-int?", 1, fn [n] -> Value.bool(n === 0) end)
+      )
+      |> Env.define("sub1", Value.primitive("sub1", 1, fn [n] -> n - 1 end))
+
+    Schooner.eval(source, env)
+  end
+end


### PR DESCRIPTION
## Summary
- New `Schooner.Eval` is a tail-recursive direct evaluator for the core forms (`quote`, `if`, `lambda`, top-level `define`, `begin`, application, variable). The TCO invariant — every branch of `eval/2`, `apply_proc/2`, `eval_sequence/2` ends with a direct tail call to one of those three — is documented at the top of the module.
- New `Schooner.Env` keeps the lexical chain as immutable maps but stores top-level bindings in an `:ets` table so closures reference the global frame *by identity*. This is what makes mutual recursion via successive top-level `define`s resolve forward references — closures defined before their callees still see the current globals when applied. The table is `:protected` and owned by the calling process, so per-execution sandboxing falls out of the BEAM's process model.
- New `Schooner.Eval.Error` carries a structured `:reason` (machine-matchable in tests) and a lazily-formatted `:message`, mirroring the `Reader.Error` shape.
- `Schooner.run/1` and `Schooner.eval/2` provide read→evaluate convenience entry points.

## Test plan
- [x] `mix precommit` green (compile-warnings-as-errors, format, credo --strict, test) — 10 properties / 168 tests, 0 failures
- [x] `test/schooner/env_test.exs`: `lookup` walks lex innermost-first then falls through to globals; redefining a global overwrites; post-define visible through earlier-built envs (frame-by-identity); two envs created independently are isolated
- [x] `test/schooner/eval_test.exs`: every core form (literals, `quote`, `if` truthy/falsy/no-else, `lambda`, `define` simple + fn-form, `begin` last-value); both lambda flavours (variadic, dotted-rest); lexical scoping (inner shadows outer; closure captures defining env, not calling); mutual recursion via two top-level defines; error cases (`()`, unbound, non-procedure, arity mismatch on fixed and `at_least`, malformed special forms)
- [x] `test/schooner/eval_tco_test.exs`: 100 000-deep recursion exercising tail position as whole body / `if` then-branch / `if` else-branch / last form of `begin` / mutual `even?`/`odd?`. Each test also asserts `Process.info(:total_heap_size)` stays under 5M words so a regression that broke TCO would fail loudly rather than silently OOMing the runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)