### PR TITLE
Add non-finite float support (+inf.0 / -inf.0 / +nan.0) via tagged value

### DIFF
--- a/lib/schooner/lexer.ex
+++ b/lib/schooner/lexer.ex
@@ -664,16 +664,12 @@ defmodule Schooner.Lexer do
 
   defp all_hex_digits?(s), do: every_byte?(s, &digit_in_radix?(&1, 16))
 
-  defp special_float("+inf.0"), do: positive_infinity()
-  defp special_float("-inf.0"), do: negative_infinity()
-  defp special_float("+nan.0"), do: nan()
-  defp special_float("-nan.0"), do: nan()
-
-  # `0/0`-style construction risks compile-time evaluation; pin them to
-  # values built by the BEAM at runtime via well-known IEEE-754 bytes.
-  defp positive_infinity, do: :erlang.binary_to_term(<<131, 70, 127, 240, 0, 0, 0, 0, 0, 0>>)
-  defp negative_infinity, do: :erlang.binary_to_term(<<131, 70, 255, 240, 0, 0, 0, 0, 0, 0>>)
-  defp nan, do: :erlang.binary_to_term(<<131, 70, 127, 248, 0, 0, 0, 0, 0, 0>>)
+  # The BEAM cannot represent IEEE-754 non-finite floats as `float()`
+  # values; they are modelled as a distinct tagged value in `Schooner.Value`.
+  defp special_float("+inf.0"), do: {:float_special, :pos_inf}
+  defp special_float("-inf.0"), do: {:float_special, :neg_inf}
+  defp special_float("+nan.0"), do: {:float_special, :nan}
+  defp special_float("-nan.0"), do: {:float_special, :nan}
 
   # ---------------------------------------------------------------------------
   # Identifier classification

--- a/lib/schooner/primitives/base.ex
+++ b/lib/schooner/primitives/base.ex
@@ -18,6 +18,9 @@ defmodule Schooner.Primitives.Base do
   alias Schooner.Primitive.Error
   alias Schooner.Value
 
+  defguardp is_special(v)
+            when is_tuple(v) and tuple_size(v) == 2 and elem(v, 0) == :float_special
+
   # ---------------------------------------------------------------------------
   # Public registration
   # ---------------------------------------------------------------------------
@@ -63,20 +66,20 @@ defmodule Schooner.Primitives.Base do
   end
 
   defp add([]), do: 0
-  defp add(args), do: reduce_numeric("+", args, 0, &+/2)
+  defp add(args), do: reduce_numeric("+", args, 0, &add_pair/2)
 
   defp sub([n]) do
     require_number!("-", n)
-    -n
+    negate(n)
   end
 
   defp sub([first | rest]) do
     require_number!("-", first)
-    reduce_numeric("-", rest, first, &-/2)
+    reduce_numeric("-", rest, first, &sub_pair/2)
   end
 
   defp mul([]), do: 1
-  defp mul(args), do: reduce_numeric("*", args, 1, &*/2)
+  defp mul(args), do: reduce_numeric("*", args, 1, &mul_pair/2)
 
   defp divide([n]) do
     require_number!("/", n)
@@ -92,6 +95,65 @@ defmodule Schooner.Primitives.Base do
     end)
   end
 
+  # ---- Specials-aware pairwise arithmetic ------------------------------------
+
+  defp add_pair(a, b) when is_special(a) or is_special(b), do: special_add(a, b)
+  defp add_pair(a, b) when is_float(a) or is_float(b), do: to_float(a) + to_float(b)
+  defp add_pair(a, b), do: a + b
+
+  defp sub_pair(a, b) when is_special(a) or is_special(b), do: special_add(a, negate(b))
+  defp sub_pair(a, b) when is_float(a) or is_float(b), do: to_float(a) - to_float(b)
+  defp sub_pair(a, b), do: a - b
+
+  defp mul_pair(a, b) when is_special(a) or is_special(b), do: special_mul(a, b)
+  defp mul_pair(a, b) when is_float(a) or is_float(b), do: to_float(a) * to_float(b)
+  defp mul_pair(a, b), do: a * b
+
+  defp negate({:float_special, :pos_inf}), do: {:float_special, :neg_inf}
+  defp negate({:float_special, :neg_inf}), do: {:float_special, :pos_inf}
+  defp negate({:float_special, :nan}), do: {:float_special, :nan}
+  defp negate(n), do: -n
+
+  # NaN propagates; otherwise IEEE-754 inf rules. `+inf + -inf` → NaN.
+  defp special_add({:float_special, :nan}, _), do: {:float_special, :nan}
+  defp special_add(_, {:float_special, :nan}), do: {:float_special, :nan}
+
+  defp special_add({:float_special, :pos_inf}, {:float_special, :neg_inf}),
+    do: {:float_special, :nan}
+
+  defp special_add({:float_special, :neg_inf}, {:float_special, :pos_inf}),
+    do: {:float_special, :nan}
+
+  defp special_add({:float_special, k}, {:float_special, k}), do: {:float_special, k}
+  defp special_add({:float_special, k}, _finite), do: {:float_special, k}
+  defp special_add(_finite, {:float_special, k}), do: {:float_special, k}
+
+  # NaN propagates; inf*inf rules; inf*0 (any zero) is NaN.
+  defp special_mul({:float_special, :nan}, _), do: {:float_special, :nan}
+  defp special_mul(_, {:float_special, :nan}), do: {:float_special, :nan}
+
+  defp special_mul({:float_special, ka}, {:float_special, kb}) do
+    if ka == kb, do: {:float_special, :pos_inf}, else: {:float_special, :neg_inf}
+  end
+
+  defp special_mul({:float_special, k}, finite), do: scale_inf(k, sign_finite(finite))
+  defp special_mul(finite, {:float_special, k}), do: scale_inf(k, sign_finite(finite))
+
+  # Sign of a finite real, treating both +0.0 and -0.0 as zero (their
+  # signed-ness only matters for division, not multiplication).
+  defp sign_finite(0), do: 0
+  defp sign_finite(+0.0), do: 0
+  defp sign_finite(-0.0), do: 0
+  defp sign_finite(n) when n > 0, do: 1
+  defp sign_finite(_), do: -1
+
+  defp scale_inf(_k, 0), do: {:float_special, :nan}
+  defp scale_inf(k, 1), do: {:float_special, k}
+  defp scale_inf(:pos_inf, -1), do: {:float_special, :neg_inf}
+  defp scale_inf(:neg_inf, -1), do: {:float_special, :pos_inf}
+
+  # ---- Division --------------------------------------------------------------
+
   defp divide_pair(_op, a, b) when is_integer(a) and is_integer(b) do
     cond do
       b == 0 -> raise Error, reason: {:division_by_zero, "/"}
