### PR TITLE
Phase 5: arithmetic, predicates, and base primitives

### DIFF
--- a/lib/schooner.ex
+++ b/lib/schooner.ex
@@ -13,15 +13,25 @@ defmodule Schooner do
 
   alias Schooner.Env
   alias Schooner.Eval
+  alias Schooner.Primitives
   alias Schooner.Reader
   alias Schooner.Value
 
   @doc """
-  Read and evaluate `source` in a fresh environment. Returns the value
-  of the last datum, or `:unspecified` for empty input.
+  An environment preloaded with the standard primitives shipped by
+  Schooner. `Env.new/0` deliberately stays empty for tests that want
+  isolation; this is the entry point for callers that want a usable
+  Scheme out of the box.
+  """
+  @spec standard_env() :: Env.t()
+  def standard_env, do: Env.new() |> Primitives.Base.register_into()
+
+  @doc """
+  Read and evaluate `source` in a fresh standard environment. Returns
+  the value of the last datum, or `:unspecified` for empty input.
   """
   @spec run(binary()) :: Value.t()
-  def run(source) when is_binary(source), do: eval(source, Env.new())
+  def run(source) when is_binary(source), do: eval(source, standard_env())
 
   @doc """
   Read and evaluate `source` in the given environment, threading

--- a/lib/schooner/primitive/error.ex
+++ b/lib/schooner/primitive/error.ex
@@ -1,0 +1,43 @@
+defmodule Schooner.Primitive.Error do
+  @moduledoc """
+  Exception raised by built-in primitives for domain-specific failures —
+  type errors, division by zero, and the family of "would require rationals
+  or complex" cases that Schooner explicitly does not implement.
+
+  Kept distinct from `Schooner.Eval.Error` because primitives report a
+  different vocabulary of failures than the evaluator. Tests can pattern
+  on `:reason` to pin behaviour without coupling to wording.
+  """
+
+  defexception [:reason, :message]
+
+  @impl true
+  def exception(opts) do
+    reason = Keyword.fetch!(opts, :reason)
+    %__MODULE__{reason: reason, message: format(reason)}
+  end
+
+  defp format({:type_error, op, expected, got}) do
+    "type error in `#{op}`: expected #{expected}, got #{inspect(got)}"
+  end
+
+  defp format({:division_by_zero, op}) do
+    "division by zero in `#{op}`"
+  end
+
+  defp format({:exact_division_not_integer, num, den}) do
+    "exact division `(/ #{num} #{den})` would yield a rational; Schooner has no rational tower"
+  end
+
+  defp format({:negative_exponent, base, exp}) do
+    "`(expt #{inspect(base)} #{inspect(exp)})` would yield a rational; Schooner has no rational tower"
+  end
+
+  defp format({:irrational, op, arg}) do
+    "`(#{op} #{inspect(arg)})` would yield an irrational; Schooner has no rational tower"
+  end
+
+  defp format({:not_representable_exact, value}) do
+    "`#{inspect(value)}` is not representable as an exact integer"
+  end
+end

--- a/lib/schooner/primitives/base.ex
+++ b/lib/schooner/primitives/base.ex
@@ -1,0 +1,455 @@
+defmodule Schooner.Primitives.Base do
+  @moduledoc """
+  Numeric core, type predicates, and boolean helpers from `(scheme base)`.
+
+  Every binding here is registered as a `Schooner.Value.primitive/3` value
+  in the standard environment. The evaluator already understands those
+  via `Schooner.Eval.apply_proc/2` — this module just supplies the
+  Elixir-side implementations.
+
+  Exactness rules follow r7rs: integer-only inputs produce exact integer
+  results where possible; any inexact (float) operand contaminates the
+  whole expression. Operations that would step outside integer/float —
+  rationals, complex, irrationals — raise `Schooner.Primitive.Error`
+  rather than silently widening, because Schooner has no rational tower.
+  """
+
+  alias Schooner.Env
+  alias Schooner.Primitive.Error
+  alias Schooner.Value
+
+  # ---------------------------------------------------------------------------
+  # Public registration
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Define every base primitive on `env`. Returns the same env (the global
+  table is mutated in place — consistent with `Env.define/3`).
+  """
+  @spec register_into(Env.t()) :: Env.t()
+  def register_into(%Env{} = env) do
+    Enum.reduce(specs(), env, fn {name, arity, fun}, acc ->
+      Env.define(acc, name, Value.primitive(name, arity, fun))
+    end)
+  end
+
+  defp specs do
+    arithmetic_specs() ++ comparison_specs() ++ predicate_specs() ++ boolean_specs()
+  end
+
+  # ---------------------------------------------------------------------------
+  # Arithmetic
+  # ---------------------------------------------------------------------------
+
+  defp arithmetic_specs do
+    [
+      {"+", {:at_least, 0}, &add/1},
+      {"-", {:at_least, 1}, &sub/1},
+      {"*", {:at_least, 0}, &mul/1},
+      {"/", {:at_least, 1}, &divide/1},
+      {"quotient", 2, &quotient/1},
+      {"remainder", 2, &remainder/1},
+      {"modulo", 2, &modulo/1},
+      {"abs", 1, &abs_/1},
+      {"min", {:at_least, 1}, &min_/1},
+      {"max", {:at_least, 1}, &max_/1},
+      {"expt", 2, &expt/1},
+      {"gcd", {:at_least, 0}, &gcd_/1},
+      {"lcm", {:at_least, 0}, &lcm_/1},
+      {"sqrt", 1, &sqrt_/1},
+      {"exact->inexact", 1, &exact_to_inexact/1},
+      {"inexact->exact", 1, &inexact_to_exact/1}
+    ]
+  end
+
+  defp add([]), do: 0
+  defp add(args), do: reduce_numeric("+", args, 0, &+/2)
+
+  defp sub([n]) do
+    require_number!("-", n)
+    -n
+  end
+
+  defp sub([first | rest]) do
+    require_number!("-", first)
+    reduce_numeric("-", rest, first, &-/2)
+  end
+
+  defp mul([]), do: 1
+  defp mul(args), do: reduce_numeric("*", args, 1, &*/2)
+
+  defp divide([n]) do
+    require_number!("/", n)
+    divide_pair("/", 1, n)
+  end
+
+  defp divide([first | rest]) do
+    require_number!("/", first)
+
+    Enum.reduce(rest, first, fn b, a ->
+      require_number!("/", b)
+      divide_pair("/", a, b)
+    end)
+  end
+
+  defp divide_pair(_op, a, b) when is_integer(a) and is_integer(b) do
+    cond do
+      b == 0 -> raise Error, reason: {:division_by_zero, "/"}
+      rem(a, b) == 0 -> div(a, b)
+      true -> raise Error, reason: {:exact_division_not_integer, a, b}
+    end
+  end
+
+  defp divide_pair(_op, a, b) do
+    a = to_float(a)
+    b = to_float(b)
+    do_float_divide(a, b)
+  end
+
+  # BEAM raises ArithmeticError on float `/0` rather than producing :inf/:nan.
+  # Surface that as a structured error consistent with the integer-divide path.
+  defp do_float_divide(_a, +0.0), do: raise(Error, reason: {:division_by_zero, "/"})
+  defp do_float_divide(_a, -0.0), do: raise(Error, reason: {:division_by_zero, "/"})
+  defp do_float_divide(a, b), do: a / b
+
+  defp quotient([a, b]) do
+    require_integer!("quotient", a)
+    require_integer!("quotient", b)
+    if b == 0, do: raise(Error, reason: {:division_by_zero, "quotient"})
+    coerce_int_result(a, b, div(trunc_int(a), trunc_int(b)))
+  end
+
+  defp remainder([a, b]) do
+    require_integer!("remainder", a)
+    require_integer!("remainder", b)
+    if b == 0, do: raise(Error, reason: {:division_by_zero, "remainder"})
+    coerce_int_result(a, b, rem(trunc_int(a), trunc_int(b)))
+  end
+
+  defp modulo([a, b]) do
+    require_integer!("modulo", a)
+    require_integer!("modulo", b)
+    if b == 0, do: raise(Error, reason: {:division_by_zero, "modulo"})
+
+    ai = trunc_int(a)
+    bi = trunc_int(b)
+    r = rem(ai, bi)
+    result = if r != 0 and signum(r) != signum(bi), do: r + bi, else: r
+    coerce_int_result(a, b, result)
+  end
+
+  defp abs_([n]) do
+    require_number!("abs", n)
+    abs(n)
+  end
+
+  defp min_([first | rest]) do
+    require_number!("min", first)
+
+    Enum.reduce(rest, first, fn b, a ->
+      require_number!("min", b)
+      pick_min(a, b)
+    end)
+  end
+
+  defp max_([first | rest]) do
+    require_number!("max", first)
+
+    Enum.reduce(rest, first, fn b, a ->
+      require_number!("max", b)
+      pick_max(a, b)
+    end)
+  end
+
+  # min/max contaminate exactness even when the chosen value is exact.
+  defp pick_min(a, b) when is_float(a) or is_float(b), do: min(to_float(a), to_float(b))
+  defp pick_min(a, b), do: min(a, b)
+
+  defp pick_max(a, b) when is_float(a) or is_float(b), do: max(to_float(a), to_float(b))
+  defp pick_max(a, b), do: max(a, b)
+
+  defp expt([base, exp]) do
+    require_number!("expt", base)
+    require_number!("expt", exp)
+    do_expt(base, exp)
+  end
+
+  defp do_expt(base, exp) when is_integer(base) and is_integer(exp) and exp >= 0 do
+    int_pow(base, exp)
+  end
+
+  defp do_expt(1, exp) when is_integer(exp), do: 1
+  defp do_expt(-1, exp) when is_integer(exp) and rem(exp, 2) == 0, do: 1
+  defp do_expt(-1, exp) when is_integer(exp), do: -1
+
+  defp do_expt(base, exp) when is_integer(base) and is_integer(exp) do
+    raise Error, reason: {:negative_exponent, base, exp}
+  end
+
+  defp do_expt(base, exp), do: :math.pow(to_float(base), to_float(exp))
+
+  defp int_pow(_b, 0), do: 1
+  defp int_pow(b, 1), do: b
+
+  defp int_pow(b, e) when rem(e, 2) == 0 do
+    half = int_pow(b, div(e, 2))
+    half * half
+  end
+
+  defp int_pow(b, e), do: b * int_pow(b, e - 1)
+
+  defp gcd_([]), do: 0
+
+  defp gcd_(args) do
+    Enum.each(args, &require_integer!("gcd", &1))
+    {ints, any_float?} = collect_int_args(args)
+    result = Enum.reduce(ints, 0, &Integer.gcd(abs(&1), abs(&2)))
+    if any_float?, do: result * 1.0, else: result
+  end
+
+  defp lcm_([]), do: 1
+
+  defp lcm_(args) do
+    Enum.each(args, &require_integer!("lcm", &1))
+    {ints, any_float?} = collect_int_args(args)
+
+    result =
+      Enum.reduce(ints, 1, fn x, acc ->
+        x = abs(x)
+        if x == 0 or acc == 0, do: 0, else: div(acc * x, Integer.gcd(acc, x))
+      end)
+
+    if any_float?, do: result * 1.0, else: result
+  end
+
+  defp sqrt_([n]) do
+    require_number!("sqrt", n)
+
+    cond do
+      is_float(n) -> :math.sqrt(n)
+      is_integer(n) and n >= 0 -> exact_isqrt_or_raise(n)
+      true -> raise Error, reason: {:irrational, "sqrt", n}
+    end
+  end
+
+  defp exact_isqrt_or_raise(n) do
+    r = isqrt(n)
+    if r * r == n, do: r, else: raise(Error, reason: {:irrational, "sqrt", n})
+  end
+
+  # Integer square root via Newton's method on arbitrary-precision integers.
+  defp isqrt(0), do: 0
+
+  defp isqrt(n) when n > 0 do
+    isqrt_loop(n, n)
+  end
+
+  defp isqrt_loop(n, x) do
+    nx = div(div(n, x) + x, 2)
+    if nx >= x, do: x, else: isqrt_loop(n, nx)
+  end
+
+  defp exact_to_inexact([n]) do
+    require_number!("exact->inexact", n)
+    to_float(n)
+  end
+
+  defp inexact_to_exact([n]) when is_integer(n), do: n
+
+  defp inexact_to_exact([n]) when is_float(n) do
+    if Value.integer?(n), do: trunc(n), else: raise(Error, reason: {:not_representable_exact, n})
+  end
+
+  defp inexact_to_exact([other]) do
+    raise Error, reason: {:type_error, "inexact->exact", "number", other}
+  end
+
+  # ---------------------------------------------------------------------------
+  # Comparison
+  # ---------------------------------------------------------------------------
+
+  defp comparison_specs do
+    [
+      {"=", {:at_least, 1}, &cmp_eq/1},
+      {"<", {:at_least, 1}, &cmp_lt/1},
+      {">", {:at_least, 1}, &cmp_gt/1},
+      {"<=", {:at_least, 1}, &cmp_le/1},
+      {">=", {:at_least, 1}, &cmp_ge/1}
+    ]
+  end
+
+  defp cmp_eq(args), do: variadic_cmp("=", args, &num_eq/2)
+  defp cmp_lt(args), do: variadic_cmp("<", args, &num_lt/2)
+  defp cmp_gt(args), do: variadic_cmp(">", args, &num_gt/2)
+  defp cmp_le(args), do: variadic_cmp("<=", args, &num_le/2)
+  defp cmp_ge(args), do: variadic_cmp(">=", args, &num_ge/2)
+
+  defp variadic_cmp(op, [first | rest], pair) do
+    require_number!(op, first)
+    Value.bool(check_pairs(rest, first, op, pair))
+  end
+
+  defp check_pairs([], _prev, _op, _pair), do: true
+
+  defp check_pairs([b | rest], prev, op, pair) do
+    require_number!(op, b)
+    pair.(prev, b) and check_pairs(rest, b, op, pair)
+  end
+
+  # `=` is numerical equality; `(= 1 1.0)` is true (only `eqv?` cares about exactness).
+  defp num_eq(a, b) when is_float(a) or is_float(b), do: to_float(a) == to_float(b)
+  defp num_eq(a, b), do: a == b
+
+  defp num_lt(a, b) when is_float(a) or is_float(b), do: to_float(a) < to_float(b)
+  defp num_lt(a, b), do: a < b
+
+  defp num_gt(a, b) when is_float(a) or is_float(b), do: to_float(a) > to_float(b)
+  defp num_gt(a, b), do: a > b
+
+  defp num_le(a, b) when is_float(a) or is_float(b), do: to_float(a) <= to_float(b)
+  defp num_le(a, b), do: a <= b
+
+  defp num_ge(a, b) when is_float(a) or is_float(b), do: to_float(a) >= to_float(b)
+  defp num_ge(a, b), do: a >= b
+
+  # ---------------------------------------------------------------------------
+  # Predicates
+  # ---------------------------------------------------------------------------
+
+  defp predicate_specs do
+    [
+      {"number?", 1, &number_p/1},
+      {"integer?", 1, &integer_p/1},
+      {"exact?", 1, &exact_p/1},
+      {"inexact?", 1, &inexact_p/1},
+      {"zero?", 1, &zero_p/1},
+      {"positive?", 1, &positive_p/1},
+      {"negative?", 1, &negative_p/1},
+      {"odd?", 1, &odd_p/1},
+      {"even?", 1, &even_p/1},
+      {"boolean?", 1, &boolean_p/1},
+      {"pair?", 1, &pair_p/1},
+      {"null?", 1, &null_p/1},
+      {"symbol?", 1, &symbol_p/1},
+      {"string?", 1, &string_p/1},
+      {"char?", 1, &char_p/1},
+      {"vector?", 1, &vector_p/1},
+      {"bytevector?", 1, &bytevector_p/1},
+      {"procedure?", 1, &procedure_p/1},
+      {"eof-object?", 1, &eof_p/1}
+    ]
+  end
+
+  defp number_p([v]), do: Value.bool(Value.number?(v))
+  defp integer_p([v]), do: Value.bool(Value.integer?(v))
+  defp exact_p([v]), do: Value.bool(Value.exact?(v))
+  defp inexact_p([v]), do: Value.bool(Value.inexact?(v))
+  defp boolean_p([v]), do: Value.bool(Value.boolean?(v))
+  defp pair_p([v]), do: Value.bool(Value.pair?(v))
+  defp null_p([v]), do: Value.bool(Value.null?(v))
+  defp symbol_p([v]), do: Value.bool(Value.symbol?(v))
+  defp string_p([v]), do: Value.bool(Value.string?(v))
+  defp char_p([v]), do: Value.bool(Value.char?(v))
+  defp vector_p([v]), do: Value.bool(Value.vector?(v))
+  defp bytevector_p([v]), do: Value.bool(Value.bytevector?(v))
+  defp procedure_p([v]), do: Value.bool(Value.procedure?(v))
+  defp eof_p([v]), do: Value.bool(Value.eof?(v))
+
+  defp zero_p([n]) do
+    require_number!("zero?", n)
+    Value.bool(n == 0)
+  end
+
+  defp positive_p([n]) do
+    require_number!("positive?", n)
+    Value.bool(n > 0)
+  end
+
+  defp negative_p([n]) do
+    require_number!("negative?", n)
+    Value.bool(n < 0)
+  end
+
+  defp odd_p([n]) do
+    require_integer!("odd?", n)
+    Value.bool(rem(trunc_int(n), 2) != 0)
+  end
+
+  defp even_p([n]) do
+    require_integer!("even?", n)
+    Value.bool(rem(trunc_int(n), 2) == 0)
+  end
+
+  # ---------------------------------------------------------------------------
+  # Boolean
+  # ---------------------------------------------------------------------------
+
+  defp boolean_specs do
+    [
+      {"not", 1, &not_p/1},
+      {"boolean=?", {:at_least, 2}, &boolean_equal/1}
+    ]
+  end
+
+  defp not_p([v]), do: Value.bool(not Value.truthy?(v))
+
+  defp boolean_equal([first | rest] = args) do
+    Enum.each(args, fn
+      {:bool, _} -> :ok
+      other -> raise(Error, reason: {:type_error, "boolean=?", "boolean", other})
+    end)
+
+    Value.bool(Enum.all?(rest, &(&1 === first)))
+  end
+
+  # ---------------------------------------------------------------------------
+  # Helpers
+  # ---------------------------------------------------------------------------
+
+  defp reduce_numeric(op, args, acc, op_fn) do
+    Enum.reduce(args, acc, fn x, a ->
+      require_number!(op, x)
+
+      if is_float(a) or is_float(x) do
+        op_fn.(to_float(a), to_float(x))
+      else
+        op_fn.(a, x)
+      end
+    end)
+  end
+
+  defp require_number!(_op, n) when is_integer(n) or is_float(n), do: :ok
+
+  defp require_number!(op, other) do
+    raise Error, reason: {:type_error, op, "number", other}
+  end
+
+  defp require_integer!(_op, n) when is_integer(n), do: :ok
+
+  defp require_integer!(op, n) when is_float(n) do
+    if Value.integer?(n), do: :ok, else: raise(Error, reason: {:type_error, op, "integer", n})
+  end
+
+  defp require_integer!(op, other) do
+    raise Error, reason: {:type_error, op, "integer", other}
+  end
+
+  defp to_float(n) when is_float(n), do: n
+  defp to_float(n) when is_integer(n), do: n * 1.0
+
+  defp trunc_int(n) when is_integer(n), do: n
+  defp trunc_int(n) when is_float(n), do: trunc(n)
+
+  defp signum(0), do: 0
+  defp signum(n) when n > 0, do: 1
+  defp signum(_), do: -1
+
+  defp coerce_int_result(a, b, n) when is_float(a) or is_float(b), do: n * 1.0
+  defp coerce_int_result(_, _, n), do: n
+
+  defp collect_int_args(args) do
+    any_float? = Enum.any?(args, &is_float/1)
+    ints = Enum.map(args, &trunc_int/1)
+    {ints, any_float?}
+  end
+end

