### PR TITLE
Phase 7: derived forms + r7rs §4 conformance tests

### DIFF
--- a/lib/schooner/env.ex
+++ b/lib/schooner/env.ex
@@ -21,7 +21,7 @@ defmodule Schooner.Env do
   @enforce_keys [:globals, :lex]
   defstruct [:globals, :lex]
 
-  @type frame :: %{optional(binary()) => Value.t()}
+  @type frame :: %{optional(binary()) => Value.t()} | {:rec, :ets.tid()}
   @type t :: %__MODULE__{globals: :ets.tid(), lex: [frame()]}
 
   @spec new() :: t()
@@ -40,6 +40,13 @@ defmodule Schooner.Env do
   end
 
   defp lex_lookup([], _name), do: :error
+
+  defp lex_lookup([{:rec, tid} | rest], name) do
+    case :ets.lookup(tid, name) do
+      [{^name, value}] -> {:ok, value}
+      [] -> lex_lookup(rest, name)
+    end
+  end
 
   defp lex_lookup([frame | rest], name) do
     case Map.fetch(frame, name) do
@@ -69,5 +76,26 @@ defmodule Schooner.Env do
   @spec extend(t(), [{binary(), Value.t()}]) :: t()
   def extend(%__MODULE__{lex: lex} = env, bindings) do
     %{env | lex: [Map.new(bindings) | lex]}
+  end
+
+  @doc """
+  Push a fresh `letrec`-style frame whose bindings can be assigned later
+  via `rec_set/3`. Closures created against the returned env see the
+  bindings by frame identity, so forward references resolve once the
+  frame has been populated. The frame is backed by an ETS table owned by
+  the calling process and is cleaned up when that process exits.
+  """
+  @spec extend_rec(t(), [binary()]) :: t()
+  def extend_rec(%__MODULE__{lex: lex} = env, names) when is_list(names) do
+    tid = :ets.new(:schooner_rec, [:set, :protected])
+    Enum.each(names, fn name when is_binary(name) -> :ets.insert(tid, {name, :unspecified}) end)
+    %{env | lex: [{:rec, tid} | lex]}
+  end
+
+  @doc "Set a binding in the topmost recursive frame on `env`."
+  @spec rec_set(t(), binary(), Value.t()) :: t()
+  def rec_set(%__MODULE__{lex: [{:rec, tid} | _]} = env, name, value) when is_binary(name) do
+    :ets.insert(tid, {name, value})
+    env
   end
 end

--- a/lib/schooner/eval.ex
+++ b/lib/schooner/eval.ex
@@ -32,16 +32,24 @@ defmodule Schooner.Eval do
 
   def eval(:null, _env), do: raise(Error, reason: :empty_application)
 
-  def eval({:pair, head, tail}, env) do
-    case head do
-      {:sym, "quote"} -> eval_quote(tail)
-      {:sym, "if"} -> eval_if(tail, env)
-      {:sym, "lambda"} -> eval_lambda(tail, env)
-      {:sym, "define"} -> eval_define(tail, env)
-      {:sym, "begin"} -> eval_sequence(tail, env)
-      _ -> eval_apply(head, tail, env)
-    end
-  end
+  def eval({:pair, {:sym, "quote"}, tail}, _env), do: eval_quote(tail)
+  def eval({:pair, {:sym, "if"}, tail}, env), do: eval_if(tail, env)
+  def eval({:pair, {:sym, "lambda"}, tail}, env), do: eval_lambda(tail, env)
+  def eval({:pair, {:sym, "define"}, tail}, env), do: eval_define(tail, env)
+  def eval({:pair, {:sym, "begin"}, tail}, env), do: eval_sequence(tail, env)
+  def eval({:pair, {:sym, "and"}, tail}, env), do: eval_and(tail, env)
+  def eval({:pair, {:sym, "or"}, tail}, env), do: eval_or(tail, env)
+  def eval({:pair, {:sym, "when"}, tail}, env), do: eval_when(tail, env)
+  def eval({:pair, {:sym, "unless"}, tail}, env), do: eval_unless(tail, env)
+  def eval({:pair, {:sym, "cond"}, tail}, env), do: eval_cond(tail, env)
+  def eval({:pair, {:sym, "case"}, tail}, env), do: eval_case(tail, env)
+  def eval({:pair, {:sym, "let"}, tail}, env), do: eval_let(tail, env)
+  def eval({:pair, {:sym, "let*"}, tail}, env), do: eval_let_star(tail, env)
+  def eval({:pair, {:sym, "letrec"}, tail}, env), do: eval_letrec_star(tail, env)
+  def eval({:pair, {:sym, "letrec*"}, tail}, env), do: eval_letrec_star(tail, env)
+  def eval({:pair, {:sym, "do"}, tail}, env), do: eval_do(tail, env)
+  def eval({:pair, {:sym, "quasiquote"}, tail}, env), do: eval_quasiquote_top(tail, env)
+  def eval({:pair, head, tail}, env), do: eval_apply(head, tail, env)
 
   def eval(value, _env), do: value
 
@@ -201,4 +209,324 @@ defmodule Schooner.Eval do
       raise(Error, reason: {:arity_mismatch, name, {:at_least, n}, got})
     end
   end
