### PR TITLE
Phase 6: pair/list/vector/string/bytevector/symbol/cxr/char primitives

### DIFF
--- a/lib/schooner.ex
+++ b/lib/schooner.ex
@@ -24,7 +24,12 @@ defmodule Schooner do
   Scheme out of the box.
   """
   @spec standard_env() :: Env.t()
-  def standard_env, do: Env.new() |> Primitives.Base.register_into()
+  def standard_env do
+    Env.new()
+    |> Primitives.Base.register_into()
+    |> Primitives.Cxr.register_into()
+    |> Primitives.Char.register_into()
+  end
 
   @doc """
   Read and evaluate `source` in a fresh standard environment. Returns

--- a/lib/schooner/primitive/error.ex
+++ b/lib/schooner/primitive/error.ex
@@ -40,4 +40,32 @@ defmodule Schooner.Primitive.Error do
   defp format({:not_representable_exact, value}) do
     "`#{inspect(value)}` is not representable as an exact integer"
   end
+
+  defp format({:index_out_of_range, op, index, length}) do
+    "index #{index} out of range in `#{op}` (length #{length})"
+  end
+
+  defp format({:improper_list, op, value}) do
+    "`#{op}` requires a proper list, got #{inspect(value)}"
+  end
+
+  defp format({:length_mismatch, op}) do
+    "`#{op}` requires arguments of equal length"
+  end
+
+  defp format({:invalid_utf8, op}) do
+    "`#{op}` received bytes that are not valid UTF-8"
+  end
+
+  defp format({:codepoint_out_of_range, op, cp}) do
+    "`#{op}`: #{inspect(cp)} is not a Unicode scalar value"
+  end
+
+  defp format({:byte_out_of_range, op, b}) do
+    "`#{op}`: #{inspect(b)} is not a byte (0..255)"
+  end
+
+  defp format({:invalid_size, op, k}) do
+    "`#{op}`: #{inspect(k)} is not a valid size"
+  end
 end

