### PR TITLE
Phase 8: internal defines and rec-frame slot cleanup

### DIFF
--- a/lib/schooner/env.ex
+++ b/lib/schooner/env.ex
@@ -14,15 +14,36 @@ defmodule Schooner.Env do
   The globals table is owned by the process that calls `new/0` and is
   GC'd when that process exits, so per-execution sandboxing falls out
   of the BEAM's process model.
+
+  ## Recursive lexical frames
+
+  `letrec`, `letrec*`, named `let`, and the `letrec*` produced by
+  internal-define splicing each push a *recursive* frame. A recursive
+  frame is a map of name → value backed by a process-dictionary slot
+  keyed by `make_ref/0`, so closures captured during init evaluation
+  see later bindings via frame identity.
+
+  Each such frame must be released by `release_rec/1` once the body of
+  the binding form finishes. The recommended pattern is to wrap the
+  body in `try ... after`. Closures that escape the body and continue
+  to reference recursive bindings after the slot is released will
+  raise — Schooner does not currently support that case.
   """
 
   alias Schooner.Value
+
+  # Sentinel held in a recursive frame for a binding whose init has
+  # not yet been evaluated. Distinct from any user-constructible value
+  # so a forward reference within an init can be flagged as a runtime
+  # error rather than silently returning `:unspecified`.
+  @rec_uninitialised :__schooner_rec_uninitialised__
 
   @enforce_keys [:globals, :lex]
   defstruct [:globals, :lex]
 
   @type frame :: %{optional(binary()) => Value.t()} | {:rec, reference()}
   @type t :: %__MODULE__{globals: :ets.tid(), lex: [frame()]}
+  @type lookup_result :: {:ok, Value.t()} | :error | {:uninitialised, binary()}
 
   @spec new() :: t()
   def new do
@@ -30,11 +51,18 @@ defmodule Schooner.Env do
     %__MODULE__{globals: table, lex: []}
   end
 
-  @doc "Look up `name`. Walks lexical frames innermost-first, then globals."
-  @spec lookup(t(), binary()) :: {:ok, Value.t()} | :error
+  @doc """
+  Look up `name`. Walks lexical frames innermost-first, then globals.
+
+  Returns `{:uninitialised, name}` when `name` is bound by an enclosing
+  recursive frame whose init expression has not yet been evaluated;
+  callers should treat this as a forward-reference runtime error.
+  """
+  @spec lookup(t(), binary()) :: lookup_result()
   def lookup(%__MODULE__{lex: lex, globals: globals}, name) when is_binary(name) do
     case lex_lookup(lex, name) do
       {:ok, _} = ok -> ok
+      {:uninitialised, _} = u -> u
       :error -> globals_lookup(globals, name)
     end
   end
@@ -43,6 +71,7 @@ defmodule Schooner.Env do
 
   defp lex_lookup([{:rec, ref} | rest], name) do
     case Map.fetch(Process.get(ref), name) do
+      {:ok, @rec_uninitialised} -> {:uninitialised, name}
       {:ok, _} = ok -> ok
       :error -> lex_lookup(rest, name)
     end
@@ -79,17 +108,23 @@ defmodule Schooner.Env do
   end
 
   @doc """