@@ -100,16 +162,31 @@ defmodule Schooner.Primitives.Base do
     end
   end
 
-  defp divide_pair(_op, a, b) do
-    a = to_float(a)
-    b = to_float(b)
-    do_float_divide(a, b)
-  end
+  defp divide_pair(_op, a, b) when is_special(a) or is_special(b),
+    do: special_divide(a, b)
 
-  # BEAM raises ArithmeticError on float `/0` rather than producing :inf/:nan.
-  # Surface that as a structured error consistent with the integer-divide path.
-  defp do_float_divide(_a, +0.0), do: raise(Error, reason: {:division_by_zero, "/"})
-  defp do_float_divide(_a, -0.0), do: raise(Error, reason: {:division_by_zero, "/"})
+  defp divide_pair(_op, a, b), do: do_float_divide(to_float(a), to_float(b))
+
+  # NaN propagates; inf/inf is NaN; finite/inf is 0; inf/finite preserves
+  # sign of inf scaled by sign of divisor.
+  defp special_divide({:float_special, :nan}, _), do: {:float_special, :nan}
+  defp special_divide(_, {:float_special, :nan}), do: {:float_special, :nan}
+  defp special_divide({:float_special, _}, {:float_special, _}), do: {:float_special, :nan}
+  defp special_divide(_finite, {:float_special, _}), do: 0.0
+  defp special_divide({:float_special, k}, finite), do: scale_inf(k, sign_finite(finite))
+
+  # IEEE-754 finite/zero: sign(numerator) determines the resulting infinity;
+  # zero/zero → NaN; sign of the zero divisor flips the result.
+  defp do_float_divide(+0.0, +0.0), do: {:float_special, :nan}
+  defp do_float_divide(+0.0, -0.0), do: {:float_special, :nan}
+  defp do_float_divide(-0.0, +0.0), do: {:float_special, :nan}
+  defp do_float_divide(-0.0, -0.0), do: {:float_special, :nan}
+
+  defp do_float_divide(a, +0.0) when a > 0, do: {:float_special, :pos_inf}
+  defp do_float_divide(a, +0.0) when a < 0, do: {:float_special, :neg_inf}
+  defp do_float_divide(a, -0.0) when a > 0, do: {:float_special, :neg_inf}
+  defp do_float_divide(a, -0.0) when a < 0, do: {:float_special, :pos_inf}
+
   defp do_float_divide(a, b), do: a / b
 
   defp quotient([a, b]) do
@@ -140,8 +217,12 @@ defmodule Schooner.Primitives.Base do
 
   defp abs_([n]) do
     require_number!("abs", n)
-    abs(n)
+    abs_special(n)
   end
+
+  defp abs_special({:float_special, :neg_inf}), do: {:float_special, :pos_inf}
+  defp abs_special({:float_special, k}), do: {:float_special, k}
+  defp abs_special(n), do: abs(n)
 
   defp min_([first | rest]) do
     require_number!("min", first)
@@ -162,9 +243,22 @@ defmodule Schooner.Primitives.Base do
   end
 
   # min/max contaminate exactness even when the chosen value is exact.
+  # NaN propagates per r7rs; +inf wins max / -inf wins min.
+  defp pick_min({:float_special, :nan}, _), do: {:float_special, :nan}
+  defp pick_min(_, {:float_special, :nan}), do: {:float_special, :nan}
+  defp pick_min({:float_special, :neg_inf}, _), do: {:float_special, :neg_inf}
+  defp pick_min(_, {:float_special, :neg_inf}), do: {:float_special, :neg_inf}
+  defp pick_min({:float_special, :pos_inf}, b), do: to_float(b)
+  defp pick_min(a, {:float_special, :pos_inf}), do: to_float(a)
   defp pick_min(a, b) when is_float(a) or is_float(b), do: min(to_float(a), to_float(b))
   defp pick_min(a, b), do: min(a, b)
 