--- a/test/schooner/primitives/base_property_test.exs
+++ b/test/schooner/primitives/base_property_test.exs
@@ -1,0 +1,64 @@
+defmodule Schooner.Primitives.BasePropertyTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  defp run(source), do: Schooner.run(source)
+
+  defp small_int, do: integer(-100..100)
+
+  property "+ is associative on small integers" do
+    check all(
+            a <- small_int(),
+            b <- small_int(),
+            c <- small_int()
+          ) do
+      lhs = run("(+ (+ #{a} #{b}) #{c})")
+      rhs = run("(+ #{a} (+ #{b} #{c}))")
+      assert lhs === rhs
+    end
+  end
+
+  property "+ is commutative on small integers" do
+    check all(a <- small_int(), b <- small_int()) do
+      assert run("(+ #{a} #{b})") === run("(+ #{b} #{a})")
+    end
+  end
+
+  property "0 is the additive identity" do
+    check all(a <- small_int()) do
+      assert run("(+ #{a} 0)") === a
+      assert run("(+ 0 #{a})") === a
+    end
+  end
+
+  property "* is associative on small integers" do
+    check all(
+            a <- small_int(),
+            b <- small_int(),
+            c <- small_int()
+          ) do
+      lhs = run("(* (* #{a} #{b}) #{c})")
+      rhs = run("(* #{a} (* #{b} #{c}))")
+      assert lhs === rhs
+    end
+  end
+
+  property "* is commutative on small integers" do
+    check all(a <- small_int(), b <- small_int()) do
+      assert run("(* #{a} #{b})") === run("(* #{b} #{a})")
+    end
+  end
+
+  property "1 is the multiplicative identity" do
+    check all(a <- small_int()) do
+      assert run("(* #{a} 1)") === a
+      assert run("(* 1 #{a})") === a
+    end
+  end
+
+  property "(- a b) = (+ a (- b))" do
+    check all(a <- small_int(), b <- small_int()) do
+      assert run("(- #{a} #{b})") === run("(+ #{a} (- #{b}))")
+    end
+  end
+end