+
+  # ---------------------------------------------------------------------------
+  # and / or — short-circuit, return the deciding value (r7rs §4.2.1).
+  # `(and)` => #t, `(or)` => #f. Last form is in tail position.
+  # ---------------------------------------------------------------------------
+
+  defp eval_and(:null, _env), do: Value.bool(true)
+  defp eval_and({:pair, last, :null}, env), do: eval(last, env)
+
+  defp eval_and({:pair, head, rest}, env) do
+    case eval(head, env) do
+      {:bool, false} = v -> v
+      _ -> eval_and(rest, env)
+    end
+  end
+
+  defp eval_and(_, _env), do: raise(Error, reason: {:bad_special_form, "and"})
+
+  defp eval_or(:null, _env), do: Value.bool(false)
+  defp eval_or({:pair, last, :null}, env), do: eval(last, env)
+
+  defp eval_or({:pair, head, rest}, env) do
+    case eval(head, env) do
+      {:bool, false} -> eval_or(rest, env)
+      v -> v
+    end
+  end
+
+  defp eval_or(_, _env), do: raise(Error, reason: {:bad_special_form, "or"})
+
+  # ---------------------------------------------------------------------------
+  # when / unless
+  # ---------------------------------------------------------------------------
+
+  defp eval_when({:pair, test, body}, env) when body != :null do
+    if Value.truthy?(eval(test, env)) do
+      eval_sequence(body, env)
+    else
+      :unspecified
+    end
+  end
+
+  defp eval_when(_, _env), do: raise(Error, reason: {:bad_special_form, "when"})
+
+  defp eval_unless({:pair, test, body}, env) when body != :null do
+    if Value.truthy?(eval(test, env)) do
+      :unspecified
+    else
+      eval_sequence(body, env)
+    end
+  end
+
+  defp eval_unless(_, _env), do: raise(Error, reason: {:bad_special_form, "unless"})
+
+  # ---------------------------------------------------------------------------
+  # cond — supports (test), (test expr ...), (test => proc), (else expr ...).
+  # ---------------------------------------------------------------------------
+
+  defp eval_cond(:null, _env), do: :unspecified
+
+  defp eval_cond({:pair, {:pair, {:sym, "else"}, body}, _rest}, env) when body != :null do
+    eval_sequence(body, env)
+  end
+
+  defp eval_cond({:pair, {:pair, {:sym, "else"}, _}, _}, _env) do
+    raise(Error, reason: {:bad_special_form, "cond"})
+  end
+
+  defp eval_cond({:pair, {:pair, test, {:pair, {:sym, "=>"}, {:pair, recv, :null}}}, rest}, env) do
+    value = eval(test, env)
+
+    if Value.truthy?(value) do
+      proc = eval(recv, env)
+      apply_proc(proc, [value])
+    else
+      eval_cond(rest, env)
+    end
+  end
+
+  defp eval_cond({:pair, {:pair, test, :null}, rest}, env) do
+    case eval(test, env) do
+      {:bool, false} -> eval_cond(rest, env)
+      v -> v
+    end
+  end
+
+  defp eval_cond({:pair, {:pair, test, body}, rest}, env) do
+    if Value.truthy?(eval(test, env)) do
+      eval_sequence(body, env)
+    else
+      eval_cond(rest, env)
+    end
+  end
+
+  defp eval_cond(_, _env), do: raise(Error, reason: {:bad_special_form, "cond"})
+
+  # ---------------------------------------------------------------------------
+  # case — keys matched with `eqv?`. `(else expr ...)` and `(keys => proc)`
+  # supported. Empty key list never matches (it falls through).
+  # ---------------------------------------------------------------------------
+
+  defp eval_case({:pair, key_expr, clauses}, env) do
+    eval_case_clauses(eval(key_expr, env), clauses, env)
+  end
+
+  defp eval_case(_, _env), do: raise(Error, reason: {:bad_special_form, "case"})
+
+  defp eval_case_clauses(_key, :null, _env), do: :unspecified
+
+  defp eval_case_clauses(key, {:pair, {:pair, {:sym, "else"}, body}, _rest}, env)
+       when body != :null do
+    case body do
+      {:pair, {:sym, "=>"}, {:pair, recv, :null}} ->
+        apply_proc(eval(recv, env), [key])
+
+      _ ->
+        eval_sequence(body, env)
+    end
+  end
+
+  defp eval_case_clauses(key, {:pair, {:pair, keys, body}, rest}, env) do
+    if case_match?(key, keys) do
+      case body do
+        {:pair, {:sym, "=>"}, {:pair, recv, :null}} ->
+          apply_proc(eval(recv, env), [key])
+
+        :null ->
+          raise(Error, reason: {:bad_special_form, "case"})
+
+        _ ->
+          eval_sequence(body, env)
+      end
+    else
+      eval_case_clauses(key, rest, env)
+    end
+  end
+
+  defp eval_case_clauses(_key, _, _env), do: raise(Error, reason: {:bad_special_form, "case"})
+
+  defp case_match?(_key, :null), do: false
+
+  defp case_match?(key, {:pair, datum, rest}) do
+    Value.eqv?(key, datum) or case_match?(key, rest)
+  end
+
+  defp case_match?(_key, _), do: raise(Error, reason: {:bad_special_form, "case"})
+
+  # ---------------------------------------------------------------------------
+  # let — including the named-let recursion form.
+  # ---------------------------------------------------------------------------
+
+  defp eval_let({:pair, {:sym, name}, {:pair, bindings_form, body}}, env)
+       when body != :null do
+    eval_named_let(name, bindings_form, body, env)
+  end
+
+  defp eval_let({:pair, bindings_form, body}, env) when body != :null do
+    {names, inits} = parse_bindings(bindings_form, "let")
+    values = Enum.map(inits, &eval(&1, env))
+    eval_sequence(body, Env.extend(env, Enum.zip(names, values)))
+  end
+
+  defp eval_let(_, _env), do: raise(Error, reason: {:bad_special_form, "let"})
+
+  defp eval_named_let(name, bindings_form, body, env) do
+    {param_names, inits} = parse_bindings(bindings_form, "let")
+    values = Enum.map(inits, &eval(&1, env))
+
+    rec_env = Env.extend_rec(env, [name])
+    closure = Value.closure({:fixed, length(param_names), param_names}, body, rec_env, name)
+    Env.rec_set(rec_env, name, closure)
+
+    apply_proc(closure, values)
+  end
+
+  defp eval_let_star({:pair, bindings_form, body}, env) when body != :null do
+    {names, inits} = parse_bindings(bindings_form, "let*")
+
+    new_env =
+      names
+      |> Enum.zip(inits)
+      |> Enum.reduce(env, fn {name, init}, e ->
+        Env.extend(e, [{name, eval(init, e)}])
+      end)
+
+    eval_sequence(body, new_env)
+  end
+
+  defp eval_let_star(_, _env), do: raise(Error, reason: {:bad_special_form, "let*"})
+
+  # `letrec` and `letrec*` share an implementation. r7rs allows
+  # `letrec` to be implemented as `letrec*`; the only difference is the
+  # spec leaves init evaluation order unspecified for `letrec`.
+  defp eval_letrec_star({:pair, bindings_form, body}, env) when body != :null do
+    {names, inits} = parse_bindings(bindings_form, "letrec*")
+    rec_env = Env.extend_rec(env, names)
+
+    names
+    |> Enum.zip(inits)
+    |> Enum.each(fn {name, init} ->
+      Env.rec_set(rec_env, name, eval(init, rec_env))
+    end)
+
+    eval_sequence(body, rec_env)
+  end
+
+  defp eval_letrec_star(_, _env), do: raise(Error, reason: {:bad_special_form, "letrec*"})
+
+  defp parse_bindings(form, ctx), do: parse_bindings(form, ctx, [], [])
+
+  defp parse_bindings(:null, _ctx, names, inits) do
+    {Enum.reverse(names), Enum.reverse(inits)}
+  end
+
+  defp parse_bindings({:pair, {:pair, {:sym, name}, {:pair, init, :null}}, rest}, ctx, ns, is) do
+    parse_bindings(rest, ctx, [name | ns], [init | is])
+  end
+
+  defp parse_bindings(_, ctx, _, _), do: raise(Error, reason: {:bad_special_form, ctx})
+
+  # ---------------------------------------------------------------------------
+  # do — iteration with stepped variables and a termination test.
+  # ---------------------------------------------------------------------------
+
+  defp eval_do({:pair, bindings_form, {:pair, test_form, body}}, env) do
+    {names, inits, steps} = parse_do_bindings(bindings_form)
+    {test, results} = parse_do_test(test_form)
+
+    init_values = Enum.map(inits, &eval(&1, env))
+    loop_env = Env.extend(env, Enum.zip(names, init_values))
+    do_loop(names, steps, test, results, body, loop_env)
+  end
+
+  defp eval_do(_, _env), do: raise(Error, reason: {:bad_special_form, "do"})
+
+  defp do_loop(names, steps, test, results, body, env) do
+    if Value.truthy?(eval(test, env)) do
+      eval_sequence(results, env)
+    else
+      _ = eval_sequence(body, env)
+      step_values = Enum.map(steps, &eval(&1, env))
+      next_env = Env.extend(pop_lex(env), Enum.zip(names, step_values))
+      do_loop(names, steps, test, results, body, next_env)
+    end
+  end
+
+  defp pop_lex(%Env{lex: [_top | rest]} = env), do: %{env | lex: rest}
+
+  defp parse_do_bindings(:null), do: {[], [], []}
+
+  defp parse_do_bindings({:pair, {:pair, {:sym, name}, {:pair, init, rest_step}}, rest}) do
+    {ns, is, ss} = parse_do_bindings(rest)
+    step = parse_do_step(name, rest_step)
+    {[name | ns], [init | is], [step | ss]}
+  end
+
+  defp parse_do_bindings(_), do: raise(Error, reason: {:bad_special_form, "do"})
+
+  defp parse_do_step(name, :null), do: Value.symbol(name)
+  defp parse_do_step(_name, {:pair, step, :null}), do: step
+  defp parse_do_step(_name, _), do: raise(Error, reason: {:bad_special_form, "do"})
+
+  defp parse_do_test({:pair, test, results}), do: {test, results}
+  defp parse_do_test(_), do: raise(Error, reason: {:bad_special_form, "do"})
+
+  # ---------------------------------------------------------------------------
+  # quasiquote — recursive expansion with nested-level tracking.
+  # `unquote` and `unquote-splicing` only fire at level 1; nested
+  # quasiquotes raise the level, nested unquotes lower it.
+  # ---------------------------------------------------------------------------
+
+  defp eval_quasiquote_top({:pair, datum, :null}, env) do
+    quasi(datum, env, 1)
+  end
+
+  defp eval_quasiquote_top(_, _env), do: raise(Error, reason: {:bad_special_form, "quasiquote"})
+
+  defp quasi({:pair, {:sym, "unquote"}, {:pair, expr, :null}}, env, 1), do: eval(expr, env)
+
+  defp quasi({:pair, {:sym, "unquote"}, {:pair, expr, :null}}, env, n) when n > 1 do
+    Value.list([Value.symbol("unquote"), quasi(expr, env, n - 1)])
+  end
+
+  defp quasi({:pair, {:sym, "quasiquote"}, {:pair, expr, :null}}, env, n) do
+    Value.list([Value.symbol("quasiquote"), quasi(expr, env, n + 1)])
+  end
+
+  defp quasi({:pair, head, tail}, env, level) do
+    case head do
+      {:pair, {:sym, "unquote-splicing"}, {:pair, expr, :null}} when level == 1 ->
+        spliced = eval(expr, env)
+        rest = quasi(tail, env, level)
+        splice_append(spliced, rest, "unquote-splicing")
+
+      _ ->
+        {:pair, quasi(head, env, level), quasi(tail, env, level)}
+    end
+  end
+
+  defp quasi({:vector, t}, env, level) do
+    list = Value.list(Tuple.to_list(t))
+
+    case quasi(list, env, level) do
+      {:pair, _, _} = pair -> {:vector, List.to_tuple(scheme_list_to_elixir(pair))}
+      :null -> {:vector, {}}
+    end
+  end
+
+  defp quasi(other, _env, _level), do: other
+
+  defp splice_append(:null, rest, _ctx), do: rest
+
+  defp splice_append({:pair, h, t}, rest, ctx) do
+    {:pair, h, splice_append(t, rest, ctx)}
+  end
+
+  defp splice_append(_, _, ctx), do: raise(Error, reason: {:bad_special_form, ctx})
+
+  defp scheme_list_to_elixir(:null), do: []
+  defp scheme_list_to_elixir({:pair, h, t}), do: [h | scheme_list_to_elixir(t)]
 end