+  defp pick_max({:float_special, :nan}, _), do: {:float_special, :nan}
+  defp pick_max(_, {:float_special, :nan}), do: {:float_special, :nan}
+  defp pick_max({:float_special, :pos_inf}, _), do: {:float_special, :pos_inf}
+  defp pick_max(_, {:float_special, :pos_inf}), do: {:float_special, :pos_inf}
+  defp pick_max({:float_special, :neg_inf}, b), do: to_float(b)
+  defp pick_max(a, {:float_special, :neg_inf}), do: to_float(a)
   defp pick_max(a, b) when is_float(a) or is_float(b), do: max(to_float(a), to_float(b))
   defp pick_max(a, b), do: max(a, b)
 
@@ -186,7 +280,67 @@ defmodule Schooner.Primitives.Base do
     raise Error, reason: {:negative_exponent, base, exp}
   end
 
+  defp do_expt(base, exp) when is_special(base) or is_special(exp),
+    do: special_expt(base, exp)
+
   defp do_expt(base, exp), do: :math.pow(to_float(base), to_float(exp))
+
+  # IEEE-754 pow: anything^0 is 1.0 (even NaN, even infinities); 1^anything
+  # is 1.0; NaN otherwise propagates. inf^positive → inf, inf^negative → 0.0,
+  # |b|>1 ^ +inf → inf, |b|<1 ^ +inf → 0.0, mirrored for -inf exponents.
+  defp special_expt(_, 0), do: 1.0
+  defp special_expt(_, +0.0), do: 1.0
+  defp special_expt(_, -0.0), do: 1.0
+  defp special_expt(1, _), do: 1.0
+  defp special_expt(1.0, _), do: 1.0
+  defp special_expt({:float_special, :nan}, _), do: {:float_special, :nan}
+  defp special_expt(_, {:float_special, :nan}), do: {:float_special, :nan}
+
+  defp special_expt({:float_special, :pos_inf}, exp) do
+    case finite_exp_sign(exp) do
+      1 -> {:float_special, :pos_inf}
+      -1 -> 0.0
+      _ -> {:float_special, :nan}
+    end
+  end
+
+  defp special_expt({:float_special, :neg_inf}, exp) do
+    # IEEE-754 pow(-inf, n): odd integer n preserves the sign;
+    # even integer n or non-integer n yields the positive form.
+    case finite_exp_sign(exp) do
+      1 -> if odd_integer?(exp), do: {:float_special, :neg_inf}, else: {:float_special, :pos_inf}
+      -1 -> 0.0
+      _ -> {:float_special, :nan}
+    end
+  end
+
+  defp special_expt(base, {:float_special, :pos_inf}) do
+    cond do
+      is_special(base) -> {:float_special, :pos_inf}
+      abs(to_float(base)) > 1.0 -> {:float_special, :pos_inf}
+      abs(to_float(base)) < 1.0 -> 0.0
+      true -> {:float_special, :nan}
+    end
+  end
+
+  defp special_expt(base, {:float_special, :neg_inf}) do
+    cond do
+      is_special(base) -> 0.0
+      abs(to_float(base)) > 1.0 -> 0.0
+      abs(to_float(base)) < 1.0 -> {:float_special, :pos_inf}
+      true -> {:float_special, :nan}
+    end
+  end
+
+  defp finite_exp_sign(e) when is_integer(e) and e > 0, do: 1
+  defp finite_exp_sign(e) when is_integer(e) and e < 0, do: -1
+  defp finite_exp_sign(e) when is_float(e) and e > 0.0, do: 1
+  defp finite_exp_sign(e) when is_float(e) and e < 0.0, do: -1
+  defp finite_exp_sign(_), do: 0
+
+  defp odd_integer?(e) when is_integer(e), do: rem(e, 2) != 0
+  defp odd_integer?(e) when is_float(e), do: e == trunc(e) and rem(trunc(e), 2) != 0
+  defp odd_integer?(_), do: false
 
   defp int_pow(_b, 0), do: 1
   defp int_pow(b, 1), do: b
@@ -226,6 +380,9 @@ defmodule Schooner.Primitives.Base do
     require_number!("sqrt", n)
 
     cond do
+      n == {:float_special, :pos_inf} -> {:float_special, :pos_inf}
+      is_special(n) -> {:float_special, :nan}
+      is_float(n) and n < 0.0 -> {:float_special, :nan}
       is_float(n) -> :math.sqrt(n)
       is_integer(n) and n >= 0 -> exact_isqrt_or_raise(n)
       true -> raise Error, reason: {:irrational, "sqrt", n}
@@ -251,13 +408,17 @@ defmodule Schooner.Primitives.Base do
 
   defp exact_to_inexact([n]) do
     require_number!("exact->inexact", n)
-    to_float(n)
+    if is_special(n), do: n, else: to_float(n)
   end
 
   defp inexact_to_exact([n]) when is_integer(n), do: n
 
   defp inexact_to_exact([n]) when is_float(n) do
     if Value.integer?(n), do: trunc(n), else: raise(Error, reason: {:not_representable_exact, n})
+  end
+
+  defp inexact_to_exact([{:float_special, _} = n]) do
+    raise Error, reason: {:not_representable_exact, n}
   end
 
   defp inexact_to_exact([other]) do
@@ -293,24 +454,47 @@ defmodule Schooner.Primitives.Base do
 
   defp check_pairs([b | rest], prev, op, pair) do
     require_number!(op, b)