--- a/test/schooner/primitives/base_test.exs
+++ b/test/schooner/primitives/base_test.exs
@@ -1,0 +1,393 @@
+defmodule Schooner.Primitives.BaseTest do
+  use ExUnit.Case, async: true
+
+  alias Schooner.Primitive.Error, as: PError
+  alias Schooner.Value
+
+  defp run(source), do: Schooner.run(source)
+
+  # ---------------------------------------------------------------------------
+  # Arithmetic — exactness contamination matrix
+  # ---------------------------------------------------------------------------
+
+  describe "exactness contamination" do
+    test "+ — exact/exact stays exact, any inexact contaminates" do
+      assert run("(+ 1 2)") === 3
+      assert run("(+ 1 2.0)") === 3.0
+      assert run("(+ 1.0 2.0)") === 3.0
+    end
+
+    test "- contamination" do
+      assert run("(- 5 2)") === 3
+      assert run("(- 5 2.0)") === 3.0
+      assert run("(- 5.0 2.0)") === 3.0
+    end
+
+    test "* contamination" do
+      assert run("(* 4 5)") === 20
+      assert run("(* 4 5.0)") === 20.0
+      assert run("(* 4.0 5.0)") === 20.0
+    end
+
+    test "/ contamination" do
+      assert run("(/ 6 3)") === 2
+      assert run("(/ 6 3.0)") === 2.0
+      assert run("(/ 6.0 3.0)") === 2.0
+    end
+
+    test "quotient/remainder/modulo contamination" do
+      assert run("(quotient 7 3)") === 2
+      assert run("(quotient 7.0 3)") === 2.0
+      assert run("(remainder 7 3)") === 1
+      assert run("(remainder 7 3.0)") === 1.0
+      assert run("(modulo 7 3)") === 1
+      assert run("(modulo 7 3.0)") === 1.0
+    end
+
+    test "min/max contamination" do
+      assert run("(min 3 1 2)") === 1
+      assert run("(min 3 1.0 2)") === 1.0
+      assert run("(max 1 2 3)") === 3
+      assert run("(max 1 2.0 3)") === 3.0
+    end
+
+    test "expt contamination" do
+      assert run("(expt 2 10)") === 1024
+      assert run("(expt 2.0 10)") === 1024.0
+      assert run("(expt 2 10.0)") === 1024.0
+    end
+
+    test "abs contamination preserves operand exactness" do
+      assert run("(abs -5)") === 5
+      assert run("(abs -5.0)") === 5.0
+    end
+
+    test "gcd/lcm contamination" do
+      assert run("(gcd 12 18)") === 6
+      assert run("(gcd 12 18.0)") === 6.0
+      assert run("(lcm 4 6)") === 12
+      assert run("(lcm 4 6.0)") === 12.0
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Arbitrary-precision integers
+  # ---------------------------------------------------------------------------
+
+  describe "arbitrary-precision integers" do
+    test "(* 10000000000 10000000000) is exact and does not overflow" do
+      n = run("(* 10000000000 10000000000)")
+      assert is_integer(n)
+      assert n === 100_000_000_000_000_000_000
+    end
+
+    test "expt produces big integers exactly" do
+      assert run("(expt 2 100)") === 1_267_650_600_228_229_401_496_703_205_376
+    end
+
+    test "factorial via expt and *" do
+      assert run("(* (expt 2 64) 1)") === 18_446_744_073_709_551_616
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Float edge cases — rendering
+  # ---------------------------------------------------------------------------
+
+  describe "float edge cases" do
+    test "negative zero renders" do
+      assert Value.write(run("(* -1.0 0.0)")) =~ "0"
+    end
+
+    test "(/ 1.0 0.0) raises division_by_zero (BEAM does not produce :inf)" do
+      assert_raise PError, fn -> run("(/ 1.0 0.0)") end
+    end
+
+    test "rendered floats round-trip via re-evaluation" do
+      v = run("3.1415")
+      assert Value.write(v) == "3.1415"
+      assert run(Value.write(v)) === v
+    end
+
+    test "small float renders without surprising scientific notation" do
+      assert Value.write(run("0.5")) == "0.5"
+    end
+
+    @tag :skip
+    test "+inf.0 / -inf.0 / +nan.0 round-trip through write/read" do
+      # The lexer tokenises these forms but the term-decoder trick used to
+      # synthesise the float values is rejected by current ERTS. Until the
+      # lexer is updated, no value of these tags can flow through eval.
+      assert Value.write(run("+inf.0")) == "+inf.0"
+      assert Value.write(run("-inf.0")) == "-inf.0"
+      assert Value.write(run("+nan.0")) == "+nan.0"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Comparison
+  # ---------------------------------------------------------------------------
+
+  describe "comparison" do
+    test "= variadic" do
+      assert run("(= 1 1)") == Value.bool(true)
+      assert run("(= 1 1 1 1)") == Value.bool(true)
+      assert run("(= 1 1.0)") == Value.bool(true)
+      assert run("(= 1 2)") == Value.bool(false)
+      assert run("(= 1)") == Value.bool(true)
+    end
+
+    test "< variadic strict" do
+      assert run("(< 1 2 3)") == Value.bool(true)
+      assert run("(< 1 1 2)") == Value.bool(false)
+      assert run("(< 3 2 1)") == Value.bool(false)
+    end
+
+    test "> < <= >= variadic" do
+      assert run("(> 3 2 1)") == Value.bool(true)
+      assert run("(<= 1 1 2)") == Value.bool(true)
+      assert run("(>= 3 3 1)") == Value.bool(true)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Predicates — table-driven
+  # ---------------------------------------------------------------------------
+
+  describe "predicates over a fixture covering each value tag" do
+    @predicates [
+      "number?",
+      "integer?",
+      "exact?",
+      "inexact?",
+      "boolean?",
+      "pair?",
+      "null?",
+      "symbol?",
+      "string?",
+      "char?",
+      "vector?",
+      "bytevector?",
+      "procedure?",
+      "eof-object?"
+    ]
+
+    @fixture [
+      {"42", [:number, :integer, :exact]},
+      {"-7", [:number, :integer, :exact]},
+      {"3.14", [:number, :inexact]},
+      {"2.0", [:number, :integer, :inexact]},
+      {"#t", [:boolean]},
+      {"#f", [:boolean]},
+      {"'()", [:null]},
+      {"'(1 2)", [:pair]},
+      {"'foo", [:symbol]},
+      {~S("hi"), [:string]},
+      {~S(#\a), [:char]},
+      {"#(1 2 3)", [:vector]},
+      {"#u8(1 2 3)", [:bytevector]},
+      {"(lambda (x) x)", [:procedure]},
+      {"+", [:procedure]}
+    ]
+
+    @pred_to_tag %{
+      "number?" => :number,
+      "integer?" => :integer,
+      "exact?" => :exact,
+      "inexact?" => :inexact,
+      "boolean?" => :boolean,
+      "pair?" => :pair,
+      "null?" => :null,
+      "symbol?" => :symbol,
+      "string?" => :string,
+      "char?" => :char,
+      "vector?" => :vector,
+      "bytevector?" => :bytevector,
+      "procedure?" => :procedure,
+      "eof-object?" => :eof
+    }
+
+    test "every predicate returns expected value over every fixture entry" do
+      for {literal, tags} <- @fixture, pred <- @predicates do
+        tag = Map.fetch!(@pred_to_tag, pred)
+        expected = Value.bool(tag in tags)
+        actual = Schooner.run("(#{pred} #{literal})")
+
+        assert actual == expected,
+               "(#{pred} #{literal}) => #{inspect(actual)} (want #{inspect(expected)})"
+      end
+    end
+
+    test "zero?/positive?/negative?" do
+      assert run("(zero? 0)") == Value.bool(true)
+      assert run("(zero? 0.0)") == Value.bool(true)
+      assert run("(zero? 1)") == Value.bool(false)
+      assert run("(positive? 1)") == Value.bool(true)
+      assert run("(positive? -1)") == Value.bool(false)
+      assert run("(positive? 0)") == Value.bool(false)
+      assert run("(negative? -1)") == Value.bool(true)
+      assert run("(negative? 0)") == Value.bool(false)
+    end
+
+    test "odd?/even?" do
+      assert run("(odd? 3)") == Value.bool(true)
+      assert run("(odd? 4)") == Value.bool(false)
+      assert run("(even? 4)") == Value.bool(true)
+      assert run("(even? 5)") == Value.bool(false)
+      assert run("(even? 4.0)") == Value.bool(true)
+    end
+
+    test "boolean=? requires at least two booleans" do
+      assert run("(boolean=? #t #t)") == Value.bool(true)
+      assert run("(boolean=? #t #f)") == Value.bool(false)
+      assert run("(boolean=? #t #t #t)") == Value.bool(true)
+      assert run("(boolean=? #t #t #f)") == Value.bool(false)
+    end
+
+    test "not" do
+      assert run("(not #f)") == Value.bool(true)
+      assert run("(not #t)") == Value.bool(false)
+      assert run("(not 0)") == Value.bool(false)
+      assert run("(not '())") == Value.bool(false)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Documented "would require rationals/complex" errors
+  # ---------------------------------------------------------------------------
+
+  describe "raises on rationals/complex" do
+    test "(/ 1 3) with exact operands raises exact_division_not_integer" do
+      e = assert_raise PError, fn -> run("(/ 1 3)") end
+      assert match?({:exact_division_not_integer, 1, 3}, e.reason)
+    end
+
+    test "(/ 6 3) with exact operands stays exact" do
+      assert run("(/ 6 3)") === 2
+    end
+
+    test "(/ 1.0 3) is fine because float operand contaminates" do
+      assert is_float(run("(/ 1.0 3)"))
+    end
+
+    test "(sqrt 2) with non-square exact integer raises irrational" do
+      e = assert_raise PError, fn -> run("(sqrt 2)") end
+      assert match?({:irrational, "sqrt", 2}, e.reason)
+    end
+
+    test "(sqrt 4) returns exact 2" do
+      assert run("(sqrt 4)") === 2
+    end
+
+    test "(sqrt 2.0) returns float (inexact context)" do
+      assert run("(sqrt 2.0)") == :math.sqrt(2.0)
+    end
+
+    test "(sqrt -1) raises irrational" do
+      e = assert_raise PError, fn -> run("(sqrt -1)") end
+      assert match?({:irrational, "sqrt", -1}, e.reason)
+    end
+
+    test "(expt 2 -3) on integers raises negative_exponent" do
+      e = assert_raise PError, fn -> run("(expt 2 -3)") end
+      assert match?({:negative_exponent, 2, -3}, e.reason)
+    end
+
+    test "(expt 1 -3) returns 1 (no rational needed)" do
+      assert run("(expt 1 -3)") === 1
+    end
+
+    test "(expt -1 -3) returns -1" do
+      assert run("(expt -1 -3)") === -1
+    end
+
+    test "(expt 2.0 -3) returns float" do
+      assert run("(expt 2.0 -3)") == 0.125
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Type errors and division by zero
+  # ---------------------------------------------------------------------------
+
+  describe "type errors" do
+    test "(+ 1 \"two\") raises type_error" do
+      e = assert_raise PError, fn -> run(~S|(+ 1 "two")|) end
+      assert match?({:type_error, "+", "number", _}, e.reason)
+    end
+
+    test "(quotient 5 0) raises division_by_zero" do
+      e = assert_raise PError, fn -> run("(quotient 5 0)") end
+      assert e.reason == {:division_by_zero, "quotient"}
+    end
+
+    test "(/ 1 0) raises division_by_zero" do
+      e = assert_raise PError, fn -> run("(/ 1 0)") end
+      assert e.reason == {:division_by_zero, "/"}
+    end
+
+    test "(modulo 5 0) raises division_by_zero" do
+      e = assert_raise PError, fn -> run("(modulo 5 0)") end
+      assert e.reason == {:division_by_zero, "modulo"}
+    end
+
+    test "(boolean=? #t 1) raises type_error" do
+      e = assert_raise PError, fn -> run("(boolean=? #t 1)") end
+      assert match?({:type_error, "boolean=?", "boolean", _}, e.reason)
+    end
+
+    test "(odd? 1.5) raises type_error (not an integer)" do
+      e = assert_raise PError, fn -> run("(odd? 1.5)") end
+      assert match?({:type_error, "odd?", "integer", _}, e.reason)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # exact/inexact conversions
+  # ---------------------------------------------------------------------------
+
+  describe "exact/inexact conversions" do
+    test "exact->inexact on integers" do
+      assert run("(exact->inexact 3)") === 3.0
+    end
+
+    test "exact->inexact on floats is identity" do
+      assert run("(exact->inexact 3.0)") === 3.0
+    end
+
+    test "inexact->exact on integer-valued floats" do
+      assert run("(inexact->exact 3.0)") === 3
+    end
+
+    test "inexact->exact on non-integer float raises" do
+      e = assert_raise PError, fn -> run("(inexact->exact 1.5)") end
+      assert match?({:not_representable_exact, _}, e.reason)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Variadic edge cases
+  # ---------------------------------------------------------------------------
+
+  describe "variadic edge cases" do
+    test "(+) is 0; (*) is 1" do
+      assert run("(+)") === 0
+      assert run("(*)") === 1
+    end
+
+    test "(- n) negates" do
+      assert run("(- 5)") === -5
+      assert run("(- 5.0)") === -5.0
+    end
+
+    test "(/ n) reciprocates only when exact-divisible" do
+      assert run("(/ 1.0)") === 1.0
+      assert_raise PError, fn -> run("(/ 3)") end
+    end
+
+    test "(gcd) is 0; (lcm) is 1" do
+      assert run("(gcd)") === 0
+      assert run("(lcm)") === 1
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- New `Schooner.Primitives.Base` registers the `(scheme base)` numeric core (`+ - * / quotient remainder modulo abs min max expt gcd lcm sqrt`, comparisons, `exact->inexact` / `inexact->exact`), all numeric and type predicates, plus `not` and `boolean=?`. Exactness contamination follows r7rs; operations that would require rationals or complex (`(/ 1 3)` on exact operands, `(sqrt 2)`, negative integer exponents on non-±1 bases, `(inexact->exact 1.5)`) raise a structured `Schooner.Primitive.Error` rather than silently widening, since Schooner has no rational tower.
- New `Schooner.standard_env/0` wraps `Env.new/0` with the base primitives preloaded; `Schooner.run/1` now uses it. `Env.new/0` is unchanged so tests that want isolation can opt out.
- Two known limitations spun out into follow-up issues:
  - **#7** — the lexer can't currently construct `+inf.0` / `-inf.0` / `+nan.0` floats on this OTP (latent bug from Phase 2). The plan's float-non-finite round-trip test is `@tag :skip` until that lands.
  - **#8** — `(/ x 0.0)` raises `{:division_by_zero, "/"}` rather than producing IEEE-754 specials, because BEAM raises `ArithmeticError` on float zero division. Depends on #7.

## Test plan
Each item from `PLAN.md`'s Phase 5 test list is covered. `mix precommit` green: 17 properties, 218 tests, 0 failures, 1 skipped (the round-trip pinned to #7).

- [x] **Item 1 — exactness contamination matrix.** `test/schooner/primitives/base_test.exs` `describe "exactness contamination"` covers `+ - * / quotient remainder modulo min max expt abs gcd lcm` over (exact, exact), (exact, inexact), (inexact, inexact) operand pairings.
- [x] **Item 2 — arbitrary-precision integers.** `describe "arbitrary-precision integers"` (10²⁰ multiplication, `(expt 2 100)`).
- [x] **Item 3 — float edge cases.** `describe "float edge cases"` covers negative zero and `(/ x 0.0)` raising. The `+inf.0` / `-inf.0` / `+nan.0` round-trip is `@tag :skip` and tracked in #7.
- [x] **Item 4 — table-driven predicate fixture.** `describe "predicates over a fixture covering each value tag"` — Cartesian product of 14 predicates × 15 fixture values covering every value tag.
- [x] **Item 5 — rationals/complex errors.** `describe "raises on rationals/complex"` pins `(/ 1 3)`, `(sqrt 2)`, `(sqrt -1)`, `(expt 2 -3)` to their structured `:reason`s.
- [x] **Item 6 — algebraic properties.** `test/schooner/primitives/base_property_test.exs` — associativity and commutativity of `+` / `*` on small integers, identity element, `(- a b) = (+ a (- b))`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)