--- a/lib/schooner/primitives/base.ex
+++ b/lib/schooner/primitives/base.ex
@@ -15,6 +15,7 @@ defmodule Schooner.Primitives.Base do
   """
 
   alias Schooner.Env
+  alias Schooner.Eval
   alias Schooner.Primitive.Error
   alias Schooner.Value
 
@@ -37,7 +38,15 @@ defmodule Schooner.Primitives.Base do
   end
 
   defp specs do
-    arithmetic_specs() ++ comparison_specs() ++ predicate_specs() ++ boolean_specs()
+    arithmetic_specs() ++
+      comparison_specs() ++
+      predicate_specs() ++
+      boolean_specs() ++
+      pair_specs() ++
+      vector_specs() ++
+      bytevector_specs() ++
+      string_specs() ++
+      symbol_specs()
   end
 
   # ---------------------------------------------------------------------------
@@ -514,13 +523,17 @@ defmodule Schooner.Primitives.Base do
       {"boolean?", 1, &boolean_p/1},
       {"pair?", 1, &pair_p/1},
       {"null?", 1, &null_p/1},
+      {"list?", 1, &list_p/1},
       {"symbol?", 1, &symbol_p/1},
       {"string?", 1, &string_p/1},
       {"char?", 1, &char_p/1},
       {"vector?", 1, &vector_p/1},
       {"bytevector?", 1, &bytevector_p/1},
       {"procedure?", 1, &procedure_p/1},
-      {"eof-object?", 1, &eof_p/1}
+      {"eof-object?", 1, &eof_p/1},
+      {"eq?", 2, &eq_p/1},
+      {"eqv?", 2, &eqv_p/1},
+      {"equal?", 2, &equal_p/1}
     ]
   end
 
@@ -531,6 +544,7 @@ defmodule Schooner.Primitives.Base do
   defp boolean_p([v]), do: Value.bool(Value.boolean?(v))
   defp pair_p([v]), do: Value.bool(Value.pair?(v))
   defp null_p([v]), do: Value.bool(Value.null?(v))
+  defp list_p([v]), do: Value.bool(Value.list?(v))
   defp symbol_p([v]), do: Value.bool(Value.symbol?(v))
   defp string_p([v]), do: Value.bool(Value.string?(v))
   defp char_p([v]), do: Value.bool(Value.char?(v))
@@ -538,6 +552,10 @@ defmodule Schooner.Primitives.Base do
   defp bytevector_p([v]), do: Value.bool(Value.bytevector?(v))
   defp procedure_p([v]), do: Value.bool(Value.procedure?(v))
   defp eof_p([v]), do: Value.bool(Value.eof?(v))
+
+  defp eq_p([a, b]), do: Value.bool(Value.eq?(a, b))
+  defp eqv_p([a, b]), do: Value.bool(Value.eqv?(a, b))
+  defp equal_p([a, b]), do: Value.bool(Value.equal?(a, b))
 
   defp zero_p([n]) do
     require_number!("zero?", n)
@@ -593,6 +611,586 @@ defmodule Schooner.Primitives.Base do
   end
 
   # ---------------------------------------------------------------------------
+  # Pairs and lists
+  # ---------------------------------------------------------------------------
+
+  defp pair_specs do
+    [
+      {"cons", 2, &cons_/1},
+      {"car", 1, &car_/1},
+      {"cdr", 1, &cdr_/1},
+      {"list", {:at_least, 0}, &list_ctor/1},
+      {"list-copy", 1, &list_copy/1},
+      {"length", 1, &length_/1},
+      {"reverse", 1, &reverse_/1},
+      {"append", {:at_least, 0}, &append_/1},
+      {"list-tail", 2, &list_tail/1},
+      {"list-ref", 2, &list_ref/1},
+      {"member", 2, &member_/1},
+      {"memv", 2, &memv_/1},
+      {"memq", 2, &memq_/1},
+      {"assoc", 2, &assoc_/1},
+      {"assv", 2, &assv_/1},
+      {"assq", 2, &assq_/1},
+      {"map", {:at_least, 2}, &map_/1},
+      {"for-each", {:at_least, 2}, &for_each_/1}
+    ]
+  end
+
+  defp cons_([a, b]), do: Value.pair(a, b)
+
+  defp car_([{:pair, a, _}]), do: a
+  defp car_([other]), do: raise(Error, reason: {:type_error, "car", "pair", other})
+
+  defp cdr_([{:pair, _, b}]), do: b
+  defp cdr_([other]), do: raise(Error, reason: {:type_error, "cdr", "pair", other})
+
+  defp list_ctor(args), do: Value.list(args)
+
+  defp list_copy([list]) do
+    require_proper_list!("list-copy", list)
+    list
+  end
+
+  defp length_([list]) do
+    case proper_length(list, 0) do
+      {:ok, n} -> n
+      :error -> raise(Error, reason: {:improper_list, "length", list})
+    end
+  end
+
+  defp proper_length(:null, n), do: {:ok, n}
+  defp proper_length({:pair, _, t}, n), do: proper_length(t, n + 1)
+  defp proper_length(_, _), do: :error
+
+  defp reverse_([list]), do: do_reverse(list, :null)
+
+  defp do_reverse(:null, acc), do: acc
+  defp do_reverse({:pair, h, t}, acc), do: do_reverse(t, {:pair, h, acc})
+  defp do_reverse(other, _acc), do: raise(Error, reason: {:improper_list, "reverse", other})
+
+  # `(append a b c)` ⇒ all but the last must be proper lists; the last is
+  # spliced in as-is, so it can be any value (including an improper tail).
+  defp append_([]), do: :null
+  defp append_([only]), do: only
+
+  defp append_(args) do
+    {fronts, [last]} = Enum.split(args, length(args) - 1)
+    Enum.each(fronts, &require_proper_list!("append", &1))
+    do_append(fronts, last)
+  end
+
+  defp do_append([], tail), do: tail
+  defp do_append([list | rest], tail), do: append_pair(list, do_append(rest, tail))
+
+  defp append_pair(:null, tail), do: tail
+  defp append_pair({:pair, h, t}, tail), do: {:pair, h, append_pair(t, tail)}
+
+  defp list_tail([list, k]) do
+    require_integer!("list-tail", k)
+    if k < 0, do: raise(Error, reason: {:index_out_of_range, "list-tail", k, "n/a"})
+    do_list_tail(list, trunc_int(k), 0)
+  end
+
+  defp do_list_tail(rest, 0, _consumed), do: rest
+
+  defp do_list_tail({:pair, _, t}, k, consumed),
+    do: do_list_tail(t, k - 1, consumed + 1)
+
+  defp do_list_tail(_other, k, consumed) do
+    raise(Error, reason: {:index_out_of_range, "list-tail", consumed + k, consumed})
+  end
+
+  defp list_ref([list, k]) do
+    require_integer!("list-ref", k)
+    if k < 0, do: raise(Error, reason: {:index_out_of_range, "list-ref", k, "n/a"})
+    do_list_ref(list, trunc_int(k), 0)
+  end
+
+  defp do_list_ref({:pair, h, _}, 0, _consumed), do: h
+
+  defp do_list_ref({:pair, _, t}, k, consumed),
+    do: do_list_ref(t, k - 1, consumed + 1)
+
+  defp do_list_ref(_other, k, consumed) do
+    raise(Error, reason: {:index_out_of_range, "list-ref", consumed + k, consumed})
+  end
+
+  defp member_([obj, list]), do: do_member("member", obj, list, &Value.equal?/2)
+  defp memv_([obj, list]), do: do_member("memv", obj, list, &Value.eqv?/2)
+  defp memq_([obj, list]), do: do_member("memq", obj, list, &Value.eq?/2)
+
+  defp do_member(_op, _obj, :null, _eq), do: Value.bool(false)
+
+  defp do_member(op, obj, {:pair, h, t} = pair, eq) do
+    if eq.(obj, h), do: pair, else: do_member(op, obj, t, eq)
+  end
+
+  defp do_member(op, _obj, other, _eq) do
+    raise(Error, reason: {:improper_list, op, other})
+  end
+
+  defp assoc_([obj, list]), do: do_assoc("assoc", obj, list, &Value.equal?/2)
+  defp assv_([obj, list]), do: do_assoc("assv", obj, list, &Value.eqv?/2)
+  defp assq_([obj, list]), do: do_assoc("assq", obj, list, &Value.eq?/2)
+
+  defp do_assoc(_op, _obj, :null, _eq), do: Value.bool(false)
+
+  defp do_assoc(op, obj, {:pair, {:pair, k, _} = entry, rest}, eq) do
+    if eq.(obj, k), do: entry, else: do_assoc(op, obj, rest, eq)
+  end
+
+  defp do_assoc(op, _obj, {:pair, other, _}, _eq) do
+    raise(Error, reason: {:type_error, op, "pair as alist entry", other})
+  end
+
+  defp do_assoc(op, _obj, other, _eq) do
+    raise(Error, reason: {:improper_list, op, other})
+  end
+
+  defp map_([proc | lists]) do
+    require_procedure!("map", proc)
+    Enum.each(lists, &require_proper_list!("map", &1))
+    Value.list(do_zip_apply(proc, lists, []))
+  end
+
+  defp for_each_([proc | lists]) do
+    require_procedure!("for-each", proc)
+    Enum.each(lists, &require_proper_list!("for-each", &1))
+    _ = do_zip_apply(proc, lists, [])
+    :unspecified
+  end
+
+  defp do_zip_apply(proc, lists, acc) do
+    case split_heads_tails(lists, [], []) do
+      :exhausted -> Enum.reverse(acc)
+      {heads, tails} -> do_zip_apply(proc, tails, [Eval.apply_proc(proc, heads) | acc])
+    end
+  end
+
+  defp split_heads_tails([], hs, ts), do: {Enum.reverse(hs), Enum.reverse(ts)}
+  defp split_heads_tails([:null | _], _hs, _ts), do: :exhausted
+
+  defp split_heads_tails([{:pair, h, t} | r], hs, ts),
+    do: split_heads_tails(r, [h | hs], [t | ts])
+
+  # ---------------------------------------------------------------------------
+  # Vectors
+  # ---------------------------------------------------------------------------
+
+  defp vector_specs do
+    [
+      {"vector", {:at_least, 0}, &vector_ctor/1},
+      {"make-vector", {:at_least, 1}, &make_vector/1},
+      {"vector-length", 1, &vector_length/1},
+      {"vector-ref", 2, &vector_ref/1},
+      {"vector->list", {:at_least, 1}, &vector_to_list/1},
+      {"list->vector", 1, &list_to_vector/1},
+      {"vector-map", {:at_least, 2}, &vector_map/1},
+      {"vector-for-each", {:at_least, 2}, &vector_for_each/1},
+      {"vector-copy", {:at_least, 1}, &vector_copy/1},
+      {"vector-append", {:at_least, 0}, &vector_append/1}
+    ]
+  end
+
+  defp vector_ctor(args), do: Value.vector(args)
+
+  defp make_vector([k]), do: make_vector([k, :unspecified])
+
+  defp make_vector([k, fill]) do
+    n = require_size!("make-vector", k)
+    Value.vector(List.duplicate(fill, n))
+  end
+
+  defp make_vector([_, _ | _]) do
+    raise(Error, reason: {:type_error, "make-vector", "1 or 2 arguments", :too_many})
+  end
+
+  defp vector_length([{:vector, t}]), do: tuple_size(t)
+
+  defp vector_length([other]),
+    do: raise(Error, reason: {:type_error, "vector-length", "vector", other})
+
+  defp vector_ref([{:vector, t}, k]) do
+    i = require_index!("vector-ref", k, tuple_size(t))
+    elem(t, i)
+  end
+
+  defp vector_ref([other, _]),
+    do: raise(Error, reason: {:type_error, "vector-ref", "vector", other})
+
+  defp vector_to_list([{:vector, t}]) do
+    Value.list(Tuple.to_list(t))
+  end
+
+  defp vector_to_list([{:vector, t}, start]) do
+    n = tuple_size(t)
+    s = require_bound!("vector->list", start, 0, n)
+    Value.list(Enum.map(s..(n - 1)//1, &elem(t, &1)))
+  end
+
+  defp vector_to_list([{:vector, t}, start, end_]) do
+    n = tuple_size(t)
+    s = require_bound!("vector->list", start, 0, n)
+    e = require_bound!("vector->list", end_, s, n)
+    Value.list(Enum.map(s..(e - 1)//1, &elem(t, &1)))
+  end
+
+  defp vector_to_list([other | _]),
+    do: raise(Error, reason: {:type_error, "vector->list", "vector", other})
+
+  defp list_to_vector([list]) do
+    Value.vector(scheme_list_to_elixir!("list->vector", list))
+  end
+
+  defp vector_map([proc | vectors]) do
+    require_procedure!("vector-map", proc)
+    Enum.each(vectors, &require_vector!("vector-map", &1))
+    tuples = Enum.map(vectors, fn {:vector, t} -> t end)
+    n = tuples |> Enum.map(&tuple_size/1) |> Enum.min()
+
+    results =
+      Enum.map(0..(n - 1)//1, fn i ->
+        Eval.apply_proc(proc, Enum.map(tuples, &elem(&1, i)))
+      end)
+
+    Value.vector(results)
+  end
+
+  defp vector_for_each([proc | vectors]) do
+    require_procedure!("vector-for-each", proc)
+    Enum.each(vectors, &require_vector!("vector-for-each", &1))
+    tuples = Enum.map(vectors, fn {:vector, t} -> t end)
+    n = tuples |> Enum.map(&tuple_size/1) |> Enum.min()
+
+    Enum.each(0..(n - 1)//1, fn i ->
+      Eval.apply_proc(proc, Enum.map(tuples, &elem(&1, i)))
+    end)
+
+    :unspecified
+  end
+
+  defp vector_copy([v]), do: vector_copy_range(v, nil, nil)
+  defp vector_copy([v, start]), do: vector_copy_range(v, start, nil)
+  defp vector_copy([v, start, end_]), do: vector_copy_range(v, start, end_)
+
+  defp vector_copy([_, _, _, _ | _]) do
+    raise(Error, reason: {:type_error, "vector-copy", "1 to 3 arguments", :too_many})
+  end
+
+  defp vector_copy_range({:vector, t}, start, end_) do
+    n = tuple_size(t)
+    s = if start == nil, do: 0, else: require_bound!("vector-copy", start, 0, n)
+    e = if end_ == nil, do: n, else: require_bound!("vector-copy", end_, s, n)
+    Value.vector(Enum.map(s..(e - 1)//1, &elem(t, &1)))
+  end
+
+  defp vector_copy_range(other, _, _),
+    do: raise(Error, reason: {:type_error, "vector-copy", "vector", other})
+
+  defp vector_append(args) do
+    Enum.each(args, &require_vector!("vector-append", &1))
+
+    items =
+      args
+      |> Enum.flat_map(fn {:vector, t} -> Tuple.to_list(t) end)
+
+    Value.vector(items)
+  end
+
+  # ---------------------------------------------------------------------------
+  # Bytevectors
+  # ---------------------------------------------------------------------------
+
+  defp bytevector_specs do
+    [
+      {"bytevector", {:at_least, 0}, &bytevector_ctor/1},
+      {"make-bytevector", {:at_least, 1}, &make_bytevector/1},
+      {"bytevector-length", 1, &bytevector_length/1},
+      {"bytevector-u8-ref", 2, &bytevector_u8_ref/1},
+      {"bytevector-copy", {:at_least, 1}, &bytevector_copy/1},
+      {"bytevector-append", {:at_least, 0}, &bytevector_append/1},
+      {"utf8->string", {:at_least, 1}, &utf8_to_string/1},
+      {"string->utf8", {:at_least, 1}, &string_to_utf8/1}
+    ]
+  end
+
+  defp bytevector_ctor(args) do
+    bytes = Enum.map(args, &require_byte!("bytevector", &1))
+    Value.bytevector(bytes)
+  end
+
+  defp make_bytevector([k]), do: make_bytevector([k, 0])
+
+  defp make_bytevector([k, fill]) do
+    n = require_size!("make-bytevector", k)
+    b = require_byte!("make-bytevector", fill)
+    Value.bytevector(:binary.copy(<<b>>, n))
+  end
+
+  defp make_bytevector([_, _ | _]) do
+    raise(Error, reason: {:type_error, "make-bytevector", "1 or 2 arguments", :too_many})
+  end
+
+  defp bytevector_length([{:bytevector, b}]), do: byte_size(b)
+
+  defp bytevector_length([other]),
+    do: raise(Error, reason: {:type_error, "bytevector-length", "bytevector", other})
+
+  defp bytevector_u8_ref([{:bytevector, b}, k]) do
+    i = require_index!("bytevector-u8-ref", k, byte_size(b))
+    :binary.at(b, i)
+  end
+
+  defp bytevector_u8_ref([other, _]),
+    do: raise(Error, reason: {:type_error, "bytevector-u8-ref", "bytevector", other})
+
+  defp bytevector_copy([v]), do: bytevector_copy_range(v, nil, nil)
+  defp bytevector_copy([v, start]), do: bytevector_copy_range(v, start, nil)
+  defp bytevector_copy([v, start, end_]), do: bytevector_copy_range(v, start, end_)
+
+  defp bytevector_copy([_, _, _, _ | _]) do
+    raise(Error, reason: {:type_error, "bytevector-copy", "1 to 3 arguments", :too_many})
+  end
+
+  defp bytevector_copy_range({:bytevector, b}, start, end_) do
+    n = byte_size(b)
+    s = if start == nil, do: 0, else: require_bound!("bytevector-copy", start, 0, n)
+    e = if end_ == nil, do: n, else: require_bound!("bytevector-copy", end_, s, n)
+    Value.bytevector(:binary.part(b, s, e - s))
+  end
+
+  defp bytevector_copy_range(other, _, _),
+    do: raise(Error, reason: {:type_error, "bytevector-copy", "bytevector", other})
+
+  defp bytevector_append(args) do
+    Enum.each(args, &require_bytevector!("bytevector-append", &1))
+    bins = Enum.map(args, fn {:bytevector, b} -> b end)
+    Value.bytevector(IO.iodata_to_binary(bins))
+  end
+
+  defp utf8_to_string([v]), do: utf8_to_string_range(v, nil, nil)
+  defp utf8_to_string([v, start]), do: utf8_to_string_range(v, start, nil)
+  defp utf8_to_string([v, start, end_]), do: utf8_to_string_range(v, start, end_)
+
+  defp utf8_to_string([_, _, _, _ | _]) do
+    raise(Error, reason: {:type_error, "utf8->string", "1 to 3 arguments", :too_many})
+  end
+
+  defp utf8_to_string_range({:bytevector, b}, start, end_) do
+    n = byte_size(b)
+    s = if start == nil, do: 0, else: require_bound!("utf8->string", start, 0, n)
+    e = if end_ == nil, do: n, else: require_bound!("utf8->string", end_, s, n)
+    slice = :binary.part(b, s, e - s)
+
+    if String.valid?(slice),
+      do: Value.string(slice),
+      else: raise(Error, reason: {:invalid_utf8, "utf8->string"})
+  end
+
+  defp utf8_to_string_range(other, _, _),
+    do: raise(Error, reason: {:type_error, "utf8->string", "bytevector", other})
+
+  defp string_to_utf8([v]), do: string_to_utf8_range(v, nil, nil)
+  defp string_to_utf8([v, start]), do: string_to_utf8_range(v, start, nil)
+  defp string_to_utf8([v, start, end_]), do: string_to_utf8_range(v, start, end_)
+
+  defp string_to_utf8([_, _, _, _ | _]) do
+    raise(Error, reason: {:type_error, "string->utf8", "1 to 3 arguments", :too_many})
+  end
+
+  defp string_to_utf8_range({:string, s}, start, end_) do
+    n = string_codepoint_length(s)
+    si = if start == nil, do: 0, else: require_bound!("string->utf8", start, 0, n)
+    ei = if end_ == nil, do: n, else: require_bound!("string->utf8", end_, si, n)
+    Value.bytevector(string_codepoint_slice(s, si, ei))
+  end
+
+  defp string_to_utf8_range(other, _, _),
+    do: raise(Error, reason: {:type_error, "string->utf8", "string", other})
+
+  # ---------------------------------------------------------------------------
+  # Strings
+  # ---------------------------------------------------------------------------
+
+  defp string_specs do
+    [
+      {"string", {:at_least, 0}, &string_ctor/1},
+      {"make-string", {:at_least, 1}, &make_string/1},
+      {"string-length", 1, &string_length/1},
+      {"string-ref", 2, &string_ref/1},
+      {"string-append", {:at_least, 0}, &string_append/1},
+      {"substring", 3, &substring_/1},
+      {"string=?", {:at_least, 2}, &string_eq/1},
+      {"string<?", {:at_least, 2}, &string_lt/1},
+      {"string<=?", {:at_least, 2}, &string_le/1},
+      {"string>?", {:at_least, 2}, &string_gt/1},
+      {"string>=?", {:at_least, 2}, &string_ge/1},
+      {"string->list", {:at_least, 1}, &string_to_list/1},
+      {"list->string", 1, &list_to_string/1},
+      {"string-upcase", 1, &string_upcase/1},
+      {"string-downcase", 1, &string_downcase/1},
+      {"string-copy", {:at_least, 1}, &string_copy/1}
+    ]
+  end
+
+  defp string_ctor(args) do
+    bytes =
+      args
+      |> Enum.map(&require_char!("string", &1))
+      |> Enum.map(&codepoint_to_utf8/1)
+
+    Value.string(IO.iodata_to_binary(bytes))
+  end
+
+  defp make_string([k]), do: make_string([k, Value.char(?\s)])
+
+  defp make_string([k, char]) do
+    n = require_size!("make-string", k)
+    cp = require_char!("make-string", char)
+    Value.string(:binary.copy(codepoint_to_utf8(cp), n))
+  end
+
+  defp make_string([_, _ | _]) do
+    raise(Error, reason: {:type_error, "make-string", "1 or 2 arguments", :too_many})
+  end
+
+  defp string_length([{:string, s}]), do: string_codepoint_length(s)
+
+  defp string_length([other]),
+    do: raise(Error, reason: {:type_error, "string-length", "string", other})
+
+  defp string_ref([{:string, s}, k]) do
+    n = string_codepoint_length(s)
+    i = require_index!("string-ref", k, n)
+    Value.char(codepoint_at!(s, i, "string-ref"))
+  end
+
+  defp string_ref([other, _]),
+    do: raise(Error, reason: {:type_error, "string-ref", "string", other})
+
+  defp string_append(args) do
+    Enum.each(args, &require_string!("string-append", &1))
+    bins = Enum.map(args, fn {:string, s} -> s end)
+    Value.string(IO.iodata_to_binary(bins))
+  end
+
+  defp substring_([{:string, s}, start, end_]) do
+    n = string_codepoint_length(s)
+    si = require_bound!("substring", start, 0, n)
+    ei = require_bound!("substring", end_, si, n)
+    Value.string(string_codepoint_slice(s, si, ei))
+  end
+
+  defp substring_([other, _, _]),
+    do: raise(Error, reason: {:type_error, "substring", "string", other})
+
+  defp string_eq(args), do: variadic_string_cmp("string=?", args, &(&1 == &2))
+  defp string_lt(args), do: variadic_string_cmp("string<?", args, &(&1 < &2))
+  defp string_le(args), do: variadic_string_cmp("string<=?", args, &(&1 <= &2))
+  defp string_gt(args), do: variadic_string_cmp("string>?", args, &(&1 > &2))
+  defp string_ge(args), do: variadic_string_cmp("string>=?", args, &(&1 >= &2))
+
+  defp variadic_string_cmp(op, [first | rest] = args, pair) do
+    Enum.each(args, &require_string!(op, &1))
+    Value.bool(check_string_pairs(rest, first, pair))
+  end
+
+  defp check_string_pairs([], _prev, _pair), do: true
+
+  defp check_string_pairs([{:string, s} = next | rest], {:string, prev}, pair) do
+    if pair.(prev, s), do: check_string_pairs(rest, next, pair), else: false
+  end
+
+  defp string_to_list([v]), do: string_to_list_range(v, nil, nil)
+  defp string_to_list([v, start]), do: string_to_list_range(v, start, nil)
+  defp string_to_list([v, start, end_]), do: string_to_list_range(v, start, end_)
+
+  defp string_to_list([_, _, _, _ | _]) do
+    raise(Error, reason: {:type_error, "string->list", "1 to 3 arguments", :too_many})
+  end
+
+  defp string_to_list_range({:string, s}, start, end_) do
+    n = string_codepoint_length(s)
+    si = if start == nil, do: 0, else: require_bound!("string->list", start, 0, n)
+    ei = if end_ == nil, do: n, else: require_bound!("string->list", end_, si, n)
+    sliced = string_codepoint_codepoints(s, si, ei)
+    Value.list(Enum.map(sliced, &Value.char/1))
+  end
+
+  defp string_to_list_range(other, _, _),
+    do: raise(Error, reason: {:type_error, "string->list", "string", other})
+
+  defp list_to_string([list]) do
+    bytes =
+      "list->string"
+      |> scheme_list_to_elixir!(list)
+      |> Enum.map(&require_char!("list->string", &1))
+      |> Enum.map(&codepoint_to_utf8/1)
+
+    Value.string(IO.iodata_to_binary(bytes))
+  end
+
+  defp string_upcase([{:string, s}]), do: Value.string(String.upcase(s, :default))
+
+  defp string_upcase([other]),
+    do: raise(Error, reason: {:type_error, "string-upcase", "string", other})
+
+  defp string_downcase([{:string, s}]), do: Value.string(String.downcase(s, :default))
+
+  defp string_downcase([other]),
+    do: raise(Error, reason: {:type_error, "string-downcase", "string", other})
+
+  defp string_copy([v]), do: string_copy_range(v, nil, nil)
+  defp string_copy([v, start]), do: string_copy_range(v, start, nil)
+  defp string_copy([v, start, end_]), do: string_copy_range(v, start, end_)
+
+  defp string_copy([_, _, _, _ | _]) do
+    raise(Error, reason: {:type_error, "string-copy", "1 to 3 arguments", :too_many})
+  end
+
+  defp string_copy_range({:string, s}, start, end_) do
+    n = string_codepoint_length(s)
+    si = if start == nil, do: 0, else: require_bound!("string-copy", start, 0, n)
+    ei = if end_ == nil, do: n, else: require_bound!("string-copy", end_, si, n)
+    Value.string(string_codepoint_slice(s, si, ei))
+  end
+
+  defp string_copy_range(other, _, _),
+    do: raise(Error, reason: {:type_error, "string-copy", "string", other})
+
+  # ---------------------------------------------------------------------------
+  # Symbols
+  # ---------------------------------------------------------------------------
+
+  defp symbol_specs do
+    [
+      {"symbol=?", {:at_least, 2}, &symbol_eq/1},
+      {"symbol->string", 1, &symbol_to_string/1},
+      {"string->symbol", 1, &string_to_symbol/1}
+    ]
+  end
+
+  defp symbol_eq([first | _] = args) do
+    Enum.each(args, fn
+      {:sym, _} -> :ok
+      other -> raise(Error, reason: {:type_error, "symbol=?", "symbol", other})
+    end)
+
+    Value.bool(Enum.all?(args, &(&1 === first)))
+  end
+
+  defp symbol_to_string([{:sym, name}]), do: Value.string(name)
+
+  defp symbol_to_string([other]),
+    do: raise(Error, reason: {:type_error, "symbol->string", "symbol", other})
+
+  defp string_to_symbol([{:string, s}]), do: Value.symbol(s)
+
+  defp string_to_symbol([other]),
+    do: raise(Error, reason: {:type_error, "string->symbol", "string", other})
+
+  # ---------------------------------------------------------------------------
   # Helpers
   # ---------------------------------------------------------------------------
 
@@ -637,5 +1235,128 @@ defmodule Schooner.Primitives.Base do
     any_float? = Enum.any?(args, &is_float/1)
     ints = Enum.map(args, &trunc_int/1)
     {ints, any_float?}
+  end
+
+  # ---- Type-checks shared by phase 6 primitives ------------------------------
+
+  defp require_proper_list!(op, value) do
+    if Value.list?(value), do: :ok, else: raise(Error, reason: {:improper_list, op, value})
+  end
+
+  defp require_procedure!(op, v) do
+    if Value.procedure?(v), do: :ok, else: raise(Error, reason: {:type_error, op, "procedure", v})
+  end
+
+  defp require_vector!(_op, {:vector, _}), do: :ok
+
+  defp require_vector!(op, other),
+    do: raise(Error, reason: {:type_error, op, "vector", other})
+
+  defp require_bytevector!(_op, {:bytevector, _}), do: :ok
+
+  defp require_bytevector!(op, other),
+    do: raise(Error, reason: {:type_error, op, "bytevector", other})
+
+  defp require_string!(_op, {:string, _}), do: :ok
+
+  defp require_string!(op, other),
+    do: raise(Error, reason: {:type_error, op, "string", other})
+
+  defp require_char!(_op, {:char, cp}), do: cp
+
+  defp require_char!(op, other),
+    do: raise(Error, reason: {:type_error, op, "char", other})
+
+  defp require_byte!(_op, n) when is_integer(n) and n >= 0 and n <= 255, do: n
+
+  defp require_byte!(op, other),
+    do: raise(Error, reason: {:byte_out_of_range, op, other})
+
+  defp require_size!(op, k) do
+    require_integer!(op, k)
+    n = trunc_int(k)
+    if n < 0, do: raise(Error, reason: {:invalid_size, op, k})
+    n
+  end
+
+  defp require_index!(op, k, length) do
+    require_integer!(op, k)
+    i = trunc_int(k)
+
+    if i < 0 or i >= length do
+      raise(Error, reason: {:index_out_of_range, op, i, length})
+    end
+
+    i
+  end
+
+  defp require_bound!(op, k, lower, upper) do
+    require_integer!(op, k)
+    i = trunc_int(k)
+
+    if i < lower or i > upper do
+      raise(Error, reason: {:index_out_of_range, op, i, upper})
+    end
+
+    i
+  end
+
+  defp scheme_list_to_elixir!(op, list), do: do_scheme_list_to_elixir(op, list, [])
+  defp do_scheme_list_to_elixir(_op, :null, acc), do: Enum.reverse(acc)
+
+  defp do_scheme_list_to_elixir(op, {:pair, h, t}, acc),
+    do: do_scheme_list_to_elixir(op, t, [h | acc])
+
+  defp do_scheme_list_to_elixir(op, other, _acc),
+    do: raise(Error, reason: {:improper_list, op, other})
+
+  defp codepoint_to_utf8(cp) when is_integer(cp) and cp >= 0 and cp <= 0x10FFFF do
+    <<cp::utf8>>
+  rescue
+    ArgumentError ->
+      reraise Error, [reason: {:codepoint_out_of_range, "char", cp}], __STACKTRACE__
+  end
+
+  defp codepoint_to_utf8(cp),
+    do: raise(Error, reason: {:codepoint_out_of_range, "char", cp})
+
+  # Codepoint count of a UTF-8 binary. We do not use `String.length/1` since
+  # that returns *grapheme* count, whereas r7rs strings are sequences of
+  # Unicode scalars (codepoints).
+  defp string_codepoint_length(s), do: count_codepoints(s, 0)
+  defp count_codepoints(<<>>, n), do: n
+  defp count_codepoints(<<_::utf8, rest::binary>>, n), do: count_codepoints(rest, n + 1)
+
+  defp codepoint_at!(s, i, op) do
+    case codepoint_at(s, i) do
+      {:ok, cp} -> cp
+      :error -> raise(Error, reason: {:index_out_of_range, op, i, string_codepoint_length(s)})
+    end
+  end
+
+  defp codepoint_at(<<cp::utf8, _::binary>>, 0), do: {:ok, cp}
+  defp codepoint_at(<<_::utf8, rest::binary>>, n) when n > 0, do: codepoint_at(rest, n - 1)
+  defp codepoint_at(_, _), do: :error
+
+  defp string_codepoint_slice(s, start, stop) do
+    s
+    |> string_codepoint_codepoints(start, stop)
+    |> Enum.map(&<<&1::utf8>>)
+    |> IO.iodata_to_binary()
+  end
+
+  defp string_codepoint_codepoints(s, start, stop) do
+    do_codepoints_slice(s, 0, start, stop, [])
+  end
+
+  defp do_codepoints_slice(_s, i, _start, stop, acc) when i >= stop, do: Enum.reverse(acc)
+  defp do_codepoints_slice(<<>>, _i, _start, _stop, acc), do: Enum.reverse(acc)
+
+  defp do_codepoints_slice(<<cp::utf8, rest::binary>>, i, start, stop, acc) do
+    if i >= start do
+      do_codepoints_slice(rest, i + 1, start, stop, [cp | acc])
+    else
+      do_codepoints_slice(rest, i + 1, start, stop, acc)
+    end
   end
 end

--- a/lib/schooner/primitives/char.ex
+++ b/lib/schooner/primitives/char.ex
@@ -1,0 +1,192 @@
+defmodule Schooner.Primitives.Char do
+  @moduledoc """
+  The `(scheme char)` library: codepoint conversion, comparators (case
+  sensitive and case-insensitive), case mappings, and category
+  predicates.
+
+  Schooner characters are single Unicode scalar values stored as
+  `{:char, codepoint}`. Case mappings that would expand to multiple
+  codepoints (e.g. `ß` → `SS`) leave the original character unchanged
+  — char-level mappings preserve the one-codepoint shape, and the
+  longer mapping is reachable through the string ops.
+  """
+
+  alias Schooner.Env
+  alias Schooner.Primitive.Error
+  alias Schooner.Value
+
+  @alpha_re ~r/^\p{L}$/u
+  @numeric_re ~r/^\p{Nd}$/u
+  @upper_re ~r/^\p{Lu}$/u
+  @lower_re ~r/^\p{Ll}$/u
+  # r7rs whitespace = Unicode Z* + the ASCII control whitespace (HT, LF, VT, FF, CR).
+  @whitespace_re ~r/^[\p{Z}\t\n\v\f\r]$/u
+
+  @doc "Register every `(scheme char)` primitive on `env`."
+  @spec register_into(Env.t()) :: Env.t()
+  def register_into(%Env{} = env) do
+    Enum.reduce(specs(), env, fn {name, arity, fun}, acc ->
+      Env.define(acc, name, Value.primitive(name, arity, fun))
+    end)
+  end
+
+  defp specs do
+    [
+      {"char->integer", 1, &char_to_integer/1},
+      {"integer->char", 1, &integer_to_char/1},
+      {"char=?", {:at_least, 2}, &char_eq/1},
+      {"char<?", {:at_least, 2}, &char_lt/1},
+      {"char<=?", {:at_least, 2}, &char_le/1},
+      {"char>?", {:at_least, 2}, &char_gt/1},
+      {"char>=?", {:at_least, 2}, &char_ge/1},
+      {"char-ci=?", {:at_least, 2}, &char_ci_eq/1},
+      {"char-ci<?", {:at_least, 2}, &char_ci_lt/1},
+      {"char-ci<=?", {:at_least, 2}, &char_ci_le/1},
+      {"char-ci>?", {:at_least, 2}, &char_ci_gt/1},
+      {"char-ci>=?", {:at_least, 2}, &char_ci_ge/1},
+      {"char-upcase", 1, &char_upcase/1},
+      {"char-downcase", 1, &char_downcase/1},
+      {"char-foldcase", 1, &char_foldcase/1},
+      {"char-alphabetic?", 1, &char_alphabetic_p/1},
+      {"char-numeric?", 1, &char_numeric_p/1},
+      {"char-whitespace?", 1, &char_whitespace_p/1},
+      {"char-upper-case?", 1, &char_upper_case_p/1},
+      {"char-lower-case?", 1, &char_lower_case_p/1}
+    ]
+  end
+
+  # ---------------------------------------------------------------------------
+  # Conversion
+  # ---------------------------------------------------------------------------
+
+  defp char_to_integer([{:char, cp}]), do: cp
+
+  defp char_to_integer([other]),
+    do: raise(Error, reason: {:type_error, "char->integer", "char", other})
+
+  defp integer_to_char([n]) when is_integer(n) and n >= 0 and n <= 0x10FFFF do
+    if surrogate?(n) do
+      raise(Error, reason: {:codepoint_out_of_range, "integer->char", n})
+    else
+      Value.char(n)
+    end
+  end
+
+  defp integer_to_char([n]) when is_integer(n),
+    do: raise(Error, reason: {:codepoint_out_of_range, "integer->char", n})
+
+  defp integer_to_char([other]),
+    do: raise(Error, reason: {:type_error, "integer->char", "integer", other})
+
+  defp surrogate?(cp), do: cp >= 0xD800 and cp <= 0xDFFF
+
+  # ---------------------------------------------------------------------------
+  # Comparators (case-sensitive and case-insensitive)
+  # ---------------------------------------------------------------------------
+
+  defp char_eq(args), do: variadic_char_cmp("char=?", args, & &1, &(&1 == &2))
+  defp char_lt(args), do: variadic_char_cmp("char<?", args, & &1, &(&1 < &2))
+  defp char_le(args), do: variadic_char_cmp("char<=?", args, & &1, &(&1 <= &2))
+  defp char_gt(args), do: variadic_char_cmp("char>?", args, & &1, &(&1 > &2))
+  defp char_ge(args), do: variadic_char_cmp("char>=?", args, & &1, &(&1 >= &2))
+
+  defp char_ci_eq(args), do: variadic_char_cmp("char-ci=?", args, &fold/1, &(&1 == &2))
+  defp char_ci_lt(args), do: variadic_char_cmp("char-ci<?", args, &fold/1, &(&1 < &2))
+  defp char_ci_le(args), do: variadic_char_cmp("char-ci<=?", args, &fold/1, &(&1 <= &2))
+  defp char_ci_gt(args), do: variadic_char_cmp("char-ci>?", args, &fold/1, &(&1 > &2))
+  defp char_ci_ge(args), do: variadic_char_cmp("char-ci>=?", args, &fold/1, &(&1 >= &2))
+
+  defp variadic_char_cmp(op, [first | rest] = args, key_fn, pair) do
+    Enum.each(args, &require_char!(op, &1))
+    {:char, h} = first
+    Value.bool(walk_chars(rest, key_fn.(h), key_fn, pair))
+  end
+
+  defp walk_chars([], _prev, _key_fn, _pair), do: true
+
+  defp walk_chars([{:char, cp} | rest], prev, key_fn, pair) do
+    k = key_fn.(cp)
+    if pair.(prev, k), do: walk_chars(rest, k, key_fn, pair), else: false
+  end
+
+  defp fold(cp) do
+    case String.to_charlist(String.downcase(<<cp::utf8>>, :default)) do
+      [single] -> single
+      _ -> cp
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Case mappings
+  # ---------------------------------------------------------------------------
+
+  defp char_upcase([{:char, cp}]), do: Value.char(map_case(cp, &String.upcase/2))
+
+  defp char_upcase([other]),
+    do: raise(Error, reason: {:type_error, "char-upcase", "char", other})
+
+  defp char_downcase([{:char, cp}]), do: Value.char(map_case(cp, &String.downcase/2))
+
+  defp char_downcase([other]),
+    do: raise(Error, reason: {:type_error, "char-downcase", "char", other})
+
+  defp char_foldcase([{:char, cp}]), do: Value.char(fold(cp))
+
+  defp char_foldcase([other]),
+    do: raise(Error, reason: {:type_error, "char-foldcase", "char", other})
+
+  # If the case mapping yields more than one codepoint, fall back to the
+  # original — char ops must preserve single-codepoint identity.
+  defp map_case(cp, mapper) do
+    case String.to_charlist(mapper.(<<cp::utf8>>, :default)) do
+      [single] -> single
+      _ -> cp
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Category predicates
+  # ---------------------------------------------------------------------------
+
+  defp char_alphabetic_p([{:char, cp}]) when cp in ?A..?Z or cp in ?a..?z, do: Value.bool(true)
+  defp char_alphabetic_p([{:char, cp}]) when cp < 128, do: Value.bool(false)
+  defp char_alphabetic_p([{:char, cp}]), do: Value.bool(Regex.match?(@alpha_re, <<cp::utf8>>))
+  defp char_alphabetic_p([other]), do: raise_char("char-alphabetic?", other)
+
+  defp char_numeric_p([{:char, cp}]) when cp in ?0..?9, do: Value.bool(true)
+  defp char_numeric_p([{:char, cp}]) when cp < 128, do: Value.bool(false)
+  defp char_numeric_p([{:char, cp}]), do: Value.bool(Regex.match?(@numeric_re, <<cp::utf8>>))
+  defp char_numeric_p([other]), do: raise_char("char-numeric?", other)
+
+  defp char_whitespace_p([{:char, cp}]) when cp in [?\s, ?\t, ?\n, ?\r, ?\v, ?\f],
+    do: Value.bool(true)
+
+  defp char_whitespace_p([{:char, cp}]) when cp < 128, do: Value.bool(false)
+
+  defp char_whitespace_p([{:char, cp}]),
+    do: Value.bool(Regex.match?(@whitespace_re, <<cp::utf8>>))
+
+  defp char_whitespace_p([other]), do: raise_char("char-whitespace?", other)
+
+  defp char_upper_case_p([{:char, cp}]) when cp in ?A..?Z, do: Value.bool(true)
+  defp char_upper_case_p([{:char, cp}]) when cp < 128, do: Value.bool(false)
+  defp char_upper_case_p([{:char, cp}]), do: Value.bool(Regex.match?(@upper_re, <<cp::utf8>>))
+  defp char_upper_case_p([other]), do: raise_char("char-upper-case?", other)
+
+  defp char_lower_case_p([{:char, cp}]) when cp in ?a..?z, do: Value.bool(true)
+  defp char_lower_case_p([{:char, cp}]) when cp < 128, do: Value.bool(false)
+  defp char_lower_case_p([{:char, cp}]), do: Value.bool(Regex.match?(@lower_re, <<cp::utf8>>))
+  defp char_lower_case_p([other]), do: raise_char("char-lower-case?", other)
+
+  defp raise_char(op, other),
+    do: raise(Error, reason: {:type_error, op, "char", other})
+
+  # ---------------------------------------------------------------------------
+  # Helpers
+  # ---------------------------------------------------------------------------
+
+  defp require_char!(_op, {:char, _}), do: :ok
+
+  defp require_char!(op, other),
+    do: raise(Error, reason: {:type_error, op, "char", other})
+end

--- a/lib/schooner/primitives/cxr.ex
+++ b/lib/schooner/primitives/cxr.ex
@@ -1,0 +1,63 @@
+defmodule Schooner.Primitives.Cxr do
+  @moduledoc """
+  The `(scheme cxr)` library: every `c…r` accessor of depth 2, 3, and 4
+  composed from `car` and `cdr`.
+
+  Each spelling like `caddr` reads right-to-left as a chain of pair
+  walks: `(caddr x)` ≡ `(car (cdr (cdr x)))`. We enumerate the 28 names
+  via a list comprehension rather than hand-writing each definition,
+  which keeps the mapping unambiguous and the code under a hundred lines.
+  """
+
+  alias Schooner.Env
+  alias Schooner.Primitive.Error
+  alias Schooner.Value
+
+  # Names of length 2/3/4 between `c` and `r`, in the canonical r7rs order
+  # (depth-first over `a`/`d` per position, outermost first).
+  @names for n <- 2..4,
+             chars <-
+               (case n do
+                  2 ->
+                    for(a <- ["a", "d"], b <- ["a", "d"], do: [a, b])
+
+                  3 ->
+                    for(
+                      a <- ["a", "d"],
+                      b <- ["a", "d"],
+                      c <- ["a", "d"],
+                      do: [a, b, c]
+                    )
+
+                  4 ->
+                    for(
+                      a <- ["a", "d"],
+                      b <- ["a", "d"],
+                      c <- ["a", "d"],
+                      d <- ["a", "d"],
+                      do: [a, b, c, d]
+                    )
+                end),
+             do: "c" <> Enum.join(chars) <> "r"
+
+  @doc "Register every `c..r` accessor on `env`."
+  @spec register_into(Env.t()) :: Env.t()
+  def register_into(%Env{} = env) do
+    Enum.reduce(@names, env, fn name, acc ->
+      Env.define(acc, name, Value.primitive(name, 1, build_fun(name)))
+    end)
+  end
+
+  # Letters between `c` and `r` apply right-to-left: `(caddr x)` ⇒ d, d, a.
+  defp build_fun(name) do
+    ops = name |> String.slice(1..-2//1) |> String.graphemes() |> Enum.reverse()
+    fn [v] -> apply_chain(name, ops, v) end
+  end
+
+  defp apply_chain(_name, [], v), do: v
+  defp apply_chain(name, ["a" | rest], {:pair, a, _}), do: apply_chain(name, rest, a)
+  defp apply_chain(name, ["d" | rest], {:pair, _, d}), do: apply_chain(name, rest, d)
+
+  defp apply_chain(name, _ops, other),
+    do: raise(Error, reason: {:type_error, name, "pair", other})
+end

--- a/lib/schooner/value.ex
+++ b/lib/schooner/value.ex
@@ -163,6 +163,15 @@ defmodule Schooner.Value do
   def eof?(:eof), do: true
   def eof?(_), do: false
 
+  @doc """
+  Scheme `list?` — true for `:null` and proper (null-terminated) pair chains;
+  false for improper lists, atoms, and anything that ends in a non-pair non-null.
+  """
+  @spec list?(term()) :: boolean()
+  def list?(:null), do: true
+  def list?({:pair, _, cdr}), do: list?(cdr)
+  def list?(_), do: false
+
   @spec unspecified?(term()) :: boolean()
   def unspecified?(:unspecified), do: true
   def unspecified?(_), do: false

--- a/test/schooner/primitives/base_pairs_property_test.exs
+++ b/test/schooner/primitives/base_pairs_property_test.exs
@@ -1,0 +1,61 @@
+defmodule Schooner.Primitives.BasePairsPropertyTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Schooner.Value
+
+  defp small_int_list, do: list_of(integer(-50..50), max_length: 16)
+
+  defp ascii_string,
+    do: string([?a..?z, ?A..?Z, ?0..?9], min_length: 0, max_length: 12)
+
+  defp render_int_list(xs), do: "(list " <> Enum.map_join(xs, " ", &Integer.to_string/1) <> ")"
+
+  property "list->vector ∘ vector->list ≡ identity" do
+    check all(xs <- small_int_list()) do
+      src = render_int_list(xs)
+
+      assert Schooner.run("(list->vector (vector->list (list->vector #{src})))") ==
+               Value.vector(xs)
+    end
+  end
+
+  property "vector->list ∘ list->vector ≡ identity (on lists)" do
+    check all(xs <- small_int_list()) do
+      src = render_int_list(xs)
+      assert Schooner.run("(vector->list (list->vector #{src}))") == Value.list(xs)
+    end
+  end
+
+  property "string->list ∘ list->string ≡ identity (ASCII)" do
+    check all(s <- ascii_string()) do
+      lit = "\"" <> s <> "\""
+
+      assert Schooner.run("(list->string (string->list #{lit}))") ==
+               Value.string(s)
+    end
+  end
+
+  property "(length (reverse xs)) == (length xs)" do
+    check all(xs <- small_int_list()) do
+      src = render_int_list(xs)
+      assert Schooner.run("(length (reverse #{src}))") === length(xs)
+    end
+  end
+
+  property "(length (map f xs)) == (length xs)" do
+    check all(xs <- small_int_list()) do
+      src = render_int_list(xs)
+
+      assert Schooner.run("(length (map (lambda (x) (* x x)) #{src}))") ===
+               length(xs)
+    end
+  end
+
+  property "reverse is its own inverse" do
+    check all(xs <- small_int_list()) do
+      src = render_int_list(xs)
+      assert Schooner.run("(reverse (reverse #{src}))") == Value.list(xs)
+    end
+  end
+end

--- a/test/schooner/primitives/base_pairs_test.exs
+++ b/test/schooner/primitives/base_pairs_test.exs
@@ -1,0 +1,196 @@
+defmodule Schooner.Primitives.BasePairsTest do
+  use ExUnit.Case, async: true
+
+  alias Schooner.Primitive.Error, as: PError
+  alias Schooner.Value
+
+  defp run(source), do: Schooner.run(source)
+
+  describe "cons / car / cdr" do
+    test "cons builds a pair, car/cdr destructure it" do
+      assert run("(cons 1 2)") == {:pair, 1, 2}
+      assert run("(car (cons 1 2))") == 1
+      assert run("(cdr (cons 1 2))") == 2
+    end
+
+    test "car/cdr on non-pair raise type_error" do
+      e = assert_raise PError, fn -> run("(car 1)") end
+      assert match?({:type_error, "car", "pair", _}, e.reason)
+
+      e = assert_raise PError, fn -> run("(cdr '())") end
+      assert match?({:type_error, "cdr", "pair", _}, e.reason)
+    end
+  end
+
+  describe "list constructors and predicates" do
+    test "(list ...) builds proper lists" do
+      assert run("(list)") == :null
+      assert run("(list 1 2 3)") == Value.list([1, 2, 3])
+    end
+
+    test "list? recognises proper lists, rejects improper and atoms" do
+      assert run("(list? '())") == Value.bool(true)
+      assert run("(list? '(1 2 3))") == Value.bool(true)
+      assert run("(list? (cons 1 2))") == Value.bool(false)
+      assert run("(list? 42)") == Value.bool(false)
+      assert run("(list? \"abc\")") == Value.bool(false)
+    end
+
+    test "list-copy returns a structurally equal list" do
+      assert run("(list-copy '(1 2 3))") == Value.list([1, 2, 3])
+      assert run("(list-copy '())") == :null
+    end
+
+    test "list-copy on improper list raises" do
+      e = assert_raise PError, fn -> run("(list-copy (cons 1 2))") end
+      assert match?({:improper_list, "list-copy", _}, e.reason)
+    end
+  end
+
+  describe "length / reverse" do
+    test "length of empty, single-element, and long lists" do
+      assert run("(length '())") === 0
+      assert run("(length '(7))") === 1
+      assert run("(length '(1 2 3 4 5))") === 5
+    end
+
+    test "length on improper list raises" do
+      e = assert_raise PError, fn -> run("(length (cons 1 2))") end
+      assert match?({:improper_list, "length", _}, e.reason)
+    end
+
+    test "reverse" do
+      assert run("(reverse '())") == :null
+      assert run("(reverse '(1))") == Value.list([1])
+      assert run("(reverse '(1 2 3))") == Value.list([3, 2, 1])
+    end
+
+    test "reverse on improper list raises" do
+      e = assert_raise PError, fn -> run("(reverse (cons 1 2))") end
+      assert match?({:improper_list, "reverse", _}, e.reason)
+    end
+  end
+
+  describe "append" do
+    test "append of zero, one, many" do
+      assert run("(append)") == :null
+      assert run("(append '(1 2 3))") == Value.list([1, 2, 3])
+      assert run("(append '(1 2) '(3 4))") == Value.list([1, 2, 3, 4])
+      assert run("(append '(1) '(2) '(3))") == Value.list([1, 2, 3])
+      assert run("(append '() '(1 2))") == Value.list([1, 2])
+    end
+
+    test "last argument may be any value (allows building improper tails)" do
+      assert run("(append '(1 2) 3)") == {:pair, 1, {:pair, 2, 3}}
+      assert run("(append '() 7)") == 7
+    end
+
+    test "non-final improper list raises" do
+      e = assert_raise PError, fn -> run("(append (cons 1 2) '(3))") end
+      assert match?({:improper_list, "append", _}, e.reason)
+    end
+  end
+
+  describe "list-tail / list-ref" do
+    test "list-tail" do
+      assert run("(list-tail '(a b c d) 0)") ==
+               Value.list([
+                 Value.symbol("a"),
+                 Value.symbol("b"),
+                 Value.symbol("c"),
+                 Value.symbol("d")
+               ])
+
+      assert run("(list-tail '(a b c d) 2)") == Value.list([Value.symbol("c"), Value.symbol("d")])
+      assert run("(list-tail '(1 2 3) 3)") == :null
+    end
+
+    test "list-tail past end raises index_out_of_range" do
+      e = assert_raise PError, fn -> run("(list-tail '(1 2) 5)") end
+      assert match?({:index_out_of_range, "list-tail", _, _}, e.reason)
+    end
+
+    test "list-ref" do
+      assert run("(list-ref '(a b c) 0)") == Value.symbol("a")
+      assert run("(list-ref '(a b c) 2)") == Value.symbol("c")
+    end
+
+    test "list-ref past end raises" do
+      e = assert_raise PError, fn -> run("(list-ref '(1 2) 5)") end
+      assert match?({:index_out_of_range, "list-ref", _, _}, e.reason)
+    end
+
+    test "negative index raises" do
+      assert_raise PError, fn -> run("(list-ref '(1 2 3) -1)") end
+      assert_raise PError, fn -> run("(list-tail '(1 2 3) -1)") end
+    end
+  end
+
+  describe "member / memv / memq" do
+    test "member uses equal?" do
+      assert run(~S|(member "abc" (list "a" "abc" "c"))|) ==
+               Value.list([Value.string("abc"), Value.string("c")])
+
+      assert run(~S|(member "z" (list "a" "b"))|) == Value.bool(false)
+    end
+
+    test "memv uses eqv?" do
+      assert run("(memv 2 '(1 2 3))") == Value.list([2, 3])
+      assert run("(memv 2.0 '(1 2 3))") == Value.bool(false)
+    end
+
+    test "memq uses eq?" do
+      assert run("(memq 'b '(a b c))") == Value.list([Value.symbol("b"), Value.symbol("c")])
+      assert run("(memq 'z '(a b c))") == Value.bool(false)
+    end
+  end
+
+  describe "assoc / assv / assq" do
+    test "assoc finds an entry by equal?" do
+      assert run(~S|(assoc "b" (list (list "a" 1) (list "b" 2) (list "c" 3)))|) ==
+               Value.list([Value.string("b"), 2])
+    end
+
+    test "assv finds an entry by eqv?" do
+      assert run("(assv 2 '((1 one) (2 two) (3 three)))") ==
+               Value.list([2, Value.symbol("two")])
+    end
+
+    test "assq finds by eq? on symbols" do
+      assert run("(assq 'b '((a 1) (b 2) (c 3)))") ==
+               Value.list([Value.symbol("b"), 2])
+    end
+
+    test "missing key returns #f" do
+      assert run("(assoc 'z '((a 1) (b 2)))") == Value.bool(false)
+      assert run("(assq 'z '())") == Value.bool(false)
+    end
+  end
+
+  describe "map / for-each" do
+    test "map with one list" do
+      assert run("(map (lambda (x) (* x x)) '(1 2 3 4))") ==
+               Value.list([1, 4, 9, 16])
+    end
+
+    test "map with multiple lists stops at the shortest" do
+      assert run("(map + '(1 2 3) '(10 20 30 40))") ==
+               Value.list([11, 22, 33])
+    end
+
+    test "for-each returns :unspecified" do
+      # Mutation is out of scope, so we cannot observe side effects from a
+      # Scheme-side accumulator. We assert the return contract instead and
+      # rely on `map`'s parallel test for evidence that the proc is invoked.
+      assert run("(for-each (lambda (x) x) '(1 2 3))") == :unspecified
+    end
+
+    test "map and for-each demand procedures" do
+      e = assert_raise PError, fn -> run("(map 1 '(1 2 3))") end
+      assert match?({:type_error, "map", "procedure", _}, e.reason)
+
+      e = assert_raise PError, fn -> run("(for-each 1 '(1 2 3))") end
+      assert match?({:type_error, "for-each", "procedure", _}, e.reason)
+    end
+  end
+end

--- a/test/schooner/primitives/base_strings_test.exs
+++ b/test/schooner/primitives/base_strings_test.exs
@@ -1,0 +1,200 @@
+defmodule Schooner.Primitives.BaseStringsTest do
+  use ExUnit.Case, async: true
+
+  alias Schooner.Primitive.Error, as: PError
+  alias Schooner.Value
+
+  defp run(source), do: Schooner.run(source)
+
+  describe "string constructors" do
+    test "(string ...) builds a string from chars" do
+      assert run(~S|(string #\h #\i)|) == Value.string("hi")
+      assert run("(string)") == Value.string("")
+    end
+
+    test "make-string fills with the given char" do
+      assert run(~S|(make-string 3 #\x)|) == Value.string("xxx")
+      assert run("(make-string 0)") == Value.string("")
+    end
+
+    test "make-string defaults to spaces" do
+      assert run("(make-string 3)") == Value.string("   ")
+    end
+
+    test "make-string with non-char fill raises" do
+      e = assert_raise PError, fn -> run("(make-string 3 1)") end
+      assert match?({:type_error, "make-string", "char", _}, e.reason)
+    end
+  end
+
+  describe "length / ref / append on UTF-8" do
+    test "string-length counts codepoints, not bytes or graphemes" do
+      assert run(~S|(string-length "hi")|) === 2
+      # café — four codepoints, é is two bytes.
+      assert run(~S|(string-length "café")|) === 4
+      # Combining accent: 'e' + COMBINING ACUTE ACCENT (U+0301) = 2 codepoints.
+      assert run(~s|(string-length "é")|) === 2
+    end
+
+    test "string-ref works on multi-byte UTF-8" do
+      # café — index 3 is the combined é (U+00E9).
+      assert run(~S|(string-ref "café" 3)|) == Value.char(0x00E9)
+    end
+
+    test "string-ref out of range raises" do
+      e = assert_raise PError, fn -> run(~S|(string-ref "abc" 5)|) end
+      assert match?({:index_out_of_range, "string-ref", _, _}, e.reason)
+    end
+
+    test "string-append concatenates" do
+      assert run(~S|(string-append)|) == Value.string("")
+      assert run(~S|(string-append "ab" "cd")|) == Value.string("abcd")
+      assert run(~S|(string-append "" "x")|) == Value.string("x")
+    end
+  end
+
+  describe "substring / string-copy" do
+    test "substring slices by codepoint" do
+      assert run(~S|(substring "abcdef" 1 4)|) == Value.string("bcd")
+      assert run(~S|(substring "abc" 0 0)|) == Value.string("")
+    end
+
+    test "substring on multi-byte input" do
+      assert run(~S|(substring "café" 2 4)|) == Value.string("fé")
+    end
+
+    test "substring out of range raises" do
+      e = assert_raise PError, fn -> run(~S|(substring "abc" 0 10)|) end
+      assert match?({:index_out_of_range, "substring", _, _}, e.reason)
+    end
+
+    test "string-copy slice" do
+      assert run(~S|(string-copy "hello")|) == Value.string("hello")
+      assert run(~S|(string-copy "hello" 1)|) == Value.string("ello")
+      assert run(~S|(string-copy "hello" 1 3)|) == Value.string("el")
+    end
+  end
+
+  describe "comparison" do
+    test "string=?" do
+      assert run(~S|(string=? "ab" "ab")|) == Value.bool(true)
+      assert run(~S|(string=? "ab" "ab" "ab")|) == Value.bool(true)
+      assert run(~S|(string=? "ab" "ac")|) == Value.bool(false)
+    end
+
+    test "string<? / string<=? / string>? / string>=?" do
+      assert run(~S|(string<? "abc" "abd")|) == Value.bool(true)
+      assert run(~S|(string<? "abc" "abc")|) == Value.bool(false)
+      assert run(~S|(string<=? "abc" "abc")|) == Value.bool(true)
+      assert run(~S|(string>? "b" "a")|) == Value.bool(true)
+      assert run(~S|(string>=? "b" "b")|) == Value.bool(true)
+    end
+
+    test "comparison rejects non-strings" do
+      e = assert_raise PError, fn -> run(~S|(string=? "ab" 1)|) end
+      assert match?({:type_error, "string=?", "string", _}, e.reason)
+    end
+  end
+
+  describe "string <-> list" do
+    test "string->list and list->string round-trip" do
+      assert run(~S|(list->string (string->list "café"))|) == Value.string("café")
+      assert run(~S|(list->string '())|) == Value.string("")
+    end
+
+    test "string->list with start / end" do
+      assert run(~S|(string->list "abcd" 1 3)|) ==
+               Value.list([Value.char(?b), Value.char(?c)])
+    end
+
+    test "list->string demands a list of chars" do
+      e = assert_raise PError, fn -> run("(list->string '(1 2 3))") end
+      assert match?({:type_error, "list->string", "char", _}, e.reason)
+    end
+  end
+
+  describe "case mappings" do
+    test "string-upcase / string-downcase preserve unicode case rules" do
+      assert run(~S|(string-upcase "abc")|) == Value.string("ABC")
+      assert run(~S|(string-downcase "ABC")|) == Value.string("abc")
+    end
+
+    test "ß upcases to SS (Unicode default mapping)" do
+      assert run(~s|(string-upcase "ß")|) == Value.string("SS")
+    end
+
+    test "Turkish dotless i — default mapping is locale-agnostic" do
+      # `ı` (U+0131) up-cases to ASCII `I` under Unicode default rules.
+      assert run(~s|(string-upcase "ı")|) == Value.string("I")
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Bytevectors
+  # ---------------------------------------------------------------------------
+
+  describe "bytevectors — constructors and length" do
+    test "(bytevector ...) accepts bytes" do
+      assert run("(bytevector)") == Value.bytevector([])
+      assert run("(bytevector 1 2 3)") == Value.bytevector([1, 2, 3])
+    end
+
+    test "make-bytevector with fill" do
+      assert run("(make-bytevector 3 0)") == Value.bytevector(<<0, 0, 0>>)
+      assert run("(make-bytevector 4 255)") == Value.bytevector(<<255, 255, 255, 255>>)
+    end
+
+    test "make-bytevector default fill is 0" do
+      assert run("(make-bytevector 2)") == Value.bytevector(<<0, 0>>)
+    end
+
+    test "out-of-range byte raises" do
+      e = assert_raise PError, fn -> run("(bytevector 256)") end
+      assert match?({:byte_out_of_range, "bytevector", _}, e.reason)
+    end
+
+    test "bytevector-length" do
+      assert run("(bytevector-length #u8(1 2 3 4))") === 4
+    end
+
+    test "bytevector-u8-ref" do
+      assert run("(bytevector-u8-ref #u8(10 20 30) 1)") === 20
+    end
+
+    test "bytevector-u8-ref out of range raises" do
+      assert_raise PError, fn -> run("(bytevector-u8-ref #u8(1 2) 5)") end
+    end
+  end
+
+  describe "bytevector copy / append" do
+    test "bytevector-copy whole / range" do
+      assert run("(bytevector-copy #u8(1 2 3))") == Value.bytevector(<<1, 2, 3>>)
+      assert run("(bytevector-copy #u8(1 2 3 4) 1 3)") == Value.bytevector(<<2, 3>>)
+    end
+
+    test "bytevector-append" do
+      assert run("(bytevector-append)") == Value.bytevector(<<>>)
+
+      assert run("(bytevector-append #u8(1 2) #u8(3 4))") ==
+               Value.bytevector(<<1, 2, 3, 4>>)
+    end
+  end
+
+  describe "utf8 conversions" do
+    test "string->utf8 returns the UTF-8 bytes" do
+      assert run(~S|(string->utf8 "abc")|) == Value.bytevector(<<?a, ?b, ?c>>)
+      # café — last codepoint U+00E9 is two bytes.
+      assert run(~S|(string->utf8 "café")|) == Value.bytevector(<<?c, ?a, ?f, 0xC3, 0xA9>>)
+    end
+
+    test "utf8->string round-trips through string->utf8" do
+      assert run(~S|(utf8->string (string->utf8 "café"))|) == Value.string("café")
+    end
+
+    test "utf8->string raises on invalid UTF-8" do
+      # 0xC3 alone is the start of a 2-byte sequence with no continuation.
+      e = assert_raise PError, fn -> run("(utf8->string #u8(195))") end
+      assert e.reason == {:invalid_utf8, "utf8->string"}
+    end
+  end
+end

--- a/test/schooner/primitives/base_symbols_test.exs
+++ b/test/schooner/primitives/base_symbols_test.exs
@@ -1,0 +1,48 @@
+defmodule Schooner.Primitives.BaseSymbolsTest do
+  use ExUnit.Case, async: true
+
+  alias Schooner.Primitive.Error, as: PError
+  alias Schooner.Value
+
+  defp run(source), do: Schooner.run(source)
+
+  describe "symbol identity" do
+    test "two string->symbol calls on the same string are eq?" do
+      assert run(~S|(eq? (string->symbol "foo") (string->symbol "foo"))|) ==
+               Value.bool(true)
+    end
+
+    test "symbol=? on equal symbols" do
+      assert run("(symbol=? 'a 'a)") == Value.bool(true)
+      assert run("(symbol=? 'a 'a 'a)") == Value.bool(true)
+      assert run("(symbol=? 'a 'b)") == Value.bool(false)
+    end
+
+    test "symbol=? rejects non-symbols" do
+      e = assert_raise PError, fn -> run(~S|(symbol=? 'a "a")|) end
+      assert match?({:type_error, "symbol=?", "symbol", _}, e.reason)
+    end
+  end
+
+  describe "symbol/string conversion" do
+    test "symbol->string" do
+      assert run("(symbol->string 'hello)") == Value.string("hello")
+    end
+
+    test "string->symbol" do
+      assert run(~S|(string->symbol "hello")|) == Value.symbol("hello")
+    end
+
+    test "round-trip" do
+      assert run(~S|(symbol->string (string->symbol "x y"))|) == Value.string("x y")
+    end
+
+    test "type errors" do
+      e = assert_raise PError, fn -> run(~S|(symbol->string "not-a-symbol")|) end
+      assert match?({:type_error, "symbol->string", "symbol", _}, e.reason)
+
+      e = assert_raise PError, fn -> run("(string->symbol 'not-a-string)") end
+      assert match?({:type_error, "string->symbol", "string", _}, e.reason)
+    end
+  end
+end

--- a/test/schooner/primitives/base_vectors_test.exs
+++ b/test/schooner/primitives/base_vectors_test.exs
@@ -1,0 +1,112 @@
+defmodule Schooner.Primitives.BaseVectorsTest do
+  use ExUnit.Case, async: true
+
+  alias Schooner.Primitive.Error, as: PError
+  alias Schooner.Value
+
+  defp run(source), do: Schooner.run(source)
+
+  describe "constructors" do
+    test "(vector ...) builds a vector" do
+      assert run("(vector)") == Value.vector([])
+      assert run("(vector 1 2 3)") == Value.vector([1, 2, 3])
+    end
+
+    test "make-vector with fill" do
+      assert run("(make-vector 3 0)") == Value.vector([0, 0, 0])
+      assert run("(make-vector 0 0)") == Value.vector([])
+    end
+
+    test "make-vector without fill defaults to :unspecified" do
+      assert run("(make-vector 2)") == Value.vector([:unspecified, :unspecified])
+    end
+
+    test "make-vector negative size raises" do
+      e = assert_raise PError, fn -> run("(make-vector -1 0)") end
+      assert match?({:invalid_size, "make-vector", _}, e.reason)
+    end
+  end
+
+  describe "vector-length / vector-ref" do
+    test "vector-length" do
+      assert run("(vector-length #(1 2 3 4))") === 4
+      assert run("(vector-length #())") === 0
+    end
+
+    test "vector-ref" do
+      assert run("(vector-ref #(a b c) 0)") == Value.symbol("a")
+      assert run("(vector-ref #(a b c) 2)") == Value.symbol("c")
+    end
+
+    test "vector-ref out of range raises" do
+      e = assert_raise PError, fn -> run("(vector-ref #(1 2 3) 5)") end
+      assert match?({:index_out_of_range, "vector-ref", _, _}, e.reason)
+
+      assert_raise PError, fn -> run("(vector-ref #(1 2 3) -1)") end
+    end
+  end
+
+  describe "vector <-> list" do
+    test "vector->list and list->vector round-trip" do
+      assert run("(list->vector (vector->list #(1 2 3)))") == Value.vector([1, 2, 3])
+
+      assert run("(vector->list (list->vector '(a b c)))") ==
+               Value.list([Value.symbol("a"), Value.symbol("b"), Value.symbol("c")])
+    end
+
+    test "vector->list with start / end slice" do
+      assert run("(vector->list #(0 1 2 3 4) 1 4)") == Value.list([1, 2, 3])
+      assert run("(vector->list #(0 1 2 3) 2)") == Value.list([2, 3])
+    end
+  end
+
+  describe "vector-map / vector-for-each" do
+    test "vector-map applies pointwise" do
+      assert run("(vector-map (lambda (x) (* x 2)) #(1 2 3))") == Value.vector([2, 4, 6])
+    end
+
+    test "vector-map with multiple vectors uses the shortest length" do
+      assert run("(vector-map + #(1 2 3) #(10 20 30 40))") == Value.vector([11, 22, 33])
+    end
+
+    test "vector-for-each returns unspecified" do
+      assert run("(vector-for-each (lambda (x) x) #(1 2 3))") == :unspecified
+    end
+  end
+
+  describe "vector-copy" do
+    test "produces a structurally equal vector" do
+      # Schooner deliberately collapses `eq?` and `eqv?` to structural
+      # equality (see `Schooner.Value` moduledoc); without mutation there
+      # is no observable identity beyond contents, so two equal-content
+      # vectors are `eq?` here. r7rs explicitly permits this. The test
+      # therefore pins the structural-equality guarantee that callers can
+      # rely on.
+      assert run("(equal? #(1 2 3) (vector-copy #(1 2 3)))") == Value.bool(true)
+      assert run("(equal? #(1 2 3) (vector-copy #(4 5 6)))") == Value.bool(false)
+    end
+
+    test "vector-copy with start / end" do
+      assert run("(vector-copy #(0 1 2 3 4) 1 4)") == Value.vector([1, 2, 3])
+      assert run("(vector-copy #(0 1 2 3) 2)") == Value.vector([2, 3])
+    end
+
+    test "out-of-range bounds raise" do
+      e = assert_raise PError, fn -> run("(vector-copy #(1 2 3) 0 10)") end
+      assert match?({:index_out_of_range, "vector-copy", _, _}, e.reason)
+    end
+  end
+
+  describe "vector-append" do
+    test "concatenates vectors" do
+      assert run("(vector-append)") == Value.vector([])
+      assert run("(vector-append #(1 2) #(3 4))") == Value.vector([1, 2, 3, 4])
+      assert run("(vector-append #(1) #() #(2))") == Value.vector([1, 2])
+    end
+
+    test "non-vector argument raises" do
+      e = assert_raise PError, fn -> run("(vector-append #(1 2) 3)") end
+      assert match?({:type_error, "vector-append", "vector", _}, e.reason)
+    end
+  end
+end

--- a/test/schooner/primitives/char_test.exs
+++ b/test/schooner/primitives/char_test.exs
@@ -1,0 +1,116 @@
+defmodule Schooner.Primitives.CharTest do
+  use ExUnit.Case, async: true
+
+  alias Schooner.Primitive.Error, as: PError
+  alias Schooner.Value
+
+  defp run(source), do: Schooner.run(source)
+
+  describe "char->integer / integer->char" do
+    test "ASCII round-trip" do
+      assert run(~S|(char->integer #\A)|) === 65
+      assert run("(integer->char 65)") == Value.char(?A)
+    end
+
+    test "non-ASCII codepoint" do
+      assert run("(integer->char 233)") == Value.char(0x00E9)
+      assert run(~S|(char->integer #\é)|) === 0x00E9
+    end
+
+    test "out-of-range codepoint raises" do
+      e = assert_raise PError, fn -> run("(integer->char -1)") end
+      assert match?({:codepoint_out_of_range, "integer->char", _}, e.reason)
+
+      e = assert_raise PError, fn -> run("(integer->char 1114112)") end
+      assert match?({:codepoint_out_of_range, "integer->char", _}, e.reason)
+    end
+
+    test "surrogate range raises" do
+      e = assert_raise PError, fn -> run("(integer->char 55296)") end
+      assert match?({:codepoint_out_of_range, "integer->char", _}, e.reason)
+    end
+  end
+
+  describe "comparators (case-sensitive)" do
+    test "char=?" do
+      assert run(~S|(char=? #\a #\a)|) == Value.bool(true)
+      assert run(~S|(char=? #\a #\a #\a)|) == Value.bool(true)
+      assert run(~S|(char=? #\a #\b)|) == Value.bool(false)
+    end
+
+    test "char<? / char<=? / char>? / char>=?" do
+      assert run(~S|(char<? #\a #\b #\c)|) == Value.bool(true)
+      assert run(~S|(char<=? #\a #\a #\b)|) == Value.bool(true)
+      assert run(~S|(char>? #\c #\b #\a)|) == Value.bool(true)
+      assert run(~S|(char>=? #\b #\b #\a)|) == Value.bool(true)
+    end
+  end
+
+  describe "comparators (case-insensitive)" do
+    test "char-ci=? folds case before comparing" do
+      assert run(~S|(char-ci=? #\A #\a)|) == Value.bool(true)
+      assert run(~S|(char-ci=? #\A #\b)|) == Value.bool(false)
+    end
+
+    test "char-ci<?" do
+      assert run(~S|(char-ci<? #\A #\b #\C)|) == Value.bool(true)
+    end
+  end
+
+  describe "case mappings" do
+    test "char-upcase / char-downcase on ASCII" do
+      assert run(~S|(char-upcase #\a)|) == Value.char(?A)
+      assert run(~S|(char-downcase #\A)|) == Value.char(?a)
+    end
+
+    test "char-foldcase folds to a canonical form" do
+      assert run(~S|(char=? (char-foldcase #\A) (char-foldcase #\a))|) ==
+               Value.bool(true)
+    end
+
+    test "ß has no single-codepoint upcase — char-upcase leaves it unchanged" do
+      assert run(~s|(char-upcase #\\ß)|) == Value.char(0x00DF)
+    end
+  end
+
+  describe "category predicates" do
+    test "char-alphabetic?" do
+      assert run(~S|(char-alphabetic? #\a)|) == Value.bool(true)
+      assert run(~S|(char-alphabetic? #\Z)|) == Value.bool(true)
+      assert run(~S|(char-alphabetic? #\1)|) == Value.bool(false)
+      assert run(~S|(char-alphabetic? #\space)|) == Value.bool(false)
+    end
+
+    test "char-numeric?" do
+      assert run(~S|(char-numeric? #\0)|) == Value.bool(true)
+      assert run(~S|(char-numeric? #\9)|) == Value.bool(true)
+      assert run(~S|(char-numeric? #\a)|) == Value.bool(false)
+    end
+
+    test "char-whitespace?" do
+      assert run(~S|(char-whitespace? #\space)|) == Value.bool(true)
+      assert run(~S|(char-whitespace? #\newline)|) == Value.bool(true)
+      assert run(~S|(char-whitespace? #\tab)|) == Value.bool(true)
+      assert run(~S|(char-whitespace? #\a)|) == Value.bool(false)
+    end
+
+    test "char-upper-case? / char-lower-case?" do
+      assert run(~S|(char-upper-case? #\A)|) == Value.bool(true)
+      assert run(~S|(char-upper-case? #\a)|) == Value.bool(false)
+      assert run(~S|(char-lower-case? #\a)|) == Value.bool(true)
+      assert run(~S|(char-lower-case? #\A)|) == Value.bool(false)
+    end
+  end
+
+  describe "type errors" do
+    test "comparator rejects non-char arg" do
+      e = assert_raise PError, fn -> run(~S|(char=? #\a 1)|) end
+      assert match?({:type_error, "char=?", "char", _}, e.reason)
+    end
+
+    test "case mapping rejects non-char arg" do
+      e = assert_raise PError, fn -> run("(char-upcase 1)") end
+      assert match?({:type_error, "char-upcase", "char", _}, e.reason)
+    end
+  end
+end

--- a/test/schooner/primitives/cxr_test.exs
+++ b/test/schooner/primitives/cxr_test.exs
@@ -1,0 +1,72 @@
+defmodule Schooner.Primitives.CxrTest do
+  use ExUnit.Case, async: true
+
+  alias Schooner.Primitive.Error, as: PError
+  alias Schooner.Value
+
+  defp run(source), do: Schooner.run(source)
+
+  describe "depth-2 accessors" do
+    test "caar / cadr / cdar / cddr" do
+      assert run("(caar '((1 2) (3 4)))") === 1
+      assert run("(cadr '(1 2 3))") === 2
+      assert run("(cdar '((1 2) 3))") == Value.list([2])
+      assert run("(cddr '(1 2 3 4))") == Value.list([3, 4])
+    end
+  end
+
+  describe "depth-3 accessors" do
+    test "caddr selects the third element" do
+      assert run("(caddr '(1 2 3 4))") === 3
+    end
+
+    test "cadar selects via mixed walks" do
+      # cadar = car (cdr (car x))) — second element of the first list.
+      assert run("(cadar '((10 20 30) (40 50 60)))") === 20
+    end
+  end
+
+  describe "depth-4 accessors" do
+    test "cadddr selects the fourth element" do
+      assert run("(cadddr '(1 2 3 4 5))") === 4
+    end
+
+    test "cddddr drops the first four" do
+      assert run("(cddddr '(1 2 3 4 5 6))") == Value.list([5, 6])
+    end
+  end
+
+  describe "type errors" do
+    test "applying caar to a non-pair raises" do
+      e = assert_raise PError, fn -> run("(caar '())") end
+      assert match?({:type_error, "caar", "pair", _}, e.reason)
+    end
+
+    test "applying caddr to a list shorter than 3 raises" do
+      e = assert_raise PError, fn -> run("(caddr '(1 2))") end
+      assert match?({:type_error, "caddr", "pair", _}, e.reason)
+    end
+  end
+
+  describe "registration completeness" do
+    test "every depth-2/3/4 c..r name is registered" do
+      depth2 = for a <- ["a", "d"], b <- ["a", "d"], do: "c" <> a <> b <> "r"
+
+      depth3 =
+        for a <- ["a", "d"], b <- ["a", "d"], c <- ["a", "d"], do: "c" <> a <> b <> c <> "r"
+
+      depth4 =
+        for a <- ["a", "d"],
+            b <- ["a", "d"],
+            c <- ["a", "d"],
+            d <- ["a", "d"],
+            do: "c" <> a <> b <> c <> d <> "r"
+
+      env = Schooner.standard_env()
+
+      for name <- depth2 ++ depth3 ++ depth4 do
+        assert {:ok, {:primitive, ^name, 1, _}} = Schooner.Env.lookup(env, name)
+      end
+    end
+  end
+end

--- a/test/schooner/value_test.exs
+++ b/test/schooner/value_test.exs
@@ -26,6 +26,14 @@ defmodule Schooner.ValueTest do
       refute Value.pair?(:null)
     end
 
+    test "list? recognises proper lists only" do
+      assert Value.list?(:null)
+      assert Value.list?(Value.list([1, 2, 3]))
+      refute Value.list?(Value.improper_list([1, 2], 3))
+      refute Value.list?(42)
+      refute Value.list?({:string, "abc"})
+    end
+
     test "list builders" do
       assert Value.list([]) == :null
       assert Value.list([1, 2, 3]) == {:pair, 1, {:pair, 2, {:pair, 3, :null}}}


### PR DESCRIPTION
## Summary

Implements PLAN.md phase 6: the immutable r7rs-small data primitives across `(scheme base)`, `(scheme cxr)`, and `(scheme char)`. After this lands, sandboxed scripts can manipulate every aggregate type Schooner ships in its value model — only the throwaway derived forms (phase 7) and the macro expander (phase 9) remain before realistic Scheme code becomes runnable.

### What's added

**`(scheme base)` data primitives** — extends `lib/schooner/primitives/base.ex`:

- **Pairs / lists** — `cons`, `car`, `cdr`, `list?`, `length`, `reverse`, `append`, `list-tail`, `list-ref`, `list`, `list-copy`, `member`/`memv`/`memq`, `assoc`/`assv`/`assq`, `map`, `for-each`.
- **Vectors** — `vector`, `make-vector`, `vector-length`, `vector-ref`, `vector->list`, `list->vector`, `vector-map`, `vector-for-each`, `vector-copy`, `vector-append`.
- **Bytevectors** — `bytevector`, `make-bytevector`, `bytevector-length`, `bytevector-u8-ref`, `bytevector-copy`, `bytevector-append`, `utf8->string`, `string->utf8`.
- **Strings** — `string`, `make-string`, `string-length`, `string-ref`, `string-append`, `substring`, `string=?`/`<?`/`<=?`/`>?`/`>=?`, `string->list`, `list->string`, `string-upcase`, `string-downcase`, `string-copy`.
- **Symbols** — `symbol=?`, `symbol->string`, `string->symbol`.
- **Equality** — `eq?`, `eqv?`, `equal?` (delegate to `Schooner.Value` — these were missing on the Scheme side).

**`Schooner.Primitives.Cxr`** — new module. Generates the 28 `c…r` accessors from letter-string chains so the mapping is unambiguous and the file stays under 80 lines.

**`Schooner.Primitives.Char`** — new module. `char->integer`, `integer->char`, case-sensitive and case-insensitive comparators, `char-upcase`/`-downcase`/`-foldcase`, category predicates (`alphabetic?`, `numeric?`, `whitespace?`, `upper-case?`, `lower-case?`) with ASCII-range guards as a fast path before the Unicode-property regex fallback.

**`Schooner.Value.list?/1`** — proper-list predicate (walks the chain).

**`Schooner.Primitive.Error`** — new error reasons: `:index_out_of_range`, `:improper_list`, `:length_mismatch`, `:invalid_utf8`, `:codepoint_out_of_range`, `:byte_out_of_range`, `:invalid_size`. Each gets a one-line `format/1` clause.

**`Schooner.standard_env/0`** — wires `Cxr` and `Char` alongside `Base`.

### Notable design choices

- **Codepoints, not graphemes.** `string-length`, `string-ref`, `substring`, `string-copy`, `string->list` walk the binary by Unicode codepoint via hand-rolled `<<cp::utf8, …>>` bit-syntax. `String.length/1` and `:string.length/1` would return grapheme counts, which violates r7rs character semantics. The plan called this out explicitly and the new tests cover combining accents, ß case-mapping, and the Turkish dotless `ı`.
- **Char case mappings preserve single-codepoint identity.** `char-upcase #\\ß` returns `#\\ß` rather than expanding to `SS` — char ops must produce a single character. The Unicode-default expansion stays observable via `string-upcase`.
- **`eq?` collapses into `eqv?`** here, per the documented choice in `Schooner.Value`. So `(eq? v (vector-copy v))` is `#t`, contrary to the original phase-6 plan text. Filed for later as #15 (with an alternative using `:erts_debug.same/2` discussed in the comments). The `vector-copy` test was rewritten with an inline note explaining the deviation.
- **No mutation.** `make-vector` without a fill defaults to `:unspecified`; `make-string` without a fill defaults to spaces; `vector-copy` returns a structurally equal but freshly allocated vector. `set!`-style mutators remain out of scope per the project constraints.

### Followups filed during the simplify pass

The simplify pass over the new code closed several issues directly and filed four for later:

- #16 — Single-walk string codepoint ops (perf — string ops currently walk the binary 2× per call)
- #17 — Unify variadic comparator family across `Base` and `Char`
- #18 — Fix arity-overflow error reporting for `make-vector` / `make-string` / `make-bytevector`
- #19 — Make `append` tail-recursive on input list length

## Test plan

- [x] `mix precommit` green — compile-warnings-as-errors, format, credo --strict, test all pass (23 properties, 367 tests, 0 failures).
- [x] `test/schooner/primitives/base_pairs_test.exs` — pairs, list constructors, length/reverse, append, list-tail/ref, member family, assoc family, map/for-each, error paths for non-procedures and improper lists.
- [x] `test/schooner/primitives/base_vectors_test.exs` — constructors, length/ref, vector↔list, vector-map/for-each, copy/append slicing, out-of-range bounds.
- [x] `test/schooner/primitives/base_strings_test.exs` — covers strings *and* bytevectors. Multi-byte UTF-8 length/ref, substring on `café`, ß and Turkish ı case mappings, `utf8->string` on invalid UTF-8.
- [x] `test/schooner/primitives/base_symbols_test.exs` — `string->symbol` interning, `symbol=?`, round-trip with `symbol->string`.
- [x] `test/schooner/primitives/cxr_test.exs` — depth-2/3/4 accessors, type-error paths, plus a registration completeness check that asserts every `c…r` name is bound.
- [x] `test/schooner/primitives/char_test.exs` — conversion, comparators, case mappings (including the ß single-codepoint preservation), category predicates, type errors.
- [x] `test/schooner/primitives/base_pairs_property_test.exs` — `list↔vector`, `string↔list` (ASCII) round-trips; `length` preservation under `reverse` and `map`; `reverse` involution.
- [x] `test/schooner/value_test.exs` — extended with a `list?` test covering `:null`, proper lists, improper lists, atoms, and strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)