-    pair.(prev, b) and check_pairs(rest, b, op, pair)
+    # IEEE-754: any comparison against NaN is "unordered" → false.
+    cond do
+      prev == {:float_special, :nan} -> false
+      b == {:float_special, :nan} -> false
+      pair.(prev, b) -> check_pairs(rest, b, op, pair)
+      true -> false
+    end
   end
 
   # `=` is numerical equality; `(= 1 1.0)` is true (only `eqv?` cares about exactness).
+  defp num_eq(a, b) when is_special(a) or is_special(b), do: special_cmp_eq(a, b)
   defp num_eq(a, b) when is_float(a) or is_float(b), do: to_float(a) == to_float(b)
   defp num_eq(a, b), do: a == b
 
+  defp num_lt(a, b) when is_special(a) or is_special(b), do: special_cmp(a, b) == :lt
   defp num_lt(a, b) when is_float(a) or is_float(b), do: to_float(a) < to_float(b)
   defp num_lt(a, b), do: a < b
 
+  defp num_gt(a, b) when is_special(a) or is_special(b), do: special_cmp(a, b) == :gt
   defp num_gt(a, b) when is_float(a) or is_float(b), do: to_float(a) > to_float(b)
   defp num_gt(a, b), do: a > b
 
+  defp num_le(a, b) when is_special(a) or is_special(b), do: special_cmp(a, b) in [:lt, :eq]
   defp num_le(a, b) when is_float(a) or is_float(b), do: to_float(a) <= to_float(b)
   defp num_le(a, b), do: a <= b
 
+  defp num_ge(a, b) when is_special(a) or is_special(b), do: special_cmp(a, b) in [:gt, :eq]
   defp num_ge(a, b) when is_float(a) or is_float(b), do: to_float(a) >= to_float(b)
   defp num_ge(a, b), do: a >= b
+
+  # Equality and ordering between specials and finite reals (NaN handled
+  # in `check_pairs/4`; not reached here for the generic comparison ops).
+  defp special_cmp_eq({:float_special, k}, {:float_special, k}), do: true
+  defp special_cmp_eq(_, _), do: false
+
+  defp special_cmp({:float_special, :pos_inf}, {:float_special, :pos_inf}), do: :eq
+  defp special_cmp({:float_special, :neg_inf}, {:float_special, :neg_inf}), do: :eq
+  defp special_cmp({:float_special, :pos_inf}, _), do: :gt
+  defp special_cmp({:float_special, :neg_inf}, _), do: :lt
+  defp special_cmp(_, {:float_special, :pos_inf}), do: :lt
+  defp special_cmp(_, {:float_special, :neg_inf}), do: :gt
 
   # ---------------------------------------------------------------------------
   # Predicates
@@ -357,13 +541,19 @@ defmodule Schooner.Primitives.Base do
 
   defp zero_p([n]) do
     require_number!("zero?", n)
-    Value.bool(n == 0)
+    Value.bool(not is_special(n) and n == 0)
   end
+
+  defp positive_p([{:float_special, :pos_inf}]), do: Value.bool(true)
+  defp positive_p([{:float_special, _}]), do: Value.bool(false)
 
   defp positive_p([n]) do
     require_number!("positive?", n)
     Value.bool(n > 0)
   end
+
+  defp negative_p([{:float_special, :neg_inf}]), do: Value.bool(true)
+  defp negative_p([{:float_special, _}]), do: Value.bool(false)
 
   defp negative_p([n]) do
     require_number!("negative?", n)
@@ -409,16 +599,12 @@ defmodule Schooner.Primitives.Base do
   defp reduce_numeric(op, args, acc, op_fn) do
     Enum.reduce(args, acc, fn x, a ->
       require_number!(op, x)
-
-      if is_float(a) or is_float(x) do
-        op_fn.(to_float(a), to_float(x))
-      else
-        op_fn.(a, x)
-      end
+      op_fn.(a, x)
     end)
   end
 
   defp require_number!(_op, n) when is_integer(n) or is_float(n), do: :ok
+  defp require_number!(_op, n) when is_special(n), do: :ok
 
   defp require_number!(op, other) do
     raise Error, reason: {:type_error, op, "number", other}

--- a/lib/schooner/value.ex
+++ b/lib/schooner/value.ex
@@ -19,6 +19,10 @@ defmodule Schooner.Value do
     * Character — `{:char, codepoint}`
     * Exact integer — bare Elixir integer
     * Inexact real — bare Elixir float
+    * Non-finite inexact — `{:float_special, :pos_inf | :neg_inf | :nan}`
+      (BEAM floats cannot represent these; tagged forms carry IEEE-754
+      semantics through arithmetic and comparison without smuggling
+      forbidden bit patterns into Elixir floats.)
     * Vector — `{:vector, tuple}`
     * Bytevector — `{:bytevector, binary}`
     * Closure — `{:closure, params, body, env, name_or_nil}`
@@ -38,6 +42,7 @@ defmodule Schooner.Value do
   @type closure_v :: {:closure, term(), term(), term(), binary() | nil}
   @type primitive_v :: {:primitive, binary(), arity_spec(), (list() -> t())}
   @type record_v :: {:record, term(), tuple()}