-  Push a fresh `letrec`-style frame whose bindings can be assigned later
-  via `rec_set/3`. Closures created against the returned env see the
-  bindings by frame identity, so forward references resolve once the
-  frame has been populated. Backed by a process-dictionary slot keyed by
-  a fresh reference; the slot is process-local and is GC'd with the
-  owning process.
+  Push a fresh `letrec`-style frame whose bindings start uninitialised
+  and can be assigned later via `rec_set/3`. Closures created against
+  the returned env see the bindings by frame identity, so forward
+  references resolve once the frame has been populated. Backed by a
+  process-dictionary slot keyed by a fresh reference; the slot must
+  be released with `release_rec/1` once the binding form's body has
+  finished evaluating.
   """
   @spec extend_rec(t(), [binary()]) :: t()
   def extend_rec(%__MODULE__{lex: lex} = env, names) when is_list(names) do
     ref = make_ref()
-    Process.put(ref, Map.new(names, fn name when is_binary(name) -> {name, :unspecified} end))
+
+    Process.put(
+      ref,
+      Map.new(names, fn name when is_binary(name) -> {name, @rec_uninitialised} end)
+    )
+
     %{env | lex: [{:rec, ref} | lex]}
   end
 
@@ -98,6 +133,18 @@ defmodule Schooner.Env do
   def rec_set(%__MODULE__{lex: [{:rec, ref} | _]} = env, name, value) when is_binary(name) do
     Process.put(ref, Map.put(Process.get(ref), name, value))
     env
+  end
+
+  @doc """
+  Release the topmost recursive frame on `env`, deleting the
+  process-dictionary slot that backs it. Must be paired with
+  `extend_rec/2`. Idempotent — releasing a frame whose slot was
+  already deleted is a no-op.
+  """
+  @spec release_rec(t()) :: :ok
+  def release_rec(%__MODULE__{lex: [{:rec, ref} | _]}) do
+    Process.delete(ref)
+    :ok
   end
 
   @doc "Pop the topmost lexical frame on `env`."

--- a/lib/schooner/eval.ex
+++ b/lib/schooner/eval.ex
@@ -26,6 +26,7 @@ defmodule Schooner.Eval do
   def eval({:sym, name}, env) do
     case Env.lookup(env, name) do
       {:ok, value} -> value
+      {:uninitialised, n} -> raise Error, reason: {:rec_uninitialised, n}
       :error -> raise Error, reason: {:unbound, name}
     end
   end
@@ -91,7 +92,7 @@ defmodule Schooner.Eval do
   end
 
   defp eval_lambda({:pair, params_form, body}, env) do
-    Value.closure(parse_params(params_form), body, env, nil)
+    Value.closure(parse_params(params_form), desugar_body(body), env, nil)
   end
 
   defp eval_lambda(_, _env), do: raise(Error, reason: {:bad_special_form, "lambda"})
@@ -127,7 +128,7 @@ defmodule Schooner.Eval do
   end
 
   defp eval_define({:pair, {:pair, {:sym, name}, params_form}, body}, env) do
-    closure = Value.closure(parse_params(params_form), body, env, name)
+    closure = Value.closure(parse_params(params_form), desugar_body(body), env, name)
     Env.define(env, name, closure)
     :unspecified
   end
@@ -238,7 +239,7 @@ defmodule Schooner.Eval do
 
   defp eval_when({:pair, test, body}, env) when body != :null do
     if Value.truthy?(eval(test, env)) do
-      eval_sequence(body, env)
+      eval_sequence(desugar_body(body), env)
     else
       :unspecified
     end
@@ -250,7 +251,7 @@ defmodule Schooner.Eval do
     if Value.truthy?(eval(test, env)) do
       :unspecified
     else
-      eval_sequence(body, env)
+      eval_sequence(desugar_body(body), env)
     end
   end
 
@@ -262,7 +263,7 @@ defmodule Schooner.Eval do
   defp eval_cond(:null, _env), do: :unspecified
 
   defp eval_cond({:pair, {:pair, {:sym, "else"}, body}, _rest}, env) when body != :null do
-    eval_sequence(body, env)
+    eval_sequence(desugar_body(body), env)
   end
 
   defp eval_cond({:pair, {:pair, {:sym, "else"}, _}, _}, _env) do
@@ -289,7 +290,7 @@ defmodule Schooner.Eval do
 
   defp eval_cond({:pair, {:pair, test, body}, rest}, env) do
     if Value.truthy?(eval(test, env)) do
-      eval_sequence(body, env)
+      eval_sequence(desugar_body(body), env)
     else
       eval_cond(rest, env)
     end
@@ -327,7 +328,7 @@ defmodule Schooner.Eval do
   end
 
   defp eval_case_body(_key, :null, _env), do: raise(Error, reason: {:bad_special_form, "case"})
-  defp eval_case_body(_key, body, env), do: eval_sequence(body, env)
+  defp eval_case_body(_key, body, env), do: eval_sequence(desugar_body(body), env)
 
   defp case_match?(_key, :null), do: false
 
@@ -345,7 +346,7 @@ defmodule Schooner.Eval do
   defp eval_let({:pair, bindings_form, body}, env) when body != :null do
     {names, inits} = parse_bindings(bindings_form, "let")
     values = Enum.map(inits, &eval(&1, env))
-    eval_sequence(body, Env.extend(env, Enum.zip(names, values)))
+    eval_sequence(desugar_body(body), Env.extend(env, Enum.zip(names, values)))
   end
 
   defp eval_let(_, _env), do: raise(Error, reason: {:bad_special_form, "let"})
@@ -355,10 +356,17 @@ defmodule Schooner.Eval do
     values = Enum.map(inits, &eval(&1, env))
 
     rec_env = Env.extend_rec(env, [name])
-    closure = Value.closure({:fixed, length(param_names), param_names}, body, rec_env, name)
+
+    closure =
+      Value.closure({:fixed, length(param_names), param_names}, desugar_body(body), rec_env, name)
+
     Env.rec_set(rec_env, name, closure)
 
-    apply_proc(closure, values)
+    try do
+      apply_proc(closure, values)
+    after
+      Env.release_rec(rec_env)
+    end
   end
 
   defp eval_let_star({:pair, bindings_form, body}, env) when body != :null do
@@ -371,7 +379,7 @@ defmodule Schooner.Eval do
         Env.extend(e, [{name, eval(init, e)}])
       end)
 
-    eval_sequence(body, new_env)
+    eval_sequence(desugar_body(body), new_env)
   end
 
   defp eval_let_star(_, _env), do: raise(Error, reason: {:bad_special_form, "let*"})
@@ -379,17 +387,27 @@ defmodule Schooner.Eval do
   # `letrec` and `letrec*` share an implementation. r7rs allows
   # `letrec` to be implemented as `letrec*`; the only difference is the
   # spec leaves init evaluation order unspecified for `letrec`.
+  #
+  # The `try ... after` wraps the body so the recursive frame's
+  # process-dictionary slot is released on every exit path. The body's
+  # tail-recursive calls bounce through `eval`/`eval_sequence`/
+  # `apply_proc` and do not return through this frame, so TCO across
+  # the body is preserved — see `eval_tco_test.exs`.
   defp eval_letrec_star({:pair, bindings_form, body}, env) when body != :null do
     {names, inits} = parse_bindings(bindings_form, "letrec*")
     rec_env = Env.extend_rec(env, names)
 
-    names
-    |> Enum.zip(inits)
-    |> Enum.each(fn {name, init} ->
-      Env.rec_set(rec_env, name, eval(init, rec_env))
-    end)
+    try do
+      names
+      |> Enum.zip(inits)
+      |> Enum.each(fn {name, init} ->
+        Env.rec_set(rec_env, name, eval(init, rec_env))
+      end)
 
-    eval_sequence(body, rec_env)
+      eval_sequence(desugar_body(body), rec_env)
+    after
+      Env.release_rec(rec_env)
+    end
   end
 
   defp eval_letrec_star(_, _env), do: raise(Error, reason: {:bad_special_form, "letrec*"})
@@ -492,4 +510,79 @@ defmodule Schooner.Eval do
 
   defp scheme_list_to_elixir(:null), do: []
   defp scheme_list_to_elixir({:pair, h, t}), do: [h | scheme_list_to_elixir(t)]
+
+  # ---------------------------------------------------------------------------
+  # Internal definitions / body splicing
+  # ---------------------------------------------------------------------------
+
+  # r7rs §5.3.3 lets a body begin with a sequence of `define` forms
+  # followed by a sequence of expressions; the defines splice into a
+  # `letrec*` whose body is the rest of the forms. `desugar_body/1`
+  # performs that rewrite. Forms with no leading defines are returned
+  # unchanged.
+  #
+  # `define` after a non-define form in the same body is a syntax
+  # error, raised here rather than at evaluation time so the whole
+  # body is rejected before any side-effecting init runs.
+  defp desugar_body(:null), do: :null
+
+  defp desugar_body(body) do
+    case scan_defines(body, []) do
+      {[], _rest} ->
+        body
+
+      {_defs, :null} ->
+        raise(Error, reason: :empty_body)
+
+      {defs, rest} ->
+        bindings = build_letrec_bindings(defs)
+        letrec_form = {:pair, {:sym, "letrec*"}, {:pair, bindings, rest}}
+        {:pair, letrec_form, :null}
+    end
+  end
+
+  defp scan_defines(:null, acc), do: {Enum.reverse(acc), :null}
+
+  defp scan_defines({:pair, form, rest}, acc) do
+    case parse_internal_define(form) do
+      nil ->
+        check_no_more_defines(rest)
+        {Enum.reverse(acc), {:pair, form, rest}}
+
+      binding ->
+        scan_defines(rest, [binding | acc])
+    end
+  end
+
+  defp parse_internal_define({:pair, {:sym, "define"}, body}) do
+    case body do
+      {:pair, {:sym, name}, {:pair, expr, :null}} ->
+        {name, expr}
+
+      {:pair, {:pair, {:sym, name}, params}, body_forms} when body_forms != :null ->
+        {name, {:pair, {:sym, "lambda"}, {:pair, params, body_forms}}}
+
+      _ ->
+        raise(Error, reason: {:bad_special_form, "define"})
+    end
+  end
+
+  defp parse_internal_define(_), do: nil
+
+  defp check_no_more_defines(:null), do: :ok
+
+  defp check_no_more_defines({:pair, form, rest}) do
+    if parse_internal_define(form) != nil do
+      raise(Error, reason: :define_after_expression)
+    else
+      check_no_more_defines(rest)
+    end
+  end
+
+  defp build_letrec_bindings([]), do: :null
+
+  defp build_letrec_bindings([{name, init} | rest]) do
+    binding = {:pair, {:sym, name}, {:pair, init, :null}}
+    {:pair, binding, build_letrec_bindings(rest)}
+  end
 end

--- a/lib/schooner/eval.ex
+++ b/lib/schooner/eval.ex
@@ -239,7 +239,7 @@ defmodule Schooner.Eval do
 
   defp eval_when({:pair, test, body}, env) when body != :null do
     if Value.truthy?(eval(test, env)) do
-      eval_sequence(desugar_body(body), env)
+      eval_body(body, env)
     else
       :unspecified
     end
@@ -251,7 +251,7 @@ defmodule Schooner.Eval do
     if Value.truthy?(eval(test, env)) do
       :unspecified
     else
-      eval_sequence(desugar_body(body), env)
+      eval_body(body, env)
     end
   end
 
@@ -263,7 +263,7 @@ defmodule Schooner.Eval do
   defp eval_cond(:null, _env), do: :unspecified
 
   defp eval_cond({:pair, {:pair, {:sym, "else"}, body}, _rest}, env) when body != :null do
-    eval_sequence(desugar_body(body), env)
+    eval_body(body, env)
   end
 
   defp eval_cond({:pair, {:pair, {:sym, "else"}, _}, _}, _env) do
@@ -290,7 +290,7 @@ defmodule Schooner.Eval do
 
   defp eval_cond({:pair, {:pair, test, body}, rest}, env) do
     if Value.truthy?(eval(test, env)) do
-      eval_sequence(desugar_body(body), env)
+      eval_body(body, env)
     else
       eval_cond(rest, env)
     end
@@ -328,7 +328,7 @@ defmodule Schooner.Eval do
   end
 
   defp eval_case_body(_key, :null, _env), do: raise(Error, reason: {:bad_special_form, "case"})
-  defp eval_case_body(_key, body, env), do: eval_sequence(desugar_body(body), env)
+  defp eval_case_body(_key, body, env), do: eval_body(body, env)
 
   defp case_match?(_key, :null), do: false
 
@@ -346,7 +346,7 @@ defmodule Schooner.Eval do
   defp eval_let({:pair, bindings_form, body}, env) when body != :null do
     {names, inits} = parse_bindings(bindings_form, "let")
     values = Enum.map(inits, &eval(&1, env))
-    eval_sequence(desugar_body(body), Env.extend(env, Enum.zip(names, values)))
+    eval_body(body, Env.extend(env, Enum.zip(names, values)))
   end
 
   defp eval_let(_, _env), do: raise(Error, reason: {:bad_special_form, "let"})
@@ -362,11 +362,7 @@ defmodule Schooner.Eval do
 
     Env.rec_set(rec_env, name, closure)
 
-    try do
-      apply_proc(closure, values)
-    after
-      Env.release_rec(rec_env)
-    end
+    with_rec_frame(rec_env, fn -> apply_proc(closure, values) end)
   end
 
   defp eval_let_star({:pair, bindings_form, body}, env) when body != :null do
@@ -379,7 +375,7 @@ defmodule Schooner.Eval do
         Env.extend(e, [{name, eval(init, e)}])
       end)
 
-    eval_sequence(desugar_body(body), new_env)
+    eval_body(body, new_env)
   end
 
   defp eval_let_star(_, _env), do: raise(Error, reason: {:bad_special_form, "let*"})
@@ -387,27 +383,19 @@ defmodule Schooner.Eval do
   # `letrec` and `letrec*` share an implementation. r7rs allows
   # `letrec` to be implemented as `letrec*`; the only difference is the
   # spec leaves init evaluation order unspecified for `letrec`.
-  #
-  # The `try ... after` wraps the body so the recursive frame's
-  # process-dictionary slot is released on every exit path. The body's
-  # tail-recursive calls bounce through `eval`/`eval_sequence`/
-  # `apply_proc` and do not return through this frame, so TCO across
-  # the body is preserved — see `eval_tco_test.exs`.
   defp eval_letrec_star({:pair, bindings_form, body}, env) when body != :null do
     {names, inits} = parse_bindings(bindings_form, "letrec*")
     rec_env = Env.extend_rec(env, names)
 
-    try do
+    with_rec_frame(rec_env, fn ->
       names
       |> Enum.zip(inits)
       |> Enum.each(fn {name, init} ->
         Env.rec_set(rec_env, name, eval(init, rec_env))
       end)
 
-      eval_sequence(desugar_body(body), rec_env)
-    after
-      Env.release_rec(rec_env)
-    end
+      eval_body(body, rec_env)
+    end)
   end
 
   defp eval_letrec_star(_, _env), do: raise(Error, reason: {:bad_special_form, "letrec*"})
@@ -514,6 +502,23 @@ defmodule Schooner.Eval do
   # ---------------------------------------------------------------------------
   # Internal definitions / body splicing
   # ---------------------------------------------------------------------------
+
+  # `eval_body/2` is the entry point for evaluating any r7rs body
+  # (lambda, let-family, when/unless, cond/case clauses): it splices
+  # leading internal defines into a `letrec*` and then evaluates the
+  # resulting sequence. Lambda bodies are pre-desugared at closure
+  # creation time so per-application cost stays at zero.
+  defp eval_body(body, env), do: eval_sequence(desugar_body(body), env)
+
+  # Run `body_fun` and release `rec_env`'s recursive frame on every
+  # exit path. The body's tail-recursive calls bounce through
+  # `eval`/`eval_sequence`/`apply_proc` and never return through this
+  # frame, so TCO across the body is preserved — see `eval_tco_test`.
+  defp with_rec_frame(rec_env, body_fun) do
+    body_fun.()
+  after
+    Env.release_rec(rec_env)
+  end
 
   # r7rs §5.3.3 lets a body begin with a sequence of `define` forms
   # followed by a sequence of expressions; the defines splice into a

--- a/lib/schooner/eval/error.ex
+++ b/lib/schooner/eval/error.ex
@@ -21,6 +21,12 @@ defmodule Schooner.Eval.Error do
   defp format({:bad_special_form, name}), do: "malformed `#{name}` form"
   defp format(:invalid_params), do: "invalid lambda parameter list"
   defp format(:improper_application), do: "improper application form"
+  defp format(:define_after_expression), do: "internal `define` after a non-definition expression"
+  defp format(:empty_body), do: "body must contain at least one expression"
+
+  defp format({:rec_uninitialised, name}) do
+    "letrec binding `#{name}` referenced before its init has been evaluated"
+  end
 
   defp format({:arity_mismatch, name, {:exact, expected}, got}) do
     "arity mismatch in #{name_str(name)}: expected #{expected}, got #{got}"

--- a/test/schooner/eval_internal_defines_test.exs
+++ b/test/schooner/eval_internal_defines_test.exs
@@ -15,6 +15,16 @@ defmodule Schooner.EvalInternalDefinesTest do
 
   defp run(source), do: Schooner.run(source)
 
+  defp assert_no_slot_leak(fun) do
+    before = count_rec_slots()
+    fun.()
+    assert count_rec_slots() == before
+  end
+
+  defp count_rec_slots do
+    Process.get_keys() |> Enum.count(&is_reference/1)
+  end
+
   describe "internal defines in lambda body" do
     test "single internal define is visible in the body" do
       assert run("""