--- a/test/conformance/r7rs_section_4_test.exs
+++ b/test/conformance/r7rs_section_4_test.exs
@@ -1,0 +1,393 @@
+defmodule Schooner.Conformance.R7rsSection4Test do
+  # Worked examples from r7rs-small §4 (expressions). Each test
+  # transcribes a `(form) ==> result` example from the spec verbatim;
+  # any deviation is a conformance failure.
+  #
+  # Examples requiring features not yet in Schooner are skipped with
+  # a one-line reason so phase 15's conformance pass can sweep them
+  # back in once the dependencies land:
+  #   - mutation (set!, vector-set!, string-set!): out of scope
+  #   - internal define / body splicing: phase 8
+  #   - multi-value returns (let-values, let*-values): later
+  #   - delayed evaluation (delay, force, make-promise): phase 13
+  #   - dynamic bindings (parameterize, make-parameter): out of scope
+  #   - exception handling (guard, raise): phase 11
+  #   - I/O (display, write, newline): host-injected; not in default env
+  use ExUnit.Case, async: true
+
+  alias Schooner.Value
+
+  defp run(source), do: Schooner.run(source)
+
+  # --- §4.1.2 — Literal expressions -----------------------------------------
+
+  describe "§4.1.2 literal expressions" do
+    test "(quote a) ==> a" do
+      assert run("(quote a)") == Value.symbol("a")
+    end
+
+    test "'a ==> a" do
+      assert run("'a") == Value.symbol("a")
+    end
+
+    test "'#(a b c) ==> #(a b c)" do
+      assert run("'#(a b c)") ==
+               Value.vector([Value.symbol("a"), Value.symbol("b"), Value.symbol("c")])
+    end
+
+    test "'() ==> ()" do
+      assert run("'()") == :null
+    end
+
+    test "'(+ 1 2) ==> (+ 1 2)" do
+      assert run("'(+ 1 2)") == Value.list([Value.symbol("+"), 1, 2])
+    end
+
+    test "'(quote a) ==> (quote a)" do
+      assert run("'(quote a)") == Value.list([Value.symbol("quote"), Value.symbol("a")])
+    end
+
+    test "''a ==> (quote a)" do
+      assert run("''a") == Value.list([Value.symbol("quote"), Value.symbol("a")])
+    end
+
+    test ~S|'"abc" ==> "abc"| do
+      assert run(~S|'"abc"|) == Value.string("abc")
+    end
+
+    test ~S|"abc" ==> "abc"| do
+      assert run(~S|"abc"|) == Value.string("abc")
+    end
+
+    test "145932 ==> 145932" do
+      assert run("145932") == 145_932
+    end
+
+    test "'145932 ==> 145932" do
+      assert run("'145932") == 145_932
+    end
+
+    test "#t ==> #t" do
+      assert run("#t") == Value.bool(true)
+    end
+
+    test "'#t ==> #t" do
+      assert run("'#t") == Value.bool(true)
+    end
+  end
+
+  # --- §4.1.3 — Procedure calls ---------------------------------------------
+
+  describe "§4.1.3 procedure calls" do
+    test "(+ 3 4) ==> 7" do
+      assert run("(+ 3 4)") == 7
+    end
+
+    test "((if #f + *) 3 4) ==> 12" do
+      assert run("((if #f + *) 3 4)") == 12
+    end
+  end
+
+  # --- §4.1.4 — Procedures --------------------------------------------------
+
+  describe "§4.1.4 procedures" do
+    test "(lambda (x) (+ x x)) evaluates to a procedure" do
+      assert match?({:closure, _, _, _, _}, run("(lambda (x) (+ x x))"))
+    end
+
+    test "((lambda (x) (+ x x)) 4) ==> 8" do
+      assert run("((lambda (x) (+ x x)) 4)") == 8
+    end
+
+    # Spec uses (define reverse-subtract …); phrased here as let to keep the
+    # example self-contained without leaning on top-level define.
+    test "let-bound reverse-subtract: (reverse-subtract 7 10) ==> 3" do
+      assert run("""
+             (let ((reverse-subtract (lambda (x y) (- y x))))
+               (reverse-subtract 7 10))
+             """) == 3
+    end
+
+    # Spec example: (define add4 (let ((x 4)) (lambda (y) (+ x y))))
+    test "closure-based add4: (add4 6) ==> 10" do
+      assert run("""
+             (let ((add4 (let ((x 4)) (lambda (y) (+ x y)))))
+               (add4 6))
+             """) == 10
+    end
+
+    test "((lambda x x) 3 4 5 6) ==> (3 4 5 6)" do
+      assert run("((lambda x x) 3 4 5 6)") == Value.list([3, 4, 5, 6])
+    end
+
+    test "((lambda (x y . z) z) 3 4 5 6) ==> (5 6)" do
+      assert run("((lambda (x y . z) z) 3 4 5 6)") == Value.list([5, 6])
+    end
+  end
+
+  # --- §4.1.5 — Conditionals ------------------------------------------------
+
+  describe "§4.1.5 if" do
+    test "(if (> 3 2) 'yes 'no) ==> yes" do
+      assert run("(if (> 3 2) 'yes 'no)") == Value.symbol("yes")
+    end
+
+    test "(if (> 2 3) 'yes 'no) ==> no" do
+      assert run("(if (> 2 3) 'yes 'no)") == Value.symbol("no")
+    end
+
+    test "(if (> 3 2) (- 3 2) (+ 3 2)) ==> 1" do
+      assert run("(if (> 3 2) (- 3 2) (+ 3 2))") == 1
+    end
+  end
+
+  # --- §4.2.1 — Conditionals (derived) --------------------------------------
+
+  describe "§4.2.1 cond" do
+    test "(cond ((> 3 2) 'greater) ((< 3 2) 'less)) ==> greater" do
+      assert run("(cond ((> 3 2) 'greater) ((< 3 2) 'less))") == Value.symbol("greater")
+    end
+
+    test "(cond ((> 3 3) 'greater) ((< 3 3) 'less) (else 'equal)) ==> equal" do
+      assert run("(cond ((> 3 3) 'greater) ((< 3 3) 'less) (else 'equal))") ==
+               Value.symbol("equal")
+    end
+
+    test "(cond ((assv 'b '((a 1) (b 2))) => cadr) (else #f)) ==> 2" do
+      assert run("(cond ((assv 'b '((a 1) (b 2))) => cadr) (else #f))") == 2
+    end
+  end
+
+  describe "§4.2.1 case" do
+    test "(case (* 2 3) ((2 3 5 7) 'prime) ((1 4 6 8 9) 'composite)) ==> composite" do
+      assert run("(case (* 2 3) ((2 3 5 7) 'prime) ((1 4 6 8 9) 'composite))") ==
+               Value.symbol("composite")
+    end
+
+    test "(case (car '(c d)) ((a) 'a) ((b) 'b)) ==> unspecified" do
+      assert run("(case (car '(c d)) ((a) 'a) ((b) 'b))") == :unspecified
+    end
+
+    test "case with else => arrow returns the key" do
+      assert run("""
+             (case (car '(c d))
+               ((a e i o u) 'vowel)
+               ((w y) 'semivowel)
+               (else => (lambda (x) x)))
+             """) == Value.symbol("c")
+    end
+  end
+
+  describe "§4.2.1 and" do
+    test "(and (= 2 2) (> 2 1)) ==> #t" do
+      assert run("(and (= 2 2) (> 2 1))") == Value.bool(true)
+    end
+
+    test "(and (= 2 2) (< 2 1)) ==> #f" do
+      assert run("(and (= 2 2) (< 2 1))") == Value.bool(false)
+    end
+
+    test "(and 1 2 'c '(f g)) ==> (f g)" do
+      assert run("(and 1 2 'c '(f g))") == Value.list([Value.symbol("f"), Value.symbol("g")])
+    end
+
+    test "(and) ==> #t" do
+      assert run("(and)") == Value.bool(true)
+    end
+  end
+
+  describe "§4.2.1 or" do
+    test "(or (= 2 2) (> 2 1)) ==> #t" do
+      assert run("(or (= 2 2) (> 2 1))") == Value.bool(true)
+    end
+
+    test "(or (= 2 2) (< 2 1)) ==> #t" do
+      assert run("(or (= 2 2) (< 2 1))") == Value.bool(true)
+    end
+
+    test "(or #f #f #f) ==> #f" do
+      assert run("(or #f #f #f)") == Value.bool(false)
+    end
+
+    test "(or (memq 'b '(a b c)) (/ 3 0)) ==> (b c) — short-circuits before the divide" do
+      assert run("(or (memq 'b '(a b c)) (/ 3 0))") ==
+               Value.list([Value.symbol("b"), Value.symbol("c")])
+    end
+  end
+
+  # §4.2.1 when/unless: spec examples use display side-effects; we check the
+  # return value (:unspecified on the dispatched branch) without I/O.
+  describe "§4.2.1 when / unless" do
+    test "when on a truthy test runs the body and returns its last value" do
+      assert run("(when (= 1 1) 'a 'b)") == Value.symbol("b")
+    end
+
+    test "when on a falsy test returns :unspecified" do
+      assert run("(when (= 1 2) 'a 'b)") == :unspecified
+    end
+
+    test "unless mirrors when" do
+      assert run("(unless (= 1 2) 'a 'b)") == Value.symbol("b")
+      assert run("(unless (= 1 1) 'a 'b)") == :unspecified
+    end
+  end
+
+  # --- §4.2.2 — Binding constructs ------------------------------------------
+
+  describe "§4.2.2 let" do
+    test "(let ((x 2) (y 3)) (* x y)) ==> 6" do
+      assert run("(let ((x 2) (y 3)) (* x y))") == 6
+    end
+
+    test "nested let with init expressions in the outer scope" do
+      assert run("""
+             (let ((x 2) (y 3))
+               (let ((x 7)
+                     (z (+ x y)))
+                 (* z x)))
+             """) == 35
+    end
+  end
+
+  describe "§4.2.2 let*" do
+    test "let* lets later bindings see earlier ones" do
+      assert run("""
+             (let ((x 2) (y 3))
+               (let* ((x 7)
+                      (z (+ x y)))
+                 (* z x)))
+             """) == 70
+    end
+  end
+
+  describe "§4.2.2 letrec" do
+    test "mutually recursive even?/odd? via letrec ==> #t" do
+      assert run("""
+             (letrec ((even?
+                       (lambda (n)
+                         (if (zero? n) #t (odd? (- n 1)))))
+                      (odd?
+                       (lambda (n)
+                         (if (zero? n) #f (even? (- n 1))))))
+               (even? 88))
+             """) == Value.bool(true)
+    end
+  end
+
+  describe "§4.2.2 letrec*" do
+    test "letrec* preserves left-to-right init order with forward closures" do
+      assert run("""
+             (letrec* ((p (lambda (x) (+ 1 (q (- x 1)))))
+                       (q (lambda (y) (if (zero? y) 0 (+ 1 (p (- y 1))))))
+                       (x (p 5))
+                       (y x))
+               y)
+             """) == 5
+    end
+  end
+
+  # --- §4.2.4 — Iteration ---------------------------------------------------
+
+  # The spec's first do example uses vector-set!, which is excluded by
+  # Schooner's no-mutation constraint. The second example below sums a list.
+  describe "§4.2.4 do" do
+    test "summing a list with do ==> 25" do
+      assert run("""
+             (let ((x '(1 3 5 7 9)))
+               (do ((x x (cdr x))
+                    (sum 0 (+ sum (car x))))
+                   ((null? x) sum)))
+             """) == 25
+    end
+  end
+
+  describe "§4.2.4 named let" do
+    test "partition into nonneg/neg lists" do
+      assert run("""
+             (let loop ((numbers '(3 -2 1 6 -5))
+                        (nonneg '())
+                        (neg '()))
+               (cond ((null? numbers) (list nonneg neg))
+                     ((>= (car numbers) 0)
+                      (loop (cdr numbers)
+                            (cons (car numbers) nonneg)
+                            neg))
+                     ((< (car numbers) 0)
+                      (loop (cdr numbers)
+                            nonneg
+                            (cons (car numbers) neg)))))
+             """) ==
+               Value.list([
+                 Value.list([6, 1, 3]),
+                 Value.list([-5, -2])
+               ])
+    end
+  end
+
+  # --- §4.2.8 — Quasiquotation ----------------------------------------------
+
+  describe "§4.2.8 quasiquote" do
+    test "`(list ,(+ 1 2) 4) ==> (list 3 4)" do
+      assert run("`(list ,(+ 1 2) 4)") == Value.list([Value.symbol("list"), 3, 4])
+    end
+
+    test "(let ((name 'a)) `(list ,name ',name)) ==> (list a (quote a))" do
+      assert run("(let ((name 'a)) `(list ,name ',name))") ==
+               Value.list([
+                 Value.symbol("list"),
+                 Value.symbol("a"),
+                 Value.list([Value.symbol("quote"), Value.symbol("a")])
+               ])
+    end
+
+    test "`(a ,(+ 1 2) ,@(map abs '(4 -5 6)) b) ==> (a 3 4 5 6 b)" do
+      assert run("`(a ,(+ 1 2) ,@(map abs '(4 -5 6)) b)") ==
+               Value.list([Value.symbol("a"), 3, 4, 5, 6, Value.symbol("b")])
+    end
+
+    test "`#(10 5 ,(* 2 3) ,@(map + '(2 3) '(2 3)) 8) ==> #(10 5 6 4 6 8)" do
+      assert run("`#(10 5 ,(* 2 3) ,@(map + '(2 3) '(2 3)) 8)") ==
+               Value.vector([10, 5, 6, 4, 6, 8])
+    end
+
+    test "nested quasiquote — inner unquote stays at level 2 unchanged" do
+      assert run("`(a `(b ,(+ 1 2) ,(foo ,(+ 1 3) d) e) f)") ==
+               Value.list([
+                 Value.symbol("a"),
+                 Value.list([
+                   Value.symbol("quasiquote"),
+                   Value.list([
+                     Value.symbol("b"),
+                     Value.list([Value.symbol("unquote"), Value.list([Value.symbol("+"), 1, 2])]),
+                     Value.list([
+                       Value.symbol("unquote"),
+                       Value.list([Value.symbol("foo"), 4, Value.symbol("d")])
+                     ]),
+                     Value.symbol("e")
+                   ])
+                 ]),
+                 Value.symbol("f")
+               ])
+    end
+
+    test "double-comma collapses two levels — inner ,, fires at the inner quasi" do
+      assert run("(let ((name1 'x) (name2 'y)) `(a `(b ,,name1 ,',name2 d) e))") ==
+               Value.list([
+                 Value.symbol("a"),
+                 Value.list([
+                   Value.symbol("quasiquote"),
+                   Value.list([
+                     Value.symbol("b"),
+                     Value.list([Value.symbol("unquote"), Value.symbol("x")]),
+                     Value.list([
+                       Value.symbol("unquote"),
+                       Value.list([Value.symbol("quote"), Value.symbol("y")])
+                     ]),
+                     Value.symbol("d")
+                   ])
+                 ]),
+                 Value.symbol("e")
+               ])
+    end
+  end
+end

--- a/test/schooner/eval_derived_test.exs
+++ b/test/schooner/eval_derived_test.exs
@@ -1,0 +1,314 @@
+defmodule Schooner.EvalDerivedTest do
+  # Phase 7 — derived forms (cond, case, when, unless, and, or, let,
+  # let*, letrec, letrec*, named let, do, quasiquote) implemented
+  # directly in the evaluator. Per the plan, these tests are kept
+  # verbatim through phase 9 and re-run after the macro expander
+  # replaces the throwaway implementations — failures there mean the
+  # macroified versions disagree with this oracle.
+  use ExUnit.Case, async: true
+
+  alias Schooner.Eval.Error
+  alias Schooner.Value
+
+  defp run(source), do: Schooner.run(source)
+
+  describe "and / or" do
+    test "(and) returns #t and (or) returns #f" do
+      assert run("(and)") == Value.bool(true)
+      assert run("(or)") == Value.bool(false)
+    end
+
+    test "and short-circuits on #f and returns #f" do
+      assert run("(and 1 #f 2)") == Value.bool(false)
+    end
+
+    test "and returns the last value when nothing is false" do
+      assert run("(and 1 2 3)") == 3
+    end
+
+    test "or short-circuits on the first truthy value and returns it" do
+      assert run("(or #f #f 7 8)") == 7
+    end
+
+    test "or with no truthies returns #f" do
+      assert run("(or #f #f)") == Value.bool(false)
+    end
+
+    test "and treats only #f as false; '() and 0 are truthy" do
+      assert run("(and '() 0 1)") == 1
+    end
+  end
+
+  describe "when / unless" do
+    test "when evaluates body when test is truthy" do
+      assert run("(when #t 1 2 3)") == 3
+    end
+
+    test "when returns :unspecified on falsy test" do
+      assert run("(when #f 1 2 3)") == :unspecified
+    end
+
+    test "unless mirrors when" do
+      assert run("(unless #f 1 2 3)") == 3
+      assert run("(unless #t 1 2 3)") == :unspecified
+    end
+
+    test "malformed when raises" do
+      e = assert_raise Error, fn -> run("(when #t)") end
+      assert e.reason == {:bad_special_form, "when"}
+    end
+  end
+
+  describe "cond" do
+    test "selects the first truthy clause's body" do
+      assert run("(cond (#f 1) (#t 2) (else 3))") == 2
+    end
+
+    test "else branch fires when no test matches" do
+      assert run("(cond (#f 1) (#f 2) (else 99))") == 99
+    end
+
+    test "single-test clause returns the test value" do
+      assert run("(cond (42))") == 42
+    end
+
+    test "with no matching clause and no else, returns :unspecified" do
+      assert run("(cond (#f 1) (#f 2))") == :unspecified
+    end
+
+    test "=> arrow form passes the test value to the receiver" do
+      assert run("(cond ((+ 1 2) => (lambda (x) (* x 10))))") == 30
+    end
+
+    test "=> does not fire when the test is false" do
+      assert run("(cond (#f => (lambda (x) (* x 10))) (else 'fallback))") ==
+               Value.symbol("fallback")
+    end
+
+    test "malformed cond raises" do
+      e = assert_raise Error, fn -> run("(cond ())") end
+      assert e.reason == {:bad_special_form, "cond"}
+    end
+  end
+
+  describe "case" do
+    test "matches the first clause whose key list contains the value (eqv?)" do
+      assert run("(case 2 ((1) 'one) ((2 3) 'two-or-three) (else 'other))") ==
+               Value.symbol("two-or-three")
+    end
+
+    test "else fires when nothing matches" do
+      assert run("(case 99 ((1) 'one) (else 'fallback))") == Value.symbol("fallback")
+    end
+
+    test "with no else and no match, returns :unspecified" do
+      assert run("(case 99 ((1) 'one))") == :unspecified
+    end
+
+    test "=> arrow receives the key value" do
+      assert run("(case 5 ((5) => (lambda (k) (* k k))) (else 0))") == 25
+    end
+
+    test "else => arrow receives the key value" do
+      assert run("(case 7 ((1) 'one) (else => (lambda (k) (+ k 100))))") == 107
+    end
+
+    test "match uses eqv?: integers and floats with the same value do not match" do
+      assert run("(case 1.0 ((1) 'int) (else 'no))") == Value.symbol("no")
+    end
+
+    test "symbols match by value" do
+      assert run("(case 'b ((a) 1) ((b c) 2) (else 3))") == 2
+    end
+  end
+
+  describe "let" do
+    test "binds names visible in the body" do
+      assert run("(let ((x 1) (y 2)) (+ x y))") == 3
+    end
+
+    test "init expressions are evaluated in the outer environment" do
+      assert run("(let ((x 1)) (let ((x 2) (y x)) y))") == 1
+    end
+
+    test "empty bindings are allowed" do
+      assert run("(let () 42)") == 42
+    end
+
+    test "binding shadows outer" do
+      assert run("(let ((x 1)) (let ((x 99)) x))") == 99
+    end
+
+    test "malformed let raises" do
+      e = assert_raise Error, fn -> run("(let bad-bindings 1)") end
+      assert e.reason == {:bad_special_form, "let"}
+    end
+  end
+
+  describe "let*" do
+    test "later bindings see earlier ones" do
+      assert run("(let* ((x 1) (y (+ x 1)) (z (* y 10))) z)") == 20
+    end
+
+    test "empty bindings allowed" do
+      assert run("(let* () 7)") == 7
+    end
+  end
+
+  describe "letrec / letrec*" do
+    test "letrec supports mutually recursive lambdas" do
+      assert run("""
+             (letrec ((even? (lambda (n) (if (= n 0) #t (odd? (- n 1)))))
+                      (odd?  (lambda (n) (if (= n 0) #f (even? (- n 1))))))
+               (even? 10))
+             """) == Value.bool(true)
+    end
+
+    test "letrec*: forward reference within an init resolves once the frame is populated" do
+      assert run("""
+             (letrec* ((f (lambda (n) (if (= n 0) 0 (g (- n 1)))))
+                       (g (lambda (n) (f n))))
+               (f 3))
+             """) == 0
+    end
+
+    test "letrec body sees all bindings" do
+      assert run("""
+             (letrec ((x 1) (y 2))
+               (+ x y))
+             """) == 3
+    end
+
+    test "letrec* evaluation is left to right" do
+      # b's init refers to a (already bound) but not c (not yet bound).
+      assert run("""
+             (letrec* ((a 1) (b (+ a 10)) (c (+ b 100)))
+               (list a b c))
+             """) == Value.list([1, 11, 111])
+    end
+  end
+
+  describe "named let" do
+    test "factorial via named let" do
+      assert run("""
+             (let loop ((n 5) (acc 1))
+               (if (= n 0) acc (loop (- n 1) (* acc n))))
+             """) == 120
+    end
+
+    test "fibonacci via named let" do
+      assert run("""
+             (let fib ((n 10))
+               (if (< n 2) n (+ (fib (- n 1)) (fib (- n 2)))))
+             """) == 55
+    end
+
+    test "named let does not leak its name into the outer scope" do
+      assert run("""
+             (let outer ((x 1)) x)
+             (define has-outer
+               (lambda () (cond ((eqv? 1 1) 'ok) (else 'no))))
+             (has-outer)
+             """) == Value.symbol("ok")
+    end
+  end
+
+  describe "do" do
+    test "basic counting loop" do
+      assert run("""
+             (do ((i 0 (+ i 1))
+                  (acc 0 (+ acc i)))
+                 ((= i 5) acc))
+             """) == 10
+    end
+
+    test "do without an explicit step keeps the variable unchanged" do
+      assert run("""
+             (do ((i 0 (+ i 1))
+                  (limit 3))
+                 ((= i limit) 'done))
+             """) == Value.symbol("done")
+    end
+
+    test "do with no result expressions returns :unspecified" do
+      assert run("""
+             (do ((i 0 (+ i 1))) ((= i 1)))
+             """) == :unspecified
+    end
+
+    test "do body executes for side effect (counts via let-bound counter unsupported, " <>
+           "but body forms are evaluated)" do
+      # Without mutation we can't observe side effects; instead we
+      # exercise that the body is at least dispatched without raising.
+      assert run("""
+             (do ((i 0 (+ i 1))) ((= i 3) i)
+               (+ i 1)
+               (- i 1))
+             """) == 3
+    end
+  end
+
+  describe "quasiquote" do
+    test "trivial quasiquote of a literal returns it" do
+      assert run("`5") == 5
+      assert run("`foo") == Value.symbol("foo")
+      assert run("`()") == :null
+    end
+
+    test "unquote splices a single value into a list" do
+      assert run("`(1 ,(+ 2 3) 4)") == Value.list([1, 5, 4])
+    end
+
+    test "unquote-splicing splices a list into the surrounding list" do
+      assert run("`(1 ,@(list 2 3 4) 5)") == Value.list([1, 2, 3, 4, 5])
+    end
+
+    test "unquote-splicing of an empty list disappears" do
+      assert run("`(1 ,@'() 2)") == Value.list([1, 2])
+    end
+
+    test "nested quasiquote raises the level; unquote inside nested level only fires at depth 1" do
+      assert run("`(a `(b ,(c)))") ==
+               Value.list([
+                 Value.symbol("a"),
+                 Value.list([
+                   Value.symbol("quasiquote"),
+                   Value.list([
+                     Value.symbol("b"),
+                     Value.list([Value.symbol("unquote"), Value.list([Value.symbol("c")])])
+                   ])
+                 ])
+               ])
+    end
+
+    test "unquote inside a nested quasiquote fires at the innermost level only" do
+      assert run("`(a `(b ,,(+ 1 2)))") ==
+               Value.list([
+                 Value.symbol("a"),
+                 Value.list([
+                   Value.symbol("quasiquote"),
+                   Value.list([
+                     Value.symbol("b"),
+                     Value.list([Value.symbol("unquote"), 3])
+                   ])
+                 ])
+               ])
+    end
+
+    test "vector quasiquote with unquote" do
+      assert run("`#(1 ,(+ 1 1) 3)") == Value.vector([1, 2, 3])
+    end
+
+    test "vector quasiquote with unquote-splicing" do
+      assert run("`#(1 ,@(list 2 3) 4)") == Value.vector([1, 2, 3, 4])
+    end
+
+    test "improper quasiquoted lists preserve their dotted tail" do
+      assert run("`(1 ,(+ 1 1) . 3)") == {:pair, 1, {:pair, 2, 3}}
+    end
+
+    test "splicing a non-list raises" do
+      assert_raise Error, fn -> run("`(1 ,@5 2)") end
+    end
+  end
+end

--- a/test/schooner/eval_tco_test.exs
+++ b/test/schooner/eval_tco_test.exs
@@ -99,4 +99,23 @@ defmodule Schooner.EvalTcoTest do
              """) == Value.bool(true)
     end)
   end
+
+  test "named let recurses tail-call style at depth" do
+    assert_bounded_heap(fn ->
+      assert run!("""
+             (let loop ((n #{depth()}))
+               (if (zero-int? n) 'done (loop (sub1 n))))
+             """) == Value.symbol("done")
+    end)
+  end
+
+  test "letrec-bound mutually recursive lambdas tail-call at depth" do
+    assert_bounded_heap(fn ->
+      assert run!("""
+             (letrec ((even? (lambda (n) (if (zero-int? n) #t (odd? (sub1 n)))))
+                      (odd?  (lambda (n) (if (zero-int? n) #f (even? (sub1 n))))))
+               (even? #{depth()}))
+             """) == Value.bool(true)
+    end)
+  end
 end


### PR DESCRIPTION
## Summary
- Adds the throwaway derived-form layer to the evaluator: `and`/`or`, `when`/`unless`, `cond` (incl. `=>`), `case` (incl. `=>` and `else`), `let`/`let*`/`letrec`/`letrec*`, named `let`, `do`, and `quasiquote` (with nested-level tracking, vector quasi, and splicing).
- Each special form lands as its own `eval/2` clause so the tail call to its helper stays direct — TCO invariant preserved. Two new 100k-depth TCO regressions cover named `let` and letrec-bound mutual recursion.
- `Env.extend_rec/2` and `rec_set/3` introduce a per-letrec ETS-backed frame so mutually recursive lambdas resolve forward references by frame identity. Same machinery phase 8 will reuse for internal-define desugaring.
- `test/schooner/eval_derived_test.exs` (52 tests) is the per-form oracle the plan says phase 9 must re-run unchanged once the macroified replacements land.
- `test/conformance/r7rs_section_4_test.exs` (54 tests) transcribes the `==> result` worked examples from r7rs-small §4 verbatim. Skipped examples are documented inline with the phase that unlocks them (mutation excluded; internal define → phase 8; delay/force → phase 13; guard/raise → phase 11; I/O is host-injected).

Suite: 479 tests, 0 failures, credo clean.

## Test plan
- [x] `mix precommit` (compile-warn-as-errors, format, credo --strict, test)
- [x] `mix test test/schooner/eval_tco_test.exs` — 7 TCO regressions including named let + letrec mutual recursion at 100k depth
- [x] `mix test test/schooner/eval_derived_test.exs` — 52 per-form unit tests
- [x] `mix test test/conformance/r7rs_section_4_test.exs` — 54 r7rs §4 worked examples