+  @type float_special_v :: {:float_special, :pos_inf | :neg_inf | :nan}
   @type arity_spec :: non_neg_integer() | {:at_least, non_neg_integer()}
 
   @type t ::
@@ -49,6 +54,7 @@ defmodule Schooner.Value do
           | char_v()
           | integer()
           | float()
+          | float_special_v()
           | vector_v()
           | bytevector_v()
           | closure_v()
@@ -163,6 +169,7 @@ defmodule Schooner.Value do
 
   @spec number?(term()) :: boolean()
   def number?(n) when is_integer(n) or is_float(n), do: true
+  def number?({:float_special, k}) when k in [:pos_inf, :neg_inf, :nan], do: true
   def number?(_), do: false
 
   @spec integer?(term()) :: boolean()
@@ -182,7 +189,12 @@ defmodule Schooner.Value do
 
   @spec inexact?(term()) :: boolean()
   def inexact?(n) when is_float(n), do: true
+  def inexact?({:float_special, k}) when k in [:pos_inf, :neg_inf, :nan], do: true
   def inexact?(_), do: false
+
+  @spec float_special?(term()) :: boolean()
+  def float_special?({:float_special, k}) when k in [:pos_inf, :neg_inf, :nan], do: true
+  def float_special?(_), do: false
 
   @doc """
   Scheme truthiness: only `{:bool, false}` is false; every other value is
@@ -210,6 +222,9 @@ defmodule Schooner.Value do
   because integers and floats are distinct terms.
   """
   @spec eqv?(t(), t()) :: boolean()
+  # IEEE-754: NaN is never equal to anything, including another NaN.
+  def eqv?({:float_special, :nan}, _), do: false
+  def eqv?(_, {:float_special, :nan}), do: false
   def eqv?(a, b), do: a === b
 
   @doc """
@@ -217,6 +232,9 @@ defmodule Schooner.Value do
   strings, and records. For everything else it falls through to `eqv?`.
   """
   @spec equal?(t(), t()) :: boolean()
+  # IEEE-754: NaN is never equal to anything, including another NaN.
+  def equal?({:float_special, :nan}, _), do: false
+  def equal?(_, {:float_special, :nan}), do: false
   def equal?(a, a), do: true
   def equal?({:pair, a1, b1}, {:pair, a2, b2}), do: equal?(a1, a2) and equal?(b1, b2)
   def equal?({:vector, t1}, {:vector, t2}), do: equal_tuples?(t1, t2)
@@ -278,6 +296,9 @@ defmodule Schooner.Value do
   defp render({:closure, _, _, _, name}, _), do: render_closure(name)
   defp render({:primitive, name, _, _}, _), do: ["#<primitive ", name, ">"]
   defp render({:record, type_id, _}, _), do: ["#<record ", inspect(type_id), ">"]
+  defp render({:float_special, :pos_inf}, _), do: "+inf.0"
+  defp render({:float_special, :neg_inf}, _), do: "-inf.0"
+  defp render({:float_special, :nan}, _), do: "+nan.0"
   defp render(n, _) when is_integer(n), do: Integer.to_string(n)
   defp render(n, _) when is_float(n), do: render_float(n)
 

--- a/test/schooner/primitives/base_test.exs
+++ b/test/schooner/primitives/base_test.exs
@@ -99,8 +99,8 @@ defmodule Schooner.Primitives.BaseTest do
       assert Value.write(run("(* -1.0 0.0)")) =~ "0"
     end
 
-    test "(/ 1.0 0.0) raises division_by_zero (BEAM does not produce :inf)" do
-      assert_raise PError, fn -> run("(/ 1.0 0.0)") end
+    test "(/ 1.0 0.0) yields +inf.0 (IEEE-754, closes #8)" do
+      assert run("(/ 1.0 0.0)") == {:float_special, :pos_inf}
     end
 
     test "rendered floats round-trip via re-evaluation" do
@@ -113,11 +113,7 @@ defmodule Schooner.Primitives.BaseTest do
       assert Value.write(run("0.5")) == "0.5"
     end
 
-    @tag :skip
     test "+inf.0 / -inf.0 / +nan.0 round-trip through write/read" do
-      # The lexer tokenises these forms but the term-decoder trick used to
-      # synthesise the float values is rejected by current ERTS. Until the
-      # lexer is updated, no value of these tags can flow through eval.
       assert Value.write(run("+inf.0")) == "+inf.0"
       assert Value.write(run("-inf.0")) == "-inf.0"
       assert Value.write(run("+nan.0")) == "+nan.0"