@@ -185,7 +195,7 @@ defmodule Schooner.EvalInternalDefinesTest do
           """)
         end
 
-      assert e.reason in [:empty_body, {:bad_special_form, "lambda"}]
+      assert e.reason == :empty_body
     end
 
     test "malformed internal define raises" do
@@ -242,46 +252,34 @@ defmodule Schooner.EvalInternalDefinesTest do
 
   describe "rec-frame slot lifecycle" do
     test "letrec* releases its process-dictionary slot when the body returns" do
-      before_keys = Process.get_keys() |> Enum.filter(&is_reference/1) |> length()
-
-      assert Schooner.run("(letrec* ((x 1) (y 2)) (+ x y))") == 3
-
-      after_keys = Process.get_keys() |> Enum.filter(&is_reference/1) |> length()
-      assert after_keys == before_keys
+      assert_no_slot_leak(fn ->
+        assert Schooner.run("(letrec* ((x 1) (y 2)) (+ x y))") == 3
+      end)
     end
 
     test "letrec* releases its slot even when the body raises" do
-      before_keys = Process.get_keys() |> Enum.filter(&is_reference/1) |> length()
-
-      assert_raise Error, fn -> Schooner.run("(letrec* ((x 1)) (undefined-name))") end
-
-      after_keys = Process.get_keys() |> Enum.filter(&is_reference/1) |> length()
-      assert after_keys == before_keys
+      assert_no_slot_leak(fn ->
+        assert_raise Error, fn -> Schooner.run("(letrec* ((x 1)) (undefined-name))") end
+      end)
     end
 
     test "named let releases its slot when the body returns" do
-      before_keys = Process.get_keys() |> Enum.filter(&is_reference/1) |> length()
-
-      assert Schooner.run("""
-             (let loop ((n 5) (acc 1))
-               (if (= n 0) acc (loop (- n 1) (* acc n))))
-             """) == 120
-
-      after_keys = Process.get_keys() |> Enum.filter(&is_reference/1) |> length()
-      assert after_keys == before_keys
+      assert_no_slot_leak(fn ->
+        assert Schooner.run("""
+               (let loop ((n 5) (acc 1))
+                 (if (= n 0) acc (loop (- n 1) (* acc n))))
+               """) == 120
+      end)
     end
 
     test "many sequential letrec*s do not leak slots" do
-      before_keys = Process.get_keys() |> Enum.filter(&is_reference/1) |> length()
-
       env = Schooner.standard_env()
 
-      for _ <- 1..50 do
-        Schooner.eval("(letrec* ((x 1) (y 2)) (+ x y))", env)
-      end
-
-      after_keys = Process.get_keys() |> Enum.filter(&is_reference/1) |> length()
-      assert after_keys == before_keys
+      assert_no_slot_leak(fn ->
+        for _ <- 1..50 do
+          Schooner.eval("(letrec* ((x 1) (y 2)) (+ x y))", env)
+        end
+      end)
     end
   end
 

--- a/test/schooner/eval_internal_defines_test.exs
+++ b/test/schooner/eval_internal_defines_test.exs
@@ -1,0 +1,311 @@
+defmodule Schooner.EvalInternalDefinesTest do
+  # Phase 8 — internal `define`s splice into a `letrec*` at the head
+  # of any body that allows internal definitions (lambda, let, let*,
+  # letrec*, when, unless, cond clauses, case clauses, named let).
+  #
+  # These tests also pin two related behaviours: forward references
+  # to a not-yet-evaluated `letrec*` init are a runtime error, and
+  # `define` appearing after a non-definition expression in the same
+  # body is a syntax error.
+  use ExUnit.Case, async: true
+
+  alias Schooner.Env
+  alias Schooner.Eval.Error
+  alias Schooner.Value
+
+  defp run(source), do: Schooner.run(source)
+
+  describe "internal defines in lambda body" do
+    test "single internal define is visible in the body" do
+      assert run("""
+             ((lambda ()
+                (define x 7)
+                x))
+             """) == 7
+    end
+
+    test "multiple internal defines accumulate left-to-right" do
+      assert run("""
+             ((lambda ()
+                (define a 1)
+                (define b (+ a 1))
+                (define c (+ b 1))
+                (list a b c)))
+             """) == Value.list([1, 2, 3])
+    end
+
+    test "function-form internal define produces a callable closure" do
+      assert run("""
+             ((lambda (x)
+                (define (double n) (* n 2))
+                (double x))
+              21)
+             """) == 42
+    end
+
+    test "internal define shadows an outer binding only inside the lambda" do
+      assert run("""
+             (define x 'outer)
+             ((lambda ()
+                (define x 'inner)
+                x))
+             """) == Value.symbol("inner")
+
+      assert run("""
+             (define x 'outer)
+             ((lambda ()
+                (define x 'inner)
+                x))
+             x
+             """) == Value.symbol("outer")
+    end
+
+    test "mutual recursion via internal defines (forward reference inside lambda)" do
+      assert run("""
+             ((lambda (n)
+                (define (even? k) (if (= k 0) #t (odd? (- k 1))))
+                (define (odd? k)  (if (= k 0) #f (even? (- k 1))))
+                (even? n))
+              10)
+             """) == Value.bool(true)
+
+      assert run("""
+             ((lambda (n)
+                (define (even? k) (if (= k 0) #t (odd? (- k 1))))
+                (define (odd? k)  (if (= k 0) #f (even? (- k 1))))
+                (even? n))
+              7)
+             """) == Value.bool(false)
+    end
+  end
+
+  describe "internal defines in let bodies" do
+    test "let body" do
+      assert run("""
+             (let ((x 10))
+               (define y (+ x 5))
+               (* x y))
+             """) == 150
+    end
+
+    test "let* body" do
+      assert run("""
+             (let* ((x 1) (y 2))
+               (define z (+ x y))
+               (* z z))
+             """) == 9
+    end
+
+    test "letrec* body" do
+      assert run("""
+             (letrec* ((a 1))
+               (define b (+ a 10))
+               (+ a b))
+             """) == 12
+    end
+
+    test "named let body" do
+      assert run("""
+             (let outer ((n 3))
+               (define double (lambda (x) (* x 2)))
+               (double n))
+             """) == 6
+    end
+  end
+
+  describe "internal defines in cond / case / when / unless bodies" do
+    test "cond clause body" do
+      assert run("""
+             (cond ((= 1 1)
+                    (define x 100)
+                    (+ x 1))
+                   (else 0))
+             """) == 101
+    end
+
+    test "cond else body" do
+      assert run("""
+             (cond ((= 1 0) 'no)
+                   (else
+                    (define x 7)
+                    (* x x)))
+             """) == 49
+    end
+
+    test "case clause body" do
+      assert run("""
+             (case 2
+               ((1 2)
+                (define x 10)
+                (+ x 5))
+               (else 0))
+             """) == 15
+    end
+
+    test "when body" do
+      assert run("""
+             (when #t
+               (define x 4)
+               (* x x))
+             """) == 16
+    end
+
+    test "unless body" do
+      assert run("""
+             (unless #f
+               (define a 'hi)
+               a)
+             """) == Value.symbol("hi")
+    end
+  end
+
+  describe "syntactic constraints" do
+    test "define after a non-definition expression in the same body is an error" do
+      e =
+        assert_raise Error, fn ->
+          run("""
+          ((lambda ()
+             (define x 1)
+             x
+             (define y 2)
+             y))
+          """)
+        end
+
+      assert e.reason == :define_after_expression
+    end
+
+    test "a body containing only defines is rejected at expansion time" do
+      e =
+        assert_raise Error, fn ->
+          run("""
+          ((lambda ()
+             (define x 1)
+             (define y 2)))
+          """)
+        end
+
+      assert e.reason in [:empty_body, {:bad_special_form, "lambda"}]
+    end
+
+    test "malformed internal define raises" do
+      e =
+        assert_raise Error, fn ->
+          run("""
+          ((lambda ()
+             (define)
+             1))
+          """)
+        end
+
+      assert e.reason == {:bad_special_form, "define"}
+    end
+  end
+
+  describe "letrec* forward-reference semantics" do
+    test "closure body may reference a binding declared later in the same frame" do
+      assert run("""
+             (letrec* ((f (lambda (n) (if (= n 0) 'done (g n))))
+                       (g (lambda (n) (f (- n 1)))))
+               (f 3))
+             """) == Value.symbol("done")
+    end
+
+    test "a closure created by an init can reference a later binding when applied later" do
+      assert run("""
+             (letrec* ((f (lambda () later))
+                       (later 42))
+               (f))
+             """) == 42
+    end
+
+    test "forward reference within an init expression itself is a runtime error" do
+      e =
+        assert_raise Error, fn ->
+          run("""
+          (letrec* ((x y)
+                    (y 1))
+            x)
+          """)
+        end
+
+      assert e.reason == {:rec_uninitialised, "y"}
+    end
+
+    test "letrec* inits run left-to-right; earlier bindings are visible in later inits" do
+      assert run("""
+             (letrec* ((a 1) (b (+ a 10)) (c (+ b 100)))
+               (list a b c))
+             """) == Value.list([1, 11, 111])
+    end
+  end
+
+  describe "rec-frame slot lifecycle" do
+    test "letrec* releases its process-dictionary slot when the body returns" do
+      before_keys = Process.get_keys() |> Enum.filter(&is_reference/1) |> length()
+
+      assert Schooner.run("(letrec* ((x 1) (y 2)) (+ x y))") == 3
+
+      after_keys = Process.get_keys() |> Enum.filter(&is_reference/1) |> length()
+      assert after_keys == before_keys
+    end
+
+    test "letrec* releases its slot even when the body raises" do
+      before_keys = Process.get_keys() |> Enum.filter(&is_reference/1) |> length()
+
+      assert_raise Error, fn -> Schooner.run("(letrec* ((x 1)) (undefined-name))") end
+
+      after_keys = Process.get_keys() |> Enum.filter(&is_reference/1) |> length()
+      assert after_keys == before_keys
+    end
+
+    test "named let releases its slot when the body returns" do
+      before_keys = Process.get_keys() |> Enum.filter(&is_reference/1) |> length()
+
+      assert Schooner.run("""
+             (let loop ((n 5) (acc 1))
+               (if (= n 0) acc (loop (- n 1) (* acc n))))
+             """) == 120
+
+      after_keys = Process.get_keys() |> Enum.filter(&is_reference/1) |> length()
+      assert after_keys == before_keys
+    end
+
+    test "many sequential letrec*s do not leak slots" do
+      before_keys = Process.get_keys() |> Enum.filter(&is_reference/1) |> length()
+
+      env = Schooner.standard_env()
+
+      for _ <- 1..50 do
+        Schooner.eval("(letrec* ((x 1) (y 2)) (+ x y))", env)
+      end
+
+      after_keys = Process.get_keys() |> Enum.filter(&is_reference/1) |> length()
+      assert after_keys == before_keys
+    end
+  end
+
+  describe "TCO across letrec* try/after" do
+    test "internal-define-driven mutual recursion at depth" do
+      env =
+        Env.new()
+        |> Env.define(
+          "zero-int?",
+          Value.primitive("zero-int?", 1, fn [n] -> Value.bool(n === 0) end)
+        )
+        |> Env.define("sub1", Value.primitive("sub1", 1, fn [n] -> n - 1 end))
+
+      source = """
+      ((lambda (n)
+         (define (even? k) (if (zero-int? k) #t (odd? (sub1 k))))
+         (define (odd? k)  (if (zero-int? k) #f (even? (sub1 k))))
+         (even? n))
+       100000)
+      """
+
+      assert Schooner.eval(source, env) == Value.bool(true)
+      {:total_heap_size, heap} = Process.info(self(), :total_heap_size)
+      assert heap < 5_000_000
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Internal `define`s at the head of a body splice into a `letrec*` (lambda / let / let* / letrec* / named-let / when / unless / cond-clause / case-clause). `define` after a non-definition expression is now a syntax error.
- Plug the rec-frame leak from phase 7: `letrec*` and named `let` release their process-dictionary slot via `try ... after Env.release_rec(rec_env)`. TCO across the body is preserved — the body's recursive bouncing through `eval`/`apply_proc`/`eval_sequence` does not return through the binding form's frame.
- Forward reference to a not-yet-evaluated `letrec*` init now raises `{:rec_uninitialised, name}` rather than silently returning `:unspecified`.

## Notes

- Implements option (a) from the phase 8 plan note. A behavioural caveat — closures that escape a letrec body and are later applied with a free reference to a rec binding will raise — is captured in #25 with a recommended walk-and-rewrite fix to land later.
- `eval_body/2` and `with_rec_frame/2` were extracted to keep the body-splicing and rec-frame-lifecycle wiring at single call sites.

## Test plan

- [x] `mix precommit` green: 505 tests, 23 properties, 0 failures, no Credo issues
- [x] Existing phase 4 TCO tests still pass at 100k depth
- [x] New 100k-depth TCO regression for internal-define-driven mutual recursion
- [x] Slot-lifecycle tests cover normal return, raise, named let, and 50 sequential letrecs