@@ -388,6 +384,262 @@ defmodule Schooner.Primitives.BaseTest do
     test "(gcd) is 0; (lcm) is 1" do
       assert run("(gcd)") === 0
       assert run("(lcm)") === 1
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Non-finite floats — arithmetic propagation
+  # ---------------------------------------------------------------------------
+
+  describe "non-finite arithmetic propagation" do
+    @pos_inf {:float_special, :pos_inf}
+    @neg_inf {:float_special, :neg_inf}
+    @nan {:float_special, :nan}
+
+    test "NaN propagates through +, -, *, /" do
+      assert run("(+ +nan.0 1)") == @nan
+      assert run("(+ 1 +nan.0)") == @nan
+      assert run("(- +nan.0 1)") == @nan
+      assert run("(- 1 +nan.0)") == @nan
+      assert run("(* +nan.0 2.0)") == @nan
+      assert run("(/ +nan.0 2)") == @nan
+      assert run("(/ 2 +nan.0)") == @nan
+    end
+
+    test "(+ +inf.0 -inf.0) is NaN" do
+      assert run("(+ +inf.0 -inf.0)") == @nan
+      assert run("(+ -inf.0 +inf.0)") == @nan
+      assert run("(- +inf.0 +inf.0)") == @nan
+    end
+
+    test "infinity + finite preserves the infinity" do
+      assert run("(+ +inf.0 1000)") == @pos_inf
+      assert run("(+ -inf.0 1000)") == @neg_inf
+      assert run("(- +inf.0 1000)") == @pos_inf
+    end
+
+    test "(* +inf.0 0) and (* +inf.0 0.0) are NaN" do
+      assert run("(* +inf.0 0)") == @nan
+      assert run("(* +inf.0 0.0)") == @nan
+      assert run("(* 0 -inf.0)") == @nan
+    end
+
+    test "(* +inf.0 +inf.0) is +inf.0; (* +inf.0 -inf.0) is -inf.0" do
+      assert run("(* +inf.0 +inf.0)") == @pos_inf
+      assert run("(* -inf.0 -inf.0)") == @pos_inf
+      assert run("(* +inf.0 -inf.0)") == @neg_inf
+    end
+
+    test "infinity times finite — sign is product of signs" do
+      assert run("(* +inf.0 2)") == @pos_inf
+      assert run("(* +inf.0 -2)") == @neg_inf
+      assert run("(* -inf.0 -2.0)") == @pos_inf
+    end
+
+    test "unary minus negates an infinity, leaves NaN" do
+      assert run("(- +inf.0)") == @neg_inf
+      assert run("(- -inf.0)") == @pos_inf
+      assert run("(- +nan.0)") == @nan
+    end
+
+    test "abs of specials" do
+      assert run("(abs +inf.0)") == @pos_inf
+      assert run("(abs -inf.0)") == @pos_inf
+      assert run("(abs +nan.0)") == @nan
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Non-finite floats — division by zero
+  # ---------------------------------------------------------------------------
+
+  describe "non-finite division" do
+    @pos_inf {:float_special, :pos_inf}
+    @neg_inf {:float_special, :neg_inf}
+    @nan {:float_special, :nan}
+
+    test "exact integer divisor of zero still raises (r7rs ticket 367)" do
+      e = assert_raise PError, fn -> run("(/ 1 0)") end
+      assert e.reason == {:division_by_zero, "/"}
+    end
+
+    test "finite float over +0.0 yields signed infinity" do
+      assert run("(/ 1.0 0.0)") == @pos_inf
+      assert run("(/ -1.0 0.0)") == @neg_inf
+      assert run("(/ 1 0.0)") == @pos_inf
+    end
+
+    test "finite float over -0.0 flips the sign" do
+      assert run("(/ 1.0 -0.0)") == @neg_inf
+      assert run("(/ -1.0 -0.0)") == @pos_inf
+    end
+
+    test "(/ 0.0 0.0) is NaN" do
+      assert run("(/ 0.0 0.0)") == @nan
+      assert run("(/ -0.0 0.0)") == @nan
+    end
+
+    test "(/ +inf.0 +inf.0) and other inf/inf forms are NaN" do
+      assert run("(/ +inf.0 +inf.0)") == @nan
+      assert run("(/ +inf.0 -inf.0)") == @nan
+      assert run("(/ -inf.0 -inf.0)") == @nan
+    end
+
+    test "finite over infinity is 0.0" do
+      assert run("(/ 1.0 +inf.0)") === 0.0
+      assert run("(/ 5 -inf.0)") === 0.0
+    end
+
+    test "infinity over finite preserves sign" do
+      assert run("(/ +inf.0 2)") == @pos_inf
+      assert run("(/ +inf.0 -2)") == @neg_inf
+      assert run("(/ -inf.0 -2.0)") == @pos_inf
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Non-finite floats — comparison
+  # ---------------------------------------------------------------------------
+
+  describe "non-finite comparison" do
+    test "any comparison involving NaN is #f (IEEE-754 unordered)" do
+      assert run("(< +nan.0 1)") == Value.bool(false)
+      assert run("(< 1 +nan.0)") == Value.bool(false)
+      assert run("(> +nan.0 1)") == Value.bool(false)
+      assert run("(<= +nan.0 +inf.0)") == Value.bool(false)
+      assert run("(>= +nan.0 +nan.0)") == Value.bool(false)
+      assert run("(= +nan.0 +nan.0)") == Value.bool(false)
+      assert run("(= +nan.0 1)") == Value.bool(false)
+    end
+
+    test "+inf.0 is greater than every finite real" do
+      assert run("(> +inf.0 1)") == Value.bool(true)
+      assert run("(> +inf.0 1.0)") == Value.bool(true)
+      assert run("(> +inf.0 1000000000000000000000)") == Value.bool(true)
+      assert run("(< 1 +inf.0)") == Value.bool(true)
+    end
+
+    test "-inf.0 is less than every finite real" do
+      assert run("(< -inf.0 -1)") == Value.bool(true)
+      assert run("(< -inf.0 -1000000000000000000000)") == Value.bool(true)
+      assert run("(> -1 -inf.0)") == Value.bool(true)
+    end
+
+    test "= between like specials (other than NaN) holds" do
+      assert run("(= +inf.0 +inf.0)") == Value.bool(true)
+      assert run("(= -inf.0 -inf.0)") == Value.bool(true)
+      assert run("(= +inf.0 -inf.0)") == Value.bool(false)
+    end
+
+    test "<= and >= follow ordinary rules between specials" do
+      assert run("(< -inf.0 +inf.0)") == Value.bool(true)
+      assert run("(<= -inf.0 +inf.0)") == Value.bool(true)
+      assert run("(<= +inf.0 +inf.0)") == Value.bool(true)
+      assert run("(>= +inf.0 1)") == Value.bool(true)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Non-finite floats — predicates
+  # ---------------------------------------------------------------------------
+
+  describe "non-finite predicates" do
+    test "type predicates classify specials as inexact, non-integer numbers" do
+      for lit <- ["+inf.0", "-inf.0", "+nan.0"] do
+        assert run("(number? #{lit})") == Value.bool(true)
+        assert run("(inexact? #{lit})") == Value.bool(true)
+        assert run("(exact? #{lit})") == Value.bool(false)
+        assert run("(integer? #{lit})") == Value.bool(false)
+      end
+    end
+
+    test "zero? is false for all specials" do
+      assert run("(zero? +inf.0)") == Value.bool(false)
+      assert run("(zero? -inf.0)") == Value.bool(false)
+      assert run("(zero? +nan.0)") == Value.bool(false)
+    end
+
+    test "positive?/negative? per spec" do
+      assert run("(positive? +inf.0)") == Value.bool(true)
+      assert run("(positive? -inf.0)") == Value.bool(false)
+      assert run("(positive? +nan.0)") == Value.bool(false)
+      assert run("(negative? -inf.0)") == Value.bool(true)
+      assert run("(negative? +inf.0)") == Value.bool(false)
+      assert run("(negative? +nan.0)") == Value.bool(false)
+    end
+
+    test "odd?/even? raise — specials are not integers" do
+      for lit <- ["+inf.0", "-inf.0", "+nan.0"] do
+        assert_raise PError, fn -> run("(odd? #{lit})") end
+        assert_raise PError, fn -> run("(even? #{lit})") end
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Non-finite floats — min/max/expt/sqrt/exact-inexact
+  # ---------------------------------------------------------------------------
+
+  describe "non-finite min/max/expt/sqrt/exact-inexact" do
+    @pos_inf {:float_special, :pos_inf}
+    @neg_inf {:float_special, :neg_inf}
+    @nan {:float_special, :nan}
+
+    test "min/max with NaN propagate NaN" do
+      assert run("(min +nan.0 1 2)") == @nan
+      assert run("(max 1 +nan.0 2)") == @nan
+    end
+
+    test "min/max with infinities" do
+      assert run("(max 1 2 +inf.0)") == @pos_inf
+      assert run("(min 1 2 -inf.0)") == @neg_inf
+      assert run("(min 1 +inf.0)") === 1.0
+      assert run("(max -inf.0 -1)") === -1.0
+    end
+
+    test "sqrt of specials" do
+      assert run("(sqrt +inf.0)") == @pos_inf
+      assert run("(sqrt -inf.0)") == @nan
+      assert run("(sqrt +nan.0)") == @nan
+    end
+
+    test "expt with infinities" do
+      assert run("(expt +inf.0 2)") == @pos_inf
+      assert run("(expt +inf.0 -2)") === 0.0
+      assert run("(expt 2 +inf.0)") == @pos_inf
+      assert run("(expt 0.5 +inf.0)") === 0.0
+      assert run("(expt 2 -inf.0)") === 0.0
+      assert run("(expt 0.5 -inf.0)") == @pos_inf
+    end
+
+    test "expt -inf.0 base preserves sign for odd integer exponents" do
+      assert run("(expt -inf.0 3)") == @neg_inf
+      assert run("(expt -inf.0 2)") == @pos_inf
+      assert run("(expt -inf.0 -3)") === 0.0
+    end
+
+    test "expt — anything to the 0 is 1.0; 1 to anything is 1.0" do
+      assert run("(expt +inf.0 0)") === 1.0
+      assert run("(expt +nan.0 0)") === 1.0
+      assert run("(expt 1 +inf.0)") === 1.0
+    end
+
+    test "expt with NaN propagates (except the 0 / 1 short-circuits)" do
+      assert run("(expt +nan.0 1)") == @nan
+      assert run("(expt 2 +nan.0)") == @nan
+    end
+
+    test "exact->inexact is identity on specials" do
+      assert run("(exact->inexact +inf.0)") == @pos_inf
+      assert run("(exact->inexact -inf.0)") == @neg_inf
+      assert run("(exact->inexact +nan.0)") == @nan
+    end
+
+    test "inexact->exact raises on specials — no exact form" do
+      for lit <- ["+inf.0", "-inf.0", "+nan.0"] do
+        e = assert_raise PError, fn -> run("(inexact->exact #{lit})") end
+        assert match?({:not_representable_exact, _}, e.reason)
+      end
     end
   end
 end

--- a/test/schooner/value_test.exs
+++ b/test/schooner/value_test.exs
@@ -235,4 +235,47 @@ defmodule Schooner.ValueTest do
       assert Value.display(Value.list([Value.string("hi"), Value.char(?!)])) == "(hi !)"
     end
   end
+
+  describe "non-finite float specials" do
+    @pos_inf {:float_special, :pos_inf}
+    @neg_inf {:float_special, :neg_inf}
+    @nan {:float_special, :nan}
+
+    test "type predicates classify specials" do
+      for v <- [@pos_inf, @neg_inf, @nan] do
+        assert Value.number?(v)
+        assert Value.inexact?(v)
+        refute Value.exact?(v)
+        refute Value.integer?(v)
+        assert Value.float_special?(v)
+      end
+
+      refute Value.float_special?(1.0)
+      refute Value.float_special?(1)
+    end
+
+    test "eqv? — like infinities are equal; NaN is never equal to anything" do
+      assert Value.eqv?(@pos_inf, @pos_inf)
+      assert Value.eqv?(@neg_inf, @neg_inf)
+      refute Value.eqv?(@pos_inf, @neg_inf)
+      refute Value.eqv?(@nan, @nan)
+      refute Value.eqv?(@nan, 1)
+      refute Value.eqv?(1, @nan)
+    end
+
+    test "equal? mirrors eqv? for specials, NaN included" do
+      assert Value.equal?(@pos_inf, @pos_inf)
+      refute Value.equal?(@pos_inf, @neg_inf)
+      refute Value.equal?(@nan, @nan)
+    end
+
+    test "write/display render the literal forms" do
+      assert Value.write(@pos_inf) == "+inf.0"
+      assert Value.write(@neg_inf) == "-inf.0"
+      assert Value.write(@nan) == "+nan.0"
+      assert Value.display(@pos_inf) == "+inf.0"
+      assert Value.display(@neg_inf) == "-inf.0"
+      assert Value.display(@nan) == "+nan.0"
+    end
+  end
 end


### PR DESCRIPTION
Closes #10. Supersedes #7 and #8 (closed as duplicates).

## Summary
- Introduces `{:float_special, :pos_inf | :neg_inf | :nan}` as a new value tag in `Schooner.Value`. Research from #7 confirmed every native BEAM path to a non-finite `float()` is hard-blocked on this OTP, so a tagged-value model is the only viable option.
- Lexer's `special_float/1` now returns the tagged values directly — no more hand-crafted IEEE-754 byte sequences fed into `:erlang.binary_to_term/1`.
- `Value` predicates and equality treat specials as inexact numbers: `eqv?`/`equal?` recognise like infinities as equal but `+nan.0` is never equal to anything (IEEE-754 NaN-never-equal-itself rule). `write` / `display` render the three literal forms.
- `Schooner.Primitives.Base` propagates specials through every numeric operation: NaN propagates universally; infinity arithmetic follows IEEE-754; `(/ a +0.0)` yields signed infinity (closes #8); `(/ 0.0 0.0)` is `+nan.0`; `(/ 1 0)` exact-integer-zero still raises per r7rs ticket 367; `(sqrt +inf.0)` is `+inf.0`, `(sqrt -inf.0)` and `(sqrt -1.0)` are `+nan.0`; comparisons against NaN return `#f` (the IEEE-754 "unordered" rule); `+inf.0 > x` and `-inf.0 < x` for every finite real `x`; `(inexact->exact <special>)` raises (no exact form).

## Test plan
`mix precommit` green: 17 properties, 255 tests, 0 failures, **0 skipped** (the previously-skipped `+inf.0` / `-inf.0` / `+nan.0` round-trip is now passing).

- [x] **Value layer** (`test/schooner/value_test.exs`): predicates, `eqv?`/`equal?` (incl. NaN-never-equal-itself), `write` / `display`.
- [x] **Round-trip** (`test/schooner/primitives/base_test.exs`): unskipped — `Value.write(read("+inf.0")) == "+inf.0"` and the matching cases for `-inf.0` / `+nan.0`.
- [x] **Arithmetic propagation**: NaN propagation; `(+ +inf.0 -inf.0)`; `(* +inf.0 0)`; `(* +inf.0 +inf.0)`; `(* +inf.0 -inf.0)`; finite × infinity sign rules; unary minus; `abs`.
- [x] **Division**: integer-zero still raises; `finite/+0.0`; `finite/-0.0`; `0/0`; `inf/inf`; `finite/inf`; `inf/finite`.
- [x] **Comparison**: NaN unordered (every comparison returns `#f`); `+inf > finite`; `-inf < finite`; equality and ordering between specials.
- [x] **Predicates over specials**: `number?` / `inexact?` / `exact?` / `integer?`; `zero?`; `positive?` / `negative?`; `odd?` / `even?` raise.
- [x] **`min` / `max` / `expt` / `sqrt` / `exact↔inexact`**: NaN propagation through `min`/`max`; infinity short-circuits; `expt` IEEE-754 cases including odd-vs-even integer exponents over `-inf.0`; `sqrt` of `+inf.0` / `-inf.0`; `inexact->exact` on a special raises.

## Three Scheme-visible decisions filed for follow-up
- #11 — `(sqrt -1.0)` now returns `+nan.0` (was raise). IEEE-754-aligned; filed for audit.
- #12 — `(expt -1 +inf.0)` returns `+nan.0` but IEEE-754 mandates `1.0` at the `|base|=1` boundary. Real (low-priority) fix.
- #13 — `(expt +nan.0 0)` returns `1` (IEEE-754 \`pow(NaN, 0)\` rule). Filed for audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)