### PR TITLE
Phase 9: hygienic syntax-rules expander

### DIFF
--- a/lib/schooner.ex
+++ b/lib/schooner.ex
@@ -3,9 +3,12 @@ defmodule Schooner do
   An embeddable, sandboxed Scheme interpreter for the BEAM, targeting the
   r7rs-small language minus its mutable operations.
 
-  The pipeline is `Schooner.Lexer` → `Schooner.Reader` → `Schooner.Eval`,
-  with `Schooner.Value` providing the tagged-term value model and
-  `Schooner.Env` the immutable-with-mutable-globals environment.
+  The pipeline is `Schooner.Lexer` → `Schooner.Reader` →
+  `Schooner.Expander` → `Schooner.Eval`, with `Schooner.Value` providing
+  the tagged-term value model and `Schooner.Env` the
+  immutable-with-mutable-globals runtime environment. Macro bindings
+  live in a separate `Schooner.Expander.SyntaxEnv` threaded through
+  expansion only.
 
   This module exposes the convenience entry points used by tests and by
   early embeddings. The full embedding API arrives in a later phase.
@@ -13,6 +16,7 @@ defmodule Schooner do
 
   alias Schooner.Env
   alias Schooner.Eval
+  alias Schooner.Expander
   alias Schooner.Primitives
   alias Schooner.Reader
   alias Schooner.Value
@@ -46,6 +50,7 @@ defmodule Schooner do
   def eval(source, %Env{} = env) when is_binary(source) do
     source
     |> Reader.read_string()
+    |> Expander.expand_program(Expander.bootstrap_env())
     |> Enum.reduce(:unspecified, fn form, _acc -> Eval.eval(form, env) end)
   end
 end

--- a/lib/schooner/eval.ex
+++ b/lib/schooner/eval.ex
@@ -12,13 +12,24 @@ defmodule Schooner.Eval do
   last-call optimisation. **Adding a wrapper around any of these
   calls breaks the invariant — see `eval_tco_test.exs`.**
 
-  Phase 4 recognises only the core forms: `quote`, `if`, `lambda`,
-  top-level `define`, `begin`, application, and variable reference.
-  Everything else is either self-evaluating or an error.
+  After phase 9 the evaluator only consumes the core forms produced
+  by `Schooner.Expander`: `quote`, `if`, `lambda`, top-level
+  `define`, `begin`, `letrec*`, `quasiquote`, application, and
+  variable reference. Everything else (`cond`, `case`, the `let`
+  family, `do`, `and`/`or`, `when`/`unless`) is a `syntax-rules`
+  macro defined by the bootstrap; the throwaway evaluator branches
+  for those forms have been removed.
+
+  `letrec*` is retained as a core form rather than reduced to a
+  macro because it backs both user-facing recursive bindings and
+  internal-`define` splicing, and a fully-macroised replacement
+  would need either mutation (which the value model does not
+  permit) or a hand-built fix-point combinator.
   """
 
   alias Schooner.Env
   alias Schooner.Eval.Error
+  alias Schooner.Expander.SyntaxRules
   alias Schooner.Value
 
   @spec eval(Value.t(), Env.t()) :: Value.t()
@@ -27,7 +38,7 @@ defmodule Schooner.Eval do
     case Env.lookup(env, name) do
       {:ok, value} -> value
       {:uninitialised, n} -> raise Error, reason: {:rec_uninitialised, n}
-      :error -> raise Error, reason: {:unbound, name}
+      :error -> resolve_marked_var(env, name)
     end
   end
 
@@ -38,21 +49,24 @@ defmodule Schooner.Eval do
   def eval({:pair, {:sym, "lambda"}, tail}, env), do: eval_lambda(tail, env)
   def eval({:pair, {:sym, "define"}, tail}, env), do: eval_define(tail, env)
   def eval({:pair, {:sym, "begin"}, tail}, env), do: eval_sequence(tail, env)
-  def eval({:pair, {:sym, "and"}, tail}, env), do: eval_and(tail, env)
-  def eval({:pair, {:sym, "or"}, tail}, env), do: eval_or(tail, env)
-  def eval({:pair, {:sym, "when"}, tail}, env), do: eval_when(tail, env)
-  def eval({:pair, {:sym, "unless"}, tail}, env), do: eval_unless(tail, env)
-  def eval({:pair, {:sym, "cond"}, tail}, env), do: eval_cond(tail, env)
-  def eval({:pair, {:sym, "case"}, tail}, env), do: eval_case(tail, env)
-  def eval({:pair, {:sym, "let"}, tail}, env), do: eval_let(tail, env)
-  def eval({:pair, {:sym, "let*"}, tail}, env), do: eval_let_star(tail, env)
-  def eval({:pair, {:sym, "letrec"}, tail}, env), do: eval_letrec_star(tail, env)
   def eval({:pair, {:sym, "letrec*"}, tail}, env), do: eval_letrec_star(tail, env)
-  def eval({:pair, {:sym, "do"}, tail}, env), do: eval_do(tail, env)
   def eval({:pair, {:sym, "quasiquote"}, tail}, env), do: eval_quasiquote_top(tail, env)
   def eval({:pair, head, tail}, env), do: eval_apply(head, tail, env)
 
   def eval(value, _env), do: value
+
+  # A name that carries a hygiene mark from a macro template but was
+  # never bound by an introduced binder is a free reference to the
+  # unmarked base name — usually a runtime primitive like `+`. Fall
+  # back to the base name before declaring it unbound.
+  defp resolve_marked_var(env, name) do
+    with {:ok, base} <- SyntaxRules.strip_mark(name),
+         {:ok, value} <- Env.lookup(env, base) do
+      value
+    else
+      _ -> raise Error, reason: {:unbound, name}
+    end
+  end
 
   # ---------------------------------------------------------------------------
   # quote
@@ -211,178 +225,14 @@ defmodule Schooner.Eval do
     end
   end
 
-  # `(and)` returns #t and `(or)` returns #f per r7rs §4.2.1; the last
-  # sub-form is in tail position so a chain of `and`s preserves TCO.
-  defp eval_and(:null, _env), do: Value.bool(true)
-  defp eval_and({:pair, last, :null}, env), do: eval(last, env)
-
-  defp eval_and({:pair, head, rest}, env) do
-    case eval(head, env) do
-      {:bool, false} = v -> v
-      _ -> eval_and(rest, env)
-    end
-  end
-
-  defp eval_and(_, _env), do: raise(Error, reason: {:bad_special_form, "and"})
-
-  defp eval_or(:null, _env), do: Value.bool(false)
-  defp eval_or({:pair, last, :null}, env), do: eval(last, env)
-
-  defp eval_or({:pair, head, rest}, env) do
-    case eval(head, env) do
-      {:bool, false} -> eval_or(rest, env)
-      v -> v
-    end
-  end
-
-  defp eval_or(_, _env), do: raise(Error, reason: {:bad_special_form, "or"})
-
-  defp eval_when({:pair, test, body}, env) when body != :null do
-    if Value.truthy?(eval(test, env)) do
-      eval_body(body, env)
-    else
-      :unspecified
-    end
-  end
-
-  defp eval_when(_, _env), do: raise(Error, reason: {:bad_special_form, "when"})
-
-  defp eval_unless({:pair, test, body}, env) when body != :null do
-    if Value.truthy?(eval(test, env)) do
-      :unspecified
-    else
-      eval_body(body, env)
-    end
-  end
-
-  defp eval_unless(_, _env), do: raise(Error, reason: {:bad_special_form, "unless"})
-
-  # `cond` clause shapes per r7rs §4.2.1: `(test)` returns the test value,
-  # `(test expr ...)` evaluates the body, `(test => proc)` applies proc
-  # to the test value, and `(else expr ...)` is the unconditional fallback.
-  defp eval_cond(:null, _env), do: :unspecified
-
-  defp eval_cond({:pair, {:pair, {:sym, "else"}, body}, _rest}, env) when body != :null do
-    eval_body(body, env)
-  end
-
-  defp eval_cond({:pair, {:pair, {:sym, "else"}, _}, _}, _env) do
-    raise(Error, reason: {:bad_special_form, "cond"})
-  end
-
-  defp eval_cond({:pair, {:pair, test, {:pair, {:sym, "=>"}, {:pair, recv, :null}}}, rest}, env) do
-    value = eval(test, env)
-
-    if Value.truthy?(value) do
-      proc = eval(recv, env)
-      apply_proc(proc, [value])
-    else
-      eval_cond(rest, env)
-    end
-  end
-
-  defp eval_cond({:pair, {:pair, test, :null}, rest}, env) do
-    case eval(test, env) do
-      {:bool, false} -> eval_cond(rest, env)
-      v -> v
-    end
-  end
-
-  defp eval_cond({:pair, {:pair, test, body}, rest}, env) do
-    if Value.truthy?(eval(test, env)) do
-      eval_body(body, env)
-    else
-      eval_cond(rest, env)
-    end
-  end
-
-  defp eval_cond(_, _env), do: raise(Error, reason: {:bad_special_form, "cond"})
-
-  # `case` keys are matched with `eqv?` per r7rs §4.2.1. Empty key list
-  # never matches and falls through to the next clause.
-  defp eval_case({:pair, key_expr, clauses}, env) do
-    eval_case_clauses(eval(key_expr, env), clauses, env)
-  end
-
-  defp eval_case(_, _env), do: raise(Error, reason: {:bad_special_form, "case"})
-
-  defp eval_case_clauses(_key, :null, _env), do: :unspecified
-
-  defp eval_case_clauses(key, {:pair, {:pair, {:sym, "else"}, body}, _rest}, env)
-       when body != :null do
-    eval_case_body(key, body, env)
-  end
-
-  defp eval_case_clauses(key, {:pair, {:pair, keys, body}, rest}, env) do
-    if case_match?(key, keys) do
-      eval_case_body(key, body, env)
-    else
-      eval_case_clauses(key, rest, env)
-    end
-  end
-
-  defp eval_case_clauses(_key, _, _env), do: raise(Error, reason: {:bad_special_form, "case"})
-
-  defp eval_case_body(key, {:pair, {:sym, "=>"}, {:pair, recv, :null}}, env) do
-    apply_proc(eval(recv, env), [key])
-  end
-
-  defp eval_case_body(_key, :null, _env), do: raise(Error, reason: {:bad_special_form, "case"})
-  defp eval_case_body(_key, body, env), do: eval_body(body, env)
-
-  defp case_match?(_key, :null), do: false
-
-  defp case_match?(key, {:pair, datum, rest}) do
-    Value.eqv?(key, datum) or case_match?(key, rest)
-  end
-
-  defp case_match?(_key, _), do: raise(Error, reason: {:bad_special_form, "case"})
-
-  defp eval_let({:pair, {:sym, name}, {:pair, bindings_form, body}}, env)
-       when body != :null do
-    eval_named_let(name, bindings_form, body, env)
-  end
-
-  defp eval_let({:pair, bindings_form, body}, env) when body != :null do
-    {names, inits} = parse_bindings(bindings_form, "let")
-    values = Enum.map(inits, &eval(&1, env))
-    eval_body(body, Env.extend(env, Enum.zip(names, values)))
-  end
-
-  defp eval_let(_, _env), do: raise(Error, reason: {:bad_special_form, "let"})
-
-  defp eval_named_let(name, bindings_form, body, env) do
-    {param_names, inits} = parse_bindings(bindings_form, "let")
-    values = Enum.map(inits, &eval(&1, env))
-
-    rec_env = Env.extend_rec(env, [name])
-
-    closure =
-      Value.closure({:fixed, length(param_names), param_names}, desugar_body(body), rec_env, name)
-
-    Env.rec_set(rec_env, name, closure)
-
-    with_rec_frame(rec_env, fn -> apply_proc(closure, values) end)
-  end
-
-  defp eval_let_star({:pair, bindings_form, body}, env) when body != :null do
-    {names, inits} = parse_bindings(bindings_form, "let*")
-
-    new_env =
-      names
-      |> Enum.zip(inits)
-      |> Enum.reduce(env, fn {name, init}, e ->
-        Env.extend(e, [{name, eval(init, e)}])
-      end)
-
-    eval_body(body, new_env)
-  end
-
-  defp eval_let_star(_, _env), do: raise(Error, reason: {:bad_special_form, "let*"})
-
-  # `letrec` and `letrec*` share an implementation. r7rs allows
-  # `letrec` to be implemented as `letrec*`; the only difference is the
-  # spec leaves init evaluation order unspecified for `letrec`.
+  # `letrec*` is the workhorse for both user-facing recursive bindings
+  # (the `let`, `let*`, `letrec`, `letrec*`, named-`let` bootstrap
+  # macros all expand to it eventually) and for internal-define
+  # splicing (see `desugar_body/1`). Init expressions are evaluated
+  # left-to-right in a frame whose closure values reference the
+  # frame's identity — `Env.extend_rec/2` plus `rec_set/3` ties the
+  # knot without any after-the-fact mutation of the closures
+  # themselves.
   defp eval_letrec_star({:pair, bindings_form, body}, env) when body != :null do
     {names, inits} = parse_bindings(bindings_form, "letrec*")
     rec_env = Env.extend_rec(env, names)
@@ -411,45 +261,6 @@ defmodule Schooner.Eval do
   end
 
   defp parse_bindings(_, ctx, _, _), do: raise(Error, reason: {:bad_special_form, ctx})
-
-  defp eval_do({:pair, bindings_form, {:pair, test_form, body}}, env) do
-    {names, inits, steps} = parse_do_bindings(bindings_form)
-    {test, results} = parse_do_test(test_form)
-
-    init_values = Enum.map(inits, &eval(&1, env))
-    loop_env = Env.extend(env, Enum.zip(names, init_values))
-    do_loop(names, steps, test, results, body, loop_env)
-  end
-
-  defp eval_do(_, _env), do: raise(Error, reason: {:bad_special_form, "do"})
-
-  defp do_loop(names, steps, test, results, body, env) do
-    if Value.truthy?(eval(test, env)) do
-      eval_sequence(results, env)
-    else
-      _ = eval_sequence(body, env)
-      step_values = Enum.map(steps, &eval(&1, env))
-      next_env = Env.extend(Env.pop(env), Enum.zip(names, step_values))
-      do_loop(names, steps, test, results, body, next_env)
-    end
-  end
-
-  defp parse_do_bindings(:null), do: {[], [], []}
-
-  defp parse_do_bindings({:pair, {:pair, {:sym, name}, {:pair, init, rest_step}}, rest}) do
-    {ns, is, ss} = parse_do_bindings(rest)
-    step = parse_do_step(name, rest_step)
-    {[name | ns], [init | is], [step | ss]}
-  end
-
-  defp parse_do_bindings(_), do: raise(Error, reason: {:bad_special_form, "do"})
-
-  defp parse_do_step(name, :null), do: Value.symbol(name)
-  defp parse_do_step(_name, {:pair, step, :null}), do: step
-  defp parse_do_step(_name, _), do: raise(Error, reason: {:bad_special_form, "do"})
-
-  defp parse_do_test({:pair, test, results}), do: {test, results}
-  defp parse_do_test(_), do: raise(Error, reason: {:bad_special_form, "do"})
 
   # `unquote` and `unquote-splicing` only fire at quasi level 1; nested
   # `quasiquote` raises the level, nested `unquote` lowers it.

--- a/lib/schooner/expander.ex
+++ b/lib/schooner/expander.ex
@@ -100,7 +100,7 @@ defmodule Schooner.Expander do
   defp expand_top(form, env), do: expand(form, env)
 
   defp expand_top_begin(:null, env, acc) do
-    {:pair, {:sym, "begin"}, build_list(Enum.reverse(acc))}
+    {:pair, {:sym, "begin"}, Value.list(Enum.reverse(acc))}
     |> finalise_top_begin(env, acc)
   end
 
@@ -116,9 +116,6 @@ defmodule Schooner.Expander do
   defp finalise_top_begin(_form, env, []), do: {:syntax_def, env}
 
   defp finalise_top_begin(form, _env, _acc), do: form
-
-  defp build_list([]), do: :null
-  defp build_list([h | t]), do: {:pair, h, build_list(t)}
 
   # ---------------------------------------------------------------------------
   # Recursive expansion of an arbitrary form
@@ -187,11 +184,10 @@ defmodule Schooner.Expander do
     {:pair, expand(head, env), expand_each(args, env)}
   end
 
-  # Recognise a special-form name that has been alpha-renamed by hygiene
-  # (e.g. `lambda<NUL>42` produced from a template that didn't list the
-  # special form in its `core_keywords` set). We re-dispatch on the
-  # canonical form so the dedicated `expand_lambda` / `expand_define` /
-  # ... clauses do their thing and the output stays canonical.
+  # A core special form's name reached us with a hygiene mark — i.e.
+  # a template wrote one of `quote`/`if`/`lambda`/etc. without
+  # listing it in `SyntaxRules`'s `@core_keywords`. Re-dispatch on
+  # the canonical name so the dedicated handlers fire.
   defp canonicalise_special(base, {:pair, {:sym, _}, tail}, env) do
     expand({:pair, {:sym, base}, tail}, env)
   end
@@ -273,34 +269,41 @@ defmodule Schooner.Expander do
   defp expand_if(_, _env), do: raise(Error, reason: {:bad_special_form, "if"})
 
   defp expand_letrec_star({:pair, bindings_form, body}, env) when body != :null do
-    names = letrec_binding_names(bindings_form)
+    parsed = parse_letrec_bindings(bindings_form, [])
+    names = Enum.map(parsed, fn {sym, _} -> sym_name(sym) end)
     inner = SyntaxEnv.push_variables(env, names)
-    expanded_bindings = expand_letrec_bindings(bindings_form, inner)
-    expanded_body = expand_each(body, inner)
 
-    {:pair, {:sym, "letrec*"}, {:pair, expanded_bindings, expanded_body}}
+    expanded_bindings =
+      parsed
+      |> Enum.map(fn {sym, init} ->
+        {:pair, sym, {:pair, expand(init, inner), :null}}
+      end)
+      |> Value.list()
+
+    {:pair, {:sym, "letrec*"}, {:pair, expanded_bindings, expand_each(body, inner)}}
   end
 
   defp expand_letrec_star(_, _env), do: raise(Error, reason: {:bad_special_form, "letrec*"})
 
-  defp letrec_binding_names(:null), do: []
+  defp sym_name({:sym, name}), do: name
 
-  defp letrec_binding_names({:pair, {:pair, {:sym, name}, _}, rest}) do
-    [name | letrec_binding_names(rest)]
-  end
+  # Single walk over the binding list yielding `[{sym, init}, ...]` —
+  # used twice by the caller (once to derive the binder names for
+  # the syntax-env shadow, once to expand the inits in that
+  # already-shadowed env), avoiding the duplicate parse the previous
+  # split into `letrec_binding_names/1` and `expand_letrec_bindings/2`
+  # required.
+  defp parse_letrec_bindings(:null, acc), do: Enum.reverse(acc)
 
-  defp letrec_binding_names(_), do: raise(Error, reason: {:bad_special_form, "letrec*"})
-
-  defp expand_letrec_bindings(:null, _env), do: :null
-
-  defp expand_letrec_bindings(
-         {:pair, {:pair, {:sym, _name} = sym, {:pair, init, :null}}, rest},
-         env
+  defp parse_letrec_bindings(
+         {:pair, {:pair, {:sym, _} = sym, {:pair, init, :null}}, rest},
+         acc
        ) do
-    {:pair, {:pair, sym, {:pair, expand(init, env), :null}}, expand_letrec_bindings(rest, env)}
+    parse_letrec_bindings(rest, [{sym, init} | acc])
   end
 
-  defp expand_letrec_bindings(_, _env), do: raise(Error, reason: {:bad_special_form, "letrec*"})
+  defp parse_letrec_bindings(_, _),
+    do: raise(Error, reason: {:bad_special_form, "letrec*"})
 
   defp expand_let_syntax({:pair, bindings_form, body}, env) when body != :null do
     bindings = parse_syntax_bindings(bindings_form, env, "let-syntax")

--- a/lib/schooner/expander.ex
+++ b/lib/schooner/expander.ex
@@ -1,0 +1,413 @@
+defmodule Schooner.Expander do
+  @moduledoc """
+  Datum-AST → core-AST expansion pass.
+
+  Walks the reader's output, applies `define-syntax` / `let-syntax` /
+  `letrec-syntax` bindings to expand macro uses, and leaves only the
+  core forms — `quote`, `if`, `lambda`, top-level `define`, `begin`,
+  application, and variable reference — for the evaluator to consume.
+  Everything else, including all of phase 7's derived forms, lives as
+  a `syntax-rules` macro registered in the bootstrap syntax env.
+
+  Hygiene is by alpha-renaming with a fresh per-expansion mark; see
+  `Schooner.Expander.SyntaxRules` for the details. The expander's job
+  in this module is to drive expansion until a fixed point and to
+  shadow macro keywords with `:variable` frames so that an inner
+  `let` shadowing the bootstrap `let` does the expected thing.
+
+  ## Top-level vs. internal `define-syntax`
+
+  Top-level `define-syntax` is the supported form. Bodies that mix
+  internal `define-syntax` with internal `define` are not yet handled
+  — `let-syntax` / `letrec-syntax` cover the in-body needs and the
+  spec leaves the internal-define-syntax case off the critical path.
+  """
+
+  alias Schooner.Eval.Error
+  alias Schooner.Expander.Derived
+  alias Schooner.Expander.SyntaxEnv
+  alias Schooner.Expander.SyntaxRules
+  alias Schooner.Reader
+  alias Schooner.Value
+
+  # `letrec*` is intentionally retained as a core form: it backs both
+  # user-facing recursive bindings and the internal-define splicing
+  # done at evaluation time, and a fully-macroised replacement would
+  # need either mutation or a hand-built fix-point combinator.
+  @core_specials MapSet.new(~w(quote if lambda define begin set! letrec*))
+
+  @doc """
+  Expand a list of top-level forms in `env`. Returns a list of
+  expanded forms with all `define-syntax` / `let-syntax` /
+  `letrec-syntax` and macro uses resolved to core forms.
+  """
+  @spec expand_program([Value.t()], SyntaxEnv.t()) :: [Value.t()]
+  def expand_program(forms, %SyntaxEnv{} = env) when is_list(forms) do
+    {expanded, _env} = expand_top_seq(forms, env, [])
+    expanded
+  end
+
+  @doc """
+  Return the cached bootstrap syntax env containing the derived-form
+  macros. Computed lazily on first call and cached via
+  `:persistent_term` so that subsequent runs do not re-parse the
+  bootstrap source.
+  """
+  @spec bootstrap_env() :: SyntaxEnv.t()
+  def bootstrap_env do
+    case :persistent_term.get({__MODULE__, :bootstrap_env}, :unset) do
+      :unset ->
+        env = build_bootstrap_env()
+        :persistent_term.put({__MODULE__, :bootstrap_env}, env)
+        env
+
+      env ->
+        env
+    end
+  end
+
+  defp build_bootstrap_env do
+    forms = Reader.read_string(Derived.source())
+    {_, env} = expand_top_seq(forms, SyntaxEnv.new(), [])
+    env
+  end
+
+  # ---------------------------------------------------------------------------
+  # Top-level sequence
+  # ---------------------------------------------------------------------------
+
+  defp expand_top_seq([], env, acc), do: {Enum.reverse(acc), env}
+
+  defp expand_top_seq([form | rest], env, acc) do
+    case expand_top(form, env) do
+      {:syntax_def, env2} -> expand_top_seq(rest, env2, acc)
+      expanded -> expand_top_seq(rest, env, [expanded | acc])
+    end
+  end
+
+  defp expand_top({:pair, {:sym, "define-syntax"}, tail}, env) do
+    {name, transformer} = parse_define_syntax(tail, env)
+    {:syntax_def, SyntaxEnv.define_macro(env, name, transformer)}
+  end
+
+  defp expand_top({:pair, {:sym, "begin"}, body}, env) do
+    case expand_top_begin(body, env, []) do
+      {:syntax_def, env2} -> {:syntax_def, env2}
+      expanded -> expanded
+    end
+  end
+
+  defp expand_top(form, env), do: expand(form, env)
+
+  defp expand_top_begin(:null, env, acc) do
+    {:pair, {:sym, "begin"}, build_list(Enum.reverse(acc))}
+    |> finalise_top_begin(env, acc)
+  end
+
+  defp expand_top_begin({:pair, form, rest}, env, acc) do
+    case expand_top(form, env) do
+      {:syntax_def, env2} -> expand_top_begin(rest, env2, acc)
+      expanded -> expand_top_begin(rest, env, [expanded | acc])
+    end
+  end
+
+  defp expand_top_begin(_, _env, _acc), do: raise(Error, reason: {:bad_special_form, "begin"})
+
+  defp finalise_top_begin(_form, env, []), do: {:syntax_def, env}
+
+  defp finalise_top_begin(form, _env, _acc), do: form
+
+  defp build_list([]), do: :null
+  defp build_list([h | t]), do: {:pair, h, build_list(t)}
+
+  # ---------------------------------------------------------------------------
+  # Recursive expansion of an arbitrary form
+  # ---------------------------------------------------------------------------
+
+  @doc "Expand a single form to a fixed point."
+  @spec expand(Value.t(), SyntaxEnv.t()) :: Value.t()
+  def expand({:pair, {:sym, "quote"}, _} = form, _env), do: form
+
+  def expand({:pair, {:sym, "lambda"}, tail}, env), do: expand_lambda(tail, env)
+
+  def expand({:pair, {:sym, "define"}, tail}, env), do: expand_define(tail, env)
+
+  def expand({:pair, {:sym, "if"}, tail}, env), do: expand_if(tail, env)
+
+  def expand({:pair, {:sym, "begin"}, tail}, env) do
+    {:pair, {:sym, "begin"}, expand_each(tail, env)}
+  end
+
+  def expand({:pair, {:sym, "letrec*"}, tail}, env), do: expand_letrec_star(tail, env)
+
+  def expand({:pair, {:sym, "set!"}, _tail}, _env) do
+    raise Error, reason: {:bad_special_form, "set!"}
+  end
+
+  def expand({:pair, {:sym, "let-syntax"}, tail}, env), do: expand_let_syntax(tail, env)
+
+  def expand({:pair, {:sym, "letrec-syntax"}, tail}, env), do: expand_letrec_syntax(tail, env)
+
+  def expand({:pair, {:sym, "define-syntax"}, _tail}, _env) do
+    raise Error, reason: :nested_define_syntax_unsupported
+  end
+
+  def expand({:pair, {:sym, "quasiquote"}, _tail} = form, env) do
+    expand_quasiquote(form, env, 1)
+  end
+
+  def expand({:pair, {:sym, name}, _args} = form, env) do
+    case lookup_with_fallback(env, name) do
+      {:macro, transformer} ->
+        new_form = transformer.(form)
+        expand(new_form, env)
+
+      {:special, base} ->
+        # A core special form's name appeared with a hygiene mark.
+        # Re-dispatch on the canonical name so the special-form
+        # clauses above pick it up and emit canonical output.
+        canonicalise_special(base, form, env)
+
+      _ ->
+        expand_application(form, env)
+    end
+  end
+
+  def expand({:pair, _head, _tail} = form, env), do: expand_application(form, env)
+
+  def expand({:sym, _} = sym, _env), do: sym
+  def expand(:null, _env), do: :null
+  def expand(other, _env), do: other
+
+  # ---------------------------------------------------------------------------
+  # Special-form expanders
+  # ---------------------------------------------------------------------------
+
+  defp expand_application({:pair, head, args}, env) do
+    {:pair, expand(head, env), expand_each(args, env)}
+  end
+
+  # Recognise a special-form name that has been alpha-renamed by hygiene
+  # (e.g. `lambda<NUL>42` produced from a template that didn't list the
+  # special form in its `core_keywords` set). We re-dispatch on the
+  # canonical form so the dedicated `expand_lambda` / `expand_define` /
+  # ... clauses do their thing and the output stays canonical.
+  defp canonicalise_special(base, {:pair, {:sym, _}, tail}, env) do
+    expand({:pair, {:sym, base}, tail}, env)
+  end
+
+  # Walk the syntax env for `name`. If unbound, strip a hygiene mark
+  # and try again. If the stripped name is a known core special form,
+  # report that so the caller can re-dispatch on its canonical name.
+  defp lookup_with_fallback(env, name) do
+    case SyntaxEnv.lookup(env, name) do
+      :undefined -> resolve_marked(env, name)
+      binding -> binding
+    end
+  end
+
+  defp resolve_marked(env, name) do
+    case SyntaxRules.strip_mark(name) do
+      :error -> :undefined
+      {:ok, base} -> resolve_base(env, base)
+    end
+  end
+
+  defp resolve_base(env, base) do
+    if MapSet.member?(@core_specials, base) do
+      {:special, base}
+    else
+      case SyntaxEnv.lookup(env, base) do
+        {:macro, _} = m -> m
+        _ -> :undefined
+      end
+    end
+  end
+
+  defp expand_each(:null, _env), do: :null
+
+  defp expand_each({:pair, h, t}, env) do
+    {:pair, expand(h, env), expand_each(t, env)}
+  end
+
+  defp expand_each(other, _env), do: other
+
+  defp expand_lambda({:pair, params_form, body}, env) when body != :null do
+    inner = SyntaxEnv.push_variables(env, collect_param_names(params_form))
+    {:pair, {:sym, "lambda"}, {:pair, params_form, expand_each(body, inner)}}
+  end
+
+  defp expand_lambda(_, _env), do: raise(Error, reason: {:bad_special_form, "lambda"})
+
+  defp collect_param_names({:sym, name}), do: [name]
+  defp collect_param_names(:null), do: []
+
+  defp collect_param_names({:pair, {:sym, name}, rest}) do
+    [name | collect_param_names(rest)]
+  end
+
+  defp collect_param_names(_), do: raise(Error, reason: {:bad_special_form, "lambda"})
+
+  defp expand_define({:pair, {:sym, name}, {:pair, expr, :null}}, env) do
+    {:pair, {:sym, "define"}, {:pair, {:sym, name}, {:pair, expand(expr, env), :null}}}
+  end
+
+  defp expand_define({:pair, {:pair, {:sym, name}, params}, body}, env) when body != :null do
+    inner = SyntaxEnv.push_variables(env, collect_param_names(params))
+    expanded_body = expand_each(body, inner)
+
+    {:pair, {:sym, "define"}, {:pair, {:pair, {:sym, name}, params}, expanded_body}}
+  end
+
+  defp expand_define(_, _env), do: raise(Error, reason: {:bad_special_form, "define"})
+
+  defp expand_if({:pair, test, {:pair, then_e, :null}}, env) do
+    {:pair, {:sym, "if"}, {:pair, expand(test, env), {:pair, expand(then_e, env), :null}}}
+  end
+
+  defp expand_if({:pair, test, {:pair, then_e, {:pair, else_e, :null}}}, env) do
+    {:pair, {:sym, "if"},
+     {:pair, expand(test, env), {:pair, expand(then_e, env), {:pair, expand(else_e, env), :null}}}}
+  end
+
+  defp expand_if(_, _env), do: raise(Error, reason: {:bad_special_form, "if"})
+
+  defp expand_letrec_star({:pair, bindings_form, body}, env) when body != :null do
+    names = letrec_binding_names(bindings_form)
+    inner = SyntaxEnv.push_variables(env, names)
+    expanded_bindings = expand_letrec_bindings(bindings_form, inner)
+    expanded_body = expand_each(body, inner)
+
+    {:pair, {:sym, "letrec*"}, {:pair, expanded_bindings, expanded_body}}
+  end
+
+  defp expand_letrec_star(_, _env), do: raise(Error, reason: {:bad_special_form, "letrec*"})
+
+  defp letrec_binding_names(:null), do: []
+
+  defp letrec_binding_names({:pair, {:pair, {:sym, name}, _}, rest}) do
+    [name | letrec_binding_names(rest)]
+  end
+
+  defp letrec_binding_names(_), do: raise(Error, reason: {:bad_special_form, "letrec*"})
+
+  defp expand_letrec_bindings(:null, _env), do: :null
+
+  defp expand_letrec_bindings(
+         {:pair, {:pair, {:sym, _name} = sym, {:pair, init, :null}}, rest},
+         env
+       ) do
+    {:pair, {:pair, sym, {:pair, expand(init, env), :null}}, expand_letrec_bindings(rest, env)}
+  end
+
+  defp expand_letrec_bindings(_, _env), do: raise(Error, reason: {:bad_special_form, "letrec*"})
+
+  defp expand_let_syntax({:pair, bindings_form, body}, env) when body != :null do
+    bindings = parse_syntax_bindings(bindings_form, env, "let-syntax")
+    inner = SyntaxEnv.push_macros(env, bindings)
+    expanded = expand_each(body, inner)
+    wrap_body_as_form("let-syntax", expanded)
+  end
+
+  defp expand_let_syntax(_, _env), do: raise(Error, reason: {:bad_special_form, "let-syntax"})
+
+  defp expand_letrec_syntax({:pair, bindings_form, body}, env) when body != :null do
+    # Collect names first; compile transformers in an env that already
+    # knows about all the new macro names so a transformer can refer to
+    # its peers (mutually recursive macros).
+    names = collect_macro_binding_names(bindings_form, "letrec-syntax")
+
+    placeholder =
+      Enum.map(
+        names,
+        &{&1, fn _ -> raise Error, reason: {:bad_special_form, "letrec-syntax"} end}
+      )
+
+    rec_env = SyntaxEnv.push_macros(env, placeholder)
+    bindings = parse_syntax_bindings(bindings_form, rec_env, "letrec-syntax")
+    inner = SyntaxEnv.push_macros(env, bindings)
+    expanded = expand_each(body, inner)
+    wrap_body_as_form("letrec-syntax", expanded)
+  end
+
+  defp expand_letrec_syntax(_, _env),
+    do: raise(Error, reason: {:bad_special_form, "letrec-syntax"})
+
+  defp wrap_body_as_form(_ctx, {:pair, single, :null}), do: single
+  defp wrap_body_as_form(_ctx, body), do: {:pair, {:sym, "begin"}, body}
+
+  # ---------------------------------------------------------------------------
+  # define-syntax parsing
+  # ---------------------------------------------------------------------------
+
+  defp parse_define_syntax({:pair, {:sym, name}, {:pair, spec, :null}}, _env) do
+    {name, SyntaxRules.compile(spec)}
+  end
+
+  defp parse_define_syntax(_, _env),
+    do: raise(Error, reason: {:bad_special_form, "define-syntax"})
+
+  defp parse_syntax_bindings(:null, _env, _ctx), do: []
+
+  defp parse_syntax_bindings({:pair, {:pair, {:sym, name}, {:pair, spec, :null}}, rest}, env, ctx) do
+    [{name, SyntaxRules.compile(spec)} | parse_syntax_bindings(rest, env, ctx)]
+  end
+
+  defp parse_syntax_bindings(_, _env, ctx), do: raise(Error, reason: {:bad_special_form, ctx})
+
+  defp collect_macro_binding_names(:null, _ctx), do: []
+
+  defp collect_macro_binding_names(
+         {:pair, {:pair, {:sym, name}, {:pair, _spec, :null}}, rest},
+         ctx
+       ) do
+    [name | collect_macro_binding_names(rest, ctx)]
+  end
+
+  defp collect_macro_binding_names(_, ctx), do: raise(Error, reason: {:bad_special_form, ctx})
+
+  # ---------------------------------------------------------------------------
+  # Quasiquote — recurse into unquoted positions but leave quoted data
+  # ---------------------------------------------------------------------------
+
+  defp expand_quasiquote({:pair, {:sym, "quasiquote"}, {:pair, datum, :null}}, env, level) do
+    {:pair, {:sym, "quasiquote"}, {:pair, walk_quasi(datum, env, level), :null}}
+  end
+
+  defp expand_quasiquote(_, _env, _level),
+    do: raise(Error, reason: {:bad_special_form, "quasiquote"})
+
+  defp walk_quasi({:pair, {:sym, "unquote"}, {:pair, expr, :null}}, env, 1) do
+    {:pair, {:sym, "unquote"}, {:pair, expand(expr, env), :null}}
+  end
+
+  defp walk_quasi({:pair, {:sym, "unquote"}, {:pair, expr, :null}}, env, n) when n > 1 do
+    {:pair, {:sym, "unquote"}, {:pair, walk_quasi(expr, env, n - 1), :null}}
+  end
+
+  defp walk_quasi({:pair, {:sym, "unquote-splicing"}, {:pair, expr, :null}}, env, 1) do
+    {:pair, {:sym, "unquote-splicing"}, {:pair, expand(expr, env), :null}}
+  end
+
+  defp walk_quasi({:pair, {:sym, "unquote-splicing"}, {:pair, expr, :null}}, env, n) when n > 1 do
+    {:pair, {:sym, "unquote-splicing"}, {:pair, walk_quasi(expr, env, n - 1), :null}}
+  end
+
+  defp walk_quasi({:pair, {:sym, "quasiquote"}, {:pair, expr, :null}}, env, n) do
+    {:pair, {:sym, "quasiquote"}, {:pair, walk_quasi(expr, env, n + 1), :null}}
+  end
+
+  defp walk_quasi({:pair, h, t}, env, level) do
+    {:pair, walk_quasi(h, env, level), walk_quasi(t, env, level)}
+  end
+
+  defp walk_quasi({:vector, t}, env, level) do
+    new_items =
+      0..(tuple_size(t) - 1)//1
+      |> Enum.map(&walk_quasi(elem(t, &1), env, level))
+
+    {:vector, List.to_tuple(new_items)}
+  end
+
+  defp walk_quasi(other, _env, _level), do: other
+end

--- a/lib/schooner/expander/derived.ex
+++ b/lib/schooner/expander/derived.ex
@@ -1,0 +1,152 @@
+defmodule Schooner.Expander.Derived do
+  @moduledoc """
+  Source for the bootstrap macros that re-express phase 7's derived
+  forms (`cond`, `case`, `when`, `unless`, `and`, `or`, `let`, `let*`,
+  `letrec`, `letrec*`, named `let`, `do`) as `syntax-rules` macros.
+
+  The source is a string in Scheme; it is read and expanded once on
+  first call to `Schooner.Expander.bootstrap_env/0`, and the resulting
+  syntax env is cached via `:persistent_term`. Tests that exercise the
+  derived forms therefore go through this expansion path on every run.
+
+  ## Quasiquote
+
+  `quasiquote` stays as a special form in `Schooner.Eval` rather than
+  becoming a `syntax-rules` macro. r7rs §4.2.8 lays out a recursive,
+  level-aware definition that includes vector quasiquotation; that
+  level tracking is awkward to express with finite, non-recursive
+  `syntax-rules` rules, and the existing evaluator implementation is
+  the simpler home.
+  """
+
+  @source ~S"""
+  ;; -- when / unless ---------------------------------------------------------
+
+  (define-syntax when
+    (syntax-rules ()
+      ((_ test e1 e2 ...)
+       (if test (begin e1 e2 ...)))))
+
+  (define-syntax unless
+    (syntax-rules ()
+      ((_ test e1 e2 ...)
+       (if test (begin) (begin e1 e2 ...)))))
+
+  ;; -- and / or --------------------------------------------------------------
+
+  (define-syntax and
+    (syntax-rules ()
+      ((_) #t)
+      ((_ e) e)
+      ((_ e1 e2 e3 ...) (if e1 (and e2 e3 ...) #f))))
+
+  (define-syntax or
+    (syntax-rules ()
+      ((_) #f)
+      ((_ e) e)
+      ((_ e1 e2 e3 ...)
+       (let ((t e1)) (if t t (or e2 e3 ...))))))
+
+  ;; -- let family ------------------------------------------------------------
+  ;;
+  ;; `letrec*` stays a core special form (it's the workhorse for both
+  ;; user-facing recursive bindings and internal-define splicing), so
+  ;; the macros below stop at expanding to it. The named-let pattern
+  ;; deliberately applies the recursive closure *inside* the letrec*
+  ;; body — returning the closure and applying it outside would let
+  ;; the closure outlive the rec frame and crash on first recursion.
+
+  (define-syntax let
+    (syntax-rules ()
+      ((_ () body1 body2 ...)
+       ((lambda () body1 body2 ...)))
+      ((_ ((name val) ...) body1 body2 ...)
+       ((lambda (name ...) body1 body2 ...) val ...))
+      ((_ tag ((name val) ...) body1 body2 ...)
+       (letrec* ((tag (lambda (name ...) body1 body2 ...)))
+         (tag val ...)))))
+
+  (define-syntax let*
+    (syntax-rules ()
+      ((_ () body1 body2 ...) (let () body1 body2 ...))
+      ((_ ((n1 v1) (n2 v2) ...) body1 body2 ...)
+       (let ((n1 v1))
+         (let* ((n2 v2) ...) body1 body2 ...)))))
+
+  (define-syntax letrec
+    (syntax-rules ()
+      ((_ bindings body1 body2 ...)
+       (letrec* bindings body1 body2 ...))))
+
+  ;; -- cond ------------------------------------------------------------------
+
+  (define-syntax cond
+    (syntax-rules (else =>)
+      ((_) (begin))
+      ((_ (else e1 e2 ...)) (begin e1 e2 ...))
+      ((_ (test => proc))
+       (let ((tmp test)) (if tmp (proc tmp))))
+      ((_ (test => proc) clause clauses ...)
+       (let ((tmp test))
+         (if tmp (proc tmp) (cond clause clauses ...))))
+      ((_ (test)) test)
+      ((_ (test) clause clauses ...)
+       (let ((tmp test)) (if tmp tmp (cond clause clauses ...))))
+      ((_ (test e1 e2 ...)) (if test (begin e1 e2 ...)))
+      ((_ (test e1 e2 ...) clause clauses ...)
+       (if test (begin e1 e2 ...) (cond clause clauses ...)))))
+
+  ;; -- case ------------------------------------------------------------------
+
+  (define-syntax case
+    (syntax-rules (else =>)
+      ((_ key) (begin))
+      ((_ key (else => proc))
+       (let ((k key)) (proc k)))
+      ((_ key (else e1 e2 ...))
+       (begin e1 e2 ...))
+      ((_ key ((d1 d2 ...) => proc))
+       (let ((k key))
+         (if (memv k '(d1 d2 ...)) (proc k))))
+      ((_ key ((d1 d2 ...) => proc) clause clauses ...)
+       (let ((k key))
+         (if (memv k '(d1 d2 ...))
+             (proc k)
+             (case k clause clauses ...))))
+      ((_ key ((d1 d2 ...) e1 e2 ...))
+       (let ((k key))
+         (if (memv k '(d1 d2 ...)) (begin e1 e2 ...))))
+      ((_ key ((d1 d2 ...) e1 e2 ...) clause clauses ...)
+       (let ((k key))
+         (if (memv k '(d1 d2 ...))
+             (begin e1 e2 ...)
+             (case k clause clauses ...))))))
+
+  ;; -- do --------------------------------------------------------------------
+  ;;
+  ;; r7rs §4.2.4: bindings without an explicit step keep their value.
+  ;; The `do-step` helper macro below picks between the user-supplied
+  ;; step and the variable name by pattern-matching on shape.
+
+  (define-syntax do
+    (syntax-rules ()
+      ((_ ((var init step ...) ...) (test result ...) body ...)
+       (letrec*
+           ((loop
+             (lambda (var ...)
+               (if test
+                   (begin (begin) result ...)
+                   (begin
+                     body ...
+                     (loop (do-step var step ...) ...))))))
+         (loop init ...)))))
+
+  (define-syntax do-step
+    (syntax-rules ()
+      ((_ var) var)
+      ((_ var step) step)))
+  """
+
+  @spec source() :: binary()
+  def source, do: @source
+end

--- a/lib/schooner/expander/error.ex
+++ b/lib/schooner/expander/error.ex
@@ -1,0 +1,40 @@
+defmodule Schooner.Expander.Error do
+  @moduledoc """
+  Exception raised by `Schooner.Expander` for malformed macro forms,
+  failed pattern matches, and other expansion-time failures.
+  """
+
+  defexception [:reason, :message]
+
+  @impl true
+  def exception(opts) do
+    reason = Keyword.fetch!(opts, :reason)
+    %__MODULE__{reason: reason, message: format(reason)}
+  end
+
+  defp format({:bad_syntax, name}), do: "malformed `#{name}` form"
+
+  defp format({:no_matching_rule, keyword}) do
+    "no matching `syntax-rules` clause for `#{keyword}`"
+  end
+
+  defp format({:bad_template, reason}), do: "malformed macro template: #{reason}"
+  defp format({:bad_pattern, reason}), do: "malformed macro pattern: #{reason}"
+  defp format(:duplicate_pattern_var), do: "duplicate pattern variable in `syntax-rules` pattern"
+
+  defp format({:ellipsis_count_mismatch, name}) do
+    "ellipsis substitution counts for pattern variable `#{name}` do not agree"
+  end
+
+  defp format({:ellipsis_no_pattern_var, where}) do
+    "no pattern variable to drive ellipsis in #{where}"
+  end
+
+  defp format({:syntax_rules_arity, count}) do
+    "`syntax-rules` requires a literals list and at least one rule (got #{count} forms)"
+  end
+
+  defp format(:nested_define_syntax_unsupported) do
+    "`define-syntax` is currently only supported at top level"
+  end
+end

--- a/lib/schooner/expander/syntax_env.ex
+++ b/lib/schooner/expander/syntax_env.ex
@@ -20,8 +20,6 @@ defmodule Schooner.Expander.SyntaxEnv do
   through top-level forms.
   """
 
-  alias Schooner.Expander.SyntaxRules
-
   @type transformer :: (term() -> term())
   @type binding ::
           {:macro, transformer()}
@@ -89,24 +87,5 @@ defmodule Schooner.Expander.SyntaxEnv do
   def push_variables(%__MODULE__{lex: lex} = env, names) when is_list(names) do
     frame = Map.new(names, &{&1, :variable})
     %{env | lex: [frame | lex]}
-  end
-
-  @doc "True iff `name` resolves to a macro binding."
-  @spec macro?(t(), binary()) :: boolean()
-  def macro?(env, name) do
-    case lookup(env, name) do
-      {:macro, _} -> true
-      _ -> false
-    end
-  end
-
-  @doc """
-  Compile and install a `syntax-rules` form as a top-level macro,
-  returning the updated env. Convenience for the bootstrap loader.
-  """
-  @spec define_syntax_rules(t(), binary(), term()) :: t()
-  def define_syntax_rules(env, name, syntax_rules_form) do
-    transformer = SyntaxRules.compile(syntax_rules_form)
-    define_macro(env, name, transformer)
   end
 end

--- a/lib/schooner/expander/syntax_env.ex
+++ b/lib/schooner/expander/syntax_env.ex
@@ -1,0 +1,112 @@
+defmodule Schooner.Expander.SyntaxEnv do
+  @moduledoc """
+  Compile-time environment used by `Schooner.Expander`.
+
+  Holds two kinds of bindings:
+
+    * **Macros** — a transformer function and a set of "literals" used by
+      `syntax-rules` to recognise constants in patterns. Transformers are
+      stored both globally (top-level `define-syntax`) and per-frame
+      (`let-syntax`, `letrec-syntax`).
+    * **Variables** — names bound as runtime values (lambda parameters,
+      `define`s, `let`s after expansion). The expander records these only
+      so that an inner `let` shadowing a macro keyword does the right
+      thing: an enclosed reference resolves as a variable rather than as
+      the outer macro.
+
+  Frames are kept innermost-first. Resolution walks the lex frames and
+  then the global map. Globals are intentionally a plain map rather than
+  ETS — the syntax env is purely functional in the expander, threaded
+  through top-level forms.
+  """
+
+  alias Schooner.Expander.SyntaxRules
+
+  @type transformer :: (term() -> term())
+  @type binding ::
+          {:macro, transformer()}
+          | :variable
+  @type frame :: %{optional(binary()) => binding()}
+  @type t :: %__MODULE__{globals: frame(), lex: [frame()]}
+
+  defstruct globals: %{}, lex: []
+
+  @spec new() :: t()
+  def new, do: %__MODULE__{}
+
+  @doc """
+  Resolve a name to its binding kind. Returns `:undefined` if the name
+  is not bound as a syntax keyword or as a variable in any visible
+  frame; the caller should treat that as a runtime free reference.
+  """
+  @spec lookup(t(), binary()) :: binding() | :undefined
+  def lookup(%__MODULE__{lex: lex, globals: g}, name) when is_binary(name) do
+    case lex_lookup(lex, name) do
+      {:ok, binding} -> binding
+      :error -> Map.get(g, name, :undefined)
+    end
+  end
+
+  defp lex_lookup([], _name), do: :error
+
+  defp lex_lookup([frame | rest], name) do
+    case Map.fetch(frame, name) do
+      {:ok, _} = ok -> ok
+      :error -> lex_lookup(rest, name)
+    end
+  end
+
+  @doc """
+  Return a new env with `name` bound at top level to `transformer`.
+
+  Used for top-level `define-syntax`. Idempotently overwrites a
+  pre-existing binding under the same name (consistent with
+  `Env.define/3` for runtime values).
+  """
+  @spec define_macro(t(), binary(), transformer()) :: t()
+  def define_macro(%__MODULE__{globals: g} = env, name, transformer)
+      when is_binary(name) and is_function(transformer, 1) do
+    %{env | globals: Map.put(g, name, {:macro, transformer})}
+  end
+
+  @doc """
+  Push a fresh lexical frame containing the given macro bindings. Used
+  by `let-syntax` and `letrec-syntax`.
+  """
+  @spec push_macros(t(), [{binary(), transformer()}]) :: t()
+  def push_macros(%__MODULE__{lex: lex} = env, bindings) do
+    frame = Map.new(bindings, fn {name, t} -> {name, {:macro, t}} end)
+    %{env | lex: [frame | lex]}
+  end
+
+  @doc """
+  Push a fresh lexical frame marking the given names as variables. Used
+  when entering a `lambda`, `let`, etc., so that an enclosed reference
+  to a name shadowed by the lex binding is not later interpreted as a
+  reference to an outer macro of the same name.
+  """
+  @spec push_variables(t(), [binary()]) :: t()
+  def push_variables(%__MODULE__{lex: lex} = env, names) when is_list(names) do
+    frame = Map.new(names, &{&1, :variable})
+    %{env | lex: [frame | lex]}
+  end
+
+  @doc "True iff `name` resolves to a macro binding."
+  @spec macro?(t(), binary()) :: boolean()
+  def macro?(env, name) do
+    case lookup(env, name) do
+      {:macro, _} -> true
+      _ -> false
+    end
+  end
+
+  @doc """
+  Compile and install a `syntax-rules` form as a top-level macro,
+  returning the updated env. Convenience for the bootstrap loader.
+  """
+  @spec define_syntax_rules(t(), binary(), term()) :: t()
+  def define_syntax_rules(env, name, syntax_rules_form) do
+    transformer = SyntaxRules.compile(syntax_rules_form)
+    define_macro(env, name, transformer)
+  end
+end

--- a/lib/schooner/expander/syntax_rules.ex
+++ b/lib/schooner/expander/syntax_rules.ex
@@ -35,17 +35,20 @@ defmodule Schooner.Expander.SyntaxRules do
   ## Hygiene
 
   At instantiation time each template-introduced identifier is
-  rewritten to `name + @mark_separator + mark` where `mark` is a
-  fresh integer per expansion. Pattern variables are substituted
-  verbatim, preserving any marks on user-supplied identifiers.
+  rewritten to `name <> @mark_separator <> Integer.to_string(mark)`
+  where `mark` is a fresh integer per expansion and the separator
+  is a NUL byte (invalid in r7rs identifiers, so the marked name
+  cannot collide with anything a user can write). Pattern variables
+  are substituted verbatim, preserving any marks on user-supplied
+  identifiers.
 
   At lookup time (in the expander's syntax env and in the evaluator's
   runtime env), an unmarked-base fallback handles free template
-  references — `+__42` is bound nowhere lexically, so the lookup
-  strips the mark and finds the global `+`. Template-introduced
-  binders such as the `t` in `(let ((t e1)) ...)` keep the mark
-  through both the binding and reference sites, which is what makes
-  the macro hygienic.
+  references — a marked `+` is bound nowhere lexically, so the
+  lookup strips the mark and finds the global `+`. Template-
+  introduced binders such as the `t` in `(let ((t e1)) ...)` keep
+  the mark through both the binding and reference sites, which is
+  what makes the macro hygienic.
   """
 
   alias Schooner.Eval.Error, as: EvalError
@@ -84,21 +87,26 @@ defmodule Schooner.Expander.SyntaxRules do
 
   def compile(_), do: raise(Error, reason: {:bad_syntax, "syntax-rules"})
 
-  @doc "Mark separator used by alpha-renaming. Exposed for the evaluator."
-  @spec mark_separator() :: binary()
-  def mark_separator, do: @mark_separator
-
   @doc """
   If `name` carries a hygiene mark, return `{:ok, base_name}` with the
   mark removed. Returns `:error` otherwise. Useful for the evaluator's
   fallback lookup and for the expander when an introduced keyword
   needs to be recognised as its base form.
+
+  Short-circuits with a no-allocation `:binary.match/2` before
+  falling into `:binary.split/2`, because the overwhelming common
+  case is unmarked names — every plain user-written variable
+  reference goes through this on a lookup miss.
   """
   @spec strip_mark(binary()) :: {:ok, binary()} | :error
   def strip_mark(name) when is_binary(name) do
-    case :binary.split(name, @mark_separator) do
-      [base, _mark] -> {:ok, base}
-      [_only] -> :error
+    case :binary.match(name, @mark_separator) do
+      :nomatch ->
+        :error
+
+      _ ->
+        [base, _mark] = :binary.split(name, @mark_separator)
+        {:ok, base}
     end
   end
 
@@ -156,7 +164,7 @@ defmodule Schooner.Expander.SyntaxRules do
   end
 
   defp compile_pattern({:vector, t}, literals, depth) do
-    items = Tuple.to_list(t) |> wrap_as_list()
+    items = t |> Tuple.to_list() |> Value.list()
 
     case compile_list_pattern(items, literals, depth, []) do
       {:list, head, :null} -> {:vector, head}
@@ -166,9 +174,6 @@ defmodule Schooner.Expander.SyntaxRules do
   end
 
   defp compile_pattern(other, _literals, _depth), do: {:const, other}
-
-  defp wrap_as_list([]), do: :null
-  defp wrap_as_list([h | t]), do: {:pair, h, wrap_as_list(t)}
 
   defp compile_list_pattern(
          {:pair, head, {:pair, {:sym, @ellipsis}, rest}},
@@ -278,7 +283,7 @@ defmodule Schooner.Expander.SyntaxRules do
   end
 
   defp compile_template({:vector, t}, pvars) do
-    items = Tuple.to_list(t) |> wrap_as_list()
+    items = t |> Tuple.to_list() |> Value.list()
     {:t_list, list_items, _tail} = compile_template_list(items, pvars, [])
     {:t_vector, list_items}
   end
@@ -330,7 +335,7 @@ defmodule Schooner.Expander.SyntaxRules do
     items =
       t
       |> Tuple.to_list()
-      |> wrap_as_list()
+      |> Value.list()
       |> compile_quoted_list(pvars, [])
 
     case items do
@@ -417,7 +422,7 @@ defmodule Schooner.Expander.SyntaxRules do
   end
 
   defp match({:vector, items}, {:vector, t}, env) do
-    list = wrap_as_list(Tuple.to_list(t))
+    list = Value.list(Tuple.to_list(t))
 
     case match_each(items, list, env) do
       {:ok, env2, :null} -> {:ok, env2}
@@ -426,7 +431,7 @@ defmodule Schooner.Expander.SyntaxRules do
   end
 
   defp match({:vector_ell, pre, ell, post}, {:vector, t}, env) do
-    list = wrap_as_list(Tuple.to_list(t))
+    list = Value.list(Tuple.to_list(t))
     match_list_ell(pre, ell, post, :null, list, env)
   end
 
@@ -456,11 +461,12 @@ defmodule Schooner.Expander.SyntaxRules do
   defp match_after_pre(ell_pat, post_pats, tail_pat, input, env) do
     {items, tail_input} = collect_proper(input)
     num_post = length(post_pats)
+    num_items = length(items)
 
-    if length(items) < num_post do
+    if num_items < num_post do
       :no_match
     else
-      {ell_items, post_items} = Enum.split(items, length(items) - num_post)
+      {ell_items, post_items} = Enum.split(items, num_items - num_post)
 
       with {:ok, ell_bindings} <- match_ellipsis(ell_pat, ell_items),
            env2 <- merge_bindings(env, ell_bindings),
@@ -623,11 +629,21 @@ defmodule Schooner.Expander.SyntaxRules do
       raise Error, reason: {:ellipsis_no_pattern_var, "quoted template"}
     end
 
-    count = ellipsis_iteration_count(pvars_used, env)
+    pvars_used
+    |> pvar_lists(env)
+    |> validate_pvar_lengths(pvars_used)
+    |> iterate_quoted_ellipsis(q, n, env, pvars_used)
+  end
 
-    Enum.flat_map(0..(count - 1)//1, fn i ->
-      expand_quoted_ellipsis(q, n - 1, ellipsis_sub_env(env, pvars_used, i))
-    end)
+  defp iterate_quoted_ellipsis([[] | _], _q, _n, _env, _pvars), do: []
+  defp iterate_quoted_ellipsis([], _q, _n, _env, _pvars), do: []
+
+  defp iterate_quoted_ellipsis(lists, q, n, env, pvars_used) do
+    {heads, tails} = peel_lists(lists, [], [])
+    sub_env = put_pvars(env, pvars_used, heads)
+
+    expand_quoted_ellipsis(q, n - 1, sub_env) ++
+      iterate_quoted_ellipsis(tails, q, n, env, pvars_used)
   end
 
   defp expand_template_items([], _env, _mark), do: []
@@ -649,40 +665,56 @@ defmodule Schooner.Expander.SyntaxRules do
       raise Error, reason: {:ellipsis_no_pattern_var, "template"}
     end
 
-    count = ellipsis_iteration_count(pvars_used, env)
-    iterate_ellipsis(tmpl, n, env, mark, pvars_used, count)
+    pvars_used
+    |> pvar_lists(env)
+    |> validate_pvar_lengths(pvars_used)
+    |> iterate_ellipsis(tmpl, n, env, mark, pvars_used)
   end
 
-  defp iterate_ellipsis(_tmpl, _n, _env, _mark, _pvars, 0), do: []
+  # The driving pvars all have the same length (or we'd raise) and we
+  # need O(N) total work per iteration count, not O(N²). Walk all
+  # the bound `:ellipsis_list`s in lockstep, peeling one element off
+  # each at every step and putting them into the sub-env. Termination
+  # is by emptiness of the first list — `validate_pvar_lengths` has
+  # already proved every list has the same length, so checking one
+  # is enough.
+  defp iterate_ellipsis([[] | _], _tmpl, _n, _env, _mark, _pvars), do: []
+  defp iterate_ellipsis([], _tmpl, _n, _env, _mark, _pvars), do: []
 
-  defp iterate_ellipsis(tmpl, n, env, mark, pvars_used, count) do
-    Enum.flat_map(0..(count - 1)//1, fn i ->
-      expand_ellipsis(tmpl, n - 1, ellipsis_sub_env(env, pvars_used, i), mark)
+  defp iterate_ellipsis(lists, tmpl, n, env, mark, pvars_used) do
+    {heads, tails} = peel_lists(lists, [], [])
+    sub_env = put_pvars(env, pvars_used, heads)
+
+    expand_ellipsis(tmpl, n - 1, sub_env, mark) ++
+      iterate_ellipsis(tails, tmpl, n, env, mark, pvars_used)
+  end
+
+  defp peel_lists([], head_acc, tail_acc),
+    do: {Enum.reverse(head_acc), Enum.reverse(tail_acc)}
+
+  defp peel_lists([[h | t] | rest], head_acc, tail_acc),
+    do: peel_lists(rest, [h | head_acc], [t | tail_acc])
+
+  defp put_pvars(env, [], []), do: env
+
+  defp put_pvars(env, [name | rest_names], [value | rest_values]),
+    do: put_pvars(Map.put(env, name, value), rest_names, rest_values)
+
+  defp pvar_lists(pvars_used, env) do
+    Enum.map(pvars_used, fn name ->
+      case Map.fetch(env, name) do
+        {:ok, {:ellipsis_list, list}} -> list
+        {:ok, _} -> raise Error, reason: {:bad_template, "pvar `#{name}` not under ellipsis"}
+        :error -> raise Error, reason: {:bad_template, "pvar `#{name}` unbound"}
+      end
     end)
   end
 
-  defp ellipsis_sub_env(env, pvars_used, i) do
-    Enum.reduce(pvars_used, env, fn name, acc ->
-      {:ellipsis_list, list} = Map.fetch!(acc, name)
-      Map.put(acc, name, Enum.at(list, i))
-    end)
-  end
-
-  defp ellipsis_iteration_count(pvars_used, env) do
-    counts = Enum.map(pvars_used, &count_for_pvar(&1, env))
-
-    case Enum.uniq(counts) do
-      [count] -> count
-      [] -> 0
+  defp validate_pvar_lengths(lists, pvars_used) do
+    case lists |> Enum.map(&length/1) |> Enum.uniq() do
+      [_] -> lists
+      [] -> []
       _ -> raise Error, reason: {:ellipsis_count_mismatch, hd(pvars_used)}
-    end
-  end
-
-  defp count_for_pvar(name, env) do
-    case Map.fetch(env, name) do
-      {:ok, {:ellipsis_list, list}} -> length(list)
-      {:ok, _} -> raise Error, reason: {:bad_template, "pvar `#{name}` not under ellipsis"}
-      :error -> raise Error, reason: {:bad_template, "pvar `#{name}` unbound"}
     end
   end
 

--- a/lib/schooner/expander/syntax_rules.ex
+++ b/lib/schooner/expander/syntax_rules.ex
@@ -1,0 +1,737 @@
+defmodule Schooner.Expander.SyntaxRules do
+  @moduledoc """
+  Compiles `syntax-rules` forms into transformer closures and
+  instantiates the chosen rule's template with hygienic alpha-renaming.
+
+  ## Compiled shapes
+
+  Patterns and templates are pre-compiled at `define-syntax` time so
+  that each macro use only does the work specific to that input —
+  pattern matching against a small AST and walking a small AST to
+  emit code.
+
+  Pattern AST nodes:
+
+    * `:wild`
+    * `{:literal, name}` — matches an identifier whose name equals
+      `name` (modulo mark-stripping)
+    * `{:pvar, name, depth}` — pattern variable; `depth` is the number
+      of enclosing ellipses (used to validate template uses)
+    * `{:const, value}` — matches `value` by `eqv?`
+    * `{:list, head_pats, tail_pat}` — proper-or-improper list
+    * `{:list_ell, pre_pats, ell_pat, post_pats, tail_pat}` — list with
+      one ellipsis
+
+  Template AST nodes:
+
+    * `{:t_sym, name}` — literal identifier from the template
+    * `{:t_pvar, name, depth}` — reference to a pattern variable
+    * `{:t_const, value}` — non-symbol leaf
+    * `{:t_list, items, tail}` — list (`items` is a list of
+      `{element_template, ellipsis_count}` tuples; `ellipsis_count` is
+      0 for plain elements and ≥ 1 for ellipsis-driven elements)
+    * `{:t_vector, items}`
+
+  ## Hygiene
+
+  At instantiation time each template-introduced identifier is
+  rewritten to `name + @mark_separator + mark` where `mark` is a
+  fresh integer per expansion. Pattern variables are substituted
+  verbatim, preserving any marks on user-supplied identifiers.
+
+  At lookup time (in the expander's syntax env and in the evaluator's
+  runtime env), an unmarked-base fallback handles free template
+  references — `+__42` is bound nowhere lexically, so the lookup
+  strips the mark and finds the global `+`. Template-introduced
+  binders such as the `t` in `(let ((t e1)) ...)` keep the mark
+  through both the binding and reference sites, which is what makes
+  the macro hygienic.
+  """
+
+  alias Schooner.Eval.Error, as: EvalError
+  alias Schooner.Expander.Error
+  alias Schooner.Value
+
+  @ellipsis "..."
+  @mark_separator <<0>>
+
+  @core_keywords MapSet.new(~w(
+    quote if lambda define begin set!
+    define-syntax let-syntax letrec-syntax syntax-rules
+    quasiquote unquote unquote-splicing
+  ))
+
+  @doc """
+  Compile a `syntax-rules` form into a transformer of arity 1 (the
+  form being expanded) → expanded form.
+
+  The transformer raises `Schooner.Eval.Error` with reason
+  `{:bad_special_form, name}` if no rule matches the supplied form,
+  mirroring what the throwaway phase-7 evaluator branches did so
+  that the regression tests preserved from that phase need no
+  special-casing for the expansion-time exception class.
+  """
+  @spec compile(Value.t()) :: (Value.t() -> Value.t())
+  def compile({:pair, {:sym, "syntax-rules"}, tail}) do
+    {literals, rules_form} = parse_spec_head(tail)
+    rules = parse_rules(rules_form, literals)
+
+    fn form ->
+      mark = :erlang.unique_integer([:positive])
+      dispatch(rules, form, mark)
+    end
+  end
+
+  def compile(_), do: raise(Error, reason: {:bad_syntax, "syntax-rules"})
+
+  @doc "Mark separator used by alpha-renaming. Exposed for the evaluator."
+  @spec mark_separator() :: binary()
+  def mark_separator, do: @mark_separator
+
+  @doc """
+  If `name` carries a hygiene mark, return `{:ok, base_name}` with the
+  mark removed. Returns `:error` otherwise. Useful for the evaluator's
+  fallback lookup and for the expander when an introduced keyword
+  needs to be recognised as its base form.
+  """
+  @spec strip_mark(binary()) :: {:ok, binary()} | :error
+  def strip_mark(name) when is_binary(name) do
+    case :binary.split(name, @mark_separator) do
+      [base, _mark] -> {:ok, base}
+      [_only] -> :error
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # syntax-rules parsing
+  # ---------------------------------------------------------------------------
+
+  defp parse_spec_head({:pair, literals_form, rules_form}) do
+    {parse_literals(literals_form, MapSet.new()), rules_form}
+  end
+
+  defp parse_spec_head(_), do: raise(Error, reason: {:bad_syntax, "syntax-rules"})
+
+  defp parse_literals(:null, acc), do: acc
+
+  defp parse_literals({:pair, {:sym, name}, rest}, acc) do
+    parse_literals(rest, MapSet.put(acc, name))
+  end
+
+  defp parse_literals(_, _), do: raise(Error, reason: {:bad_syntax, "syntax-rules"})
+
+  defp parse_rules(:null, _literals), do: []
+
+  defp parse_rules({:pair, {:pair, pat, {:pair, tmpl, :null}}, rest}, literals) do
+    cpat = compile_pattern(pat, literals, 0)
+    pvars = collect_pvars(cpat, %{})
+    ctmpl = compile_template(tmpl, pvars)
+    [{cpat, ctmpl} | parse_rules(rest, literals)]
+  end
+
+  defp parse_rules(_, _), do: raise(Error, reason: {:bad_syntax, "syntax-rules"})
+
+  # ---------------------------------------------------------------------------
+  # Pattern compilation
+  # ---------------------------------------------------------------------------
+
+  defp compile_pattern({:sym, "_"}, _literals, _depth), do: :wild
+
+  defp compile_pattern({:sym, @ellipsis}, _literals, _depth) do
+    raise Error, reason: {:bad_pattern, "stray ellipsis"}
+  end
+
+  defp compile_pattern({:sym, name}, literals, depth) do
+    if MapSet.member?(literals, name) do
+      {:literal, name}
+    else
+      {:pvar, name, depth}
+    end
+  end
+
+  defp compile_pattern(:null, _literals, _depth), do: {:list, [], :null}
+
+  defp compile_pattern({:pair, _, _} = list, literals, depth) do
+    compile_list_pattern(list, literals, depth, [])
+  end
+
+  defp compile_pattern({:vector, t}, literals, depth) do
+    items = Tuple.to_list(t) |> wrap_as_list()
+
+    case compile_list_pattern(items, literals, depth, []) do
+      {:list, head, :null} -> {:vector, head}
+      {:list_ell, pre, ell, post, :null} -> {:vector_ell, pre, ell, post}
+      _ -> raise Error, reason: {:bad_pattern, "vector pattern with dotted tail"}
+    end
+  end
+
+  defp compile_pattern(other, _literals, _depth), do: {:const, other}
+
+  defp wrap_as_list([]), do: :null
+  defp wrap_as_list([h | t]), do: {:pair, h, wrap_as_list(t)}
+
+  defp compile_list_pattern(
+         {:pair, head, {:pair, {:sym, @ellipsis}, rest}},
+         literals,
+         depth,
+         acc
+       ) do
+    ell_pat = compile_pattern(head, literals, depth + 1)
+    {post, tail} = compile_post_ellipsis(rest, literals, depth, [])
+    {:list_ell, Enum.reverse(acc), ell_pat, post, tail}
+  end
+
+  defp compile_list_pattern({:pair, head, rest}, literals, depth, acc) do
+    compile_list_pattern(rest, literals, depth, [compile_pattern(head, literals, depth) | acc])
+  end
+
+  defp compile_list_pattern(:null, _literals, _depth, acc) do
+    {:list, Enum.reverse(acc), :null}
+  end
+
+  defp compile_list_pattern(other, literals, depth, acc) do
+    {:list, Enum.reverse(acc), compile_pattern(other, literals, depth)}
+  end
+
+  defp compile_post_ellipsis(:null, _literals, _depth, acc), do: {Enum.reverse(acc), :null}
+
+  defp compile_post_ellipsis({:pair, {:sym, @ellipsis}, _}, _literals, _depth, _acc) do
+    raise Error, reason: {:bad_pattern, "two ellipses in one list"}
+  end
+
+  defp compile_post_ellipsis({:pair, head, rest}, literals, depth, acc) do
+    compile_post_ellipsis(rest, literals, depth, [compile_pattern(head, literals, depth) | acc])
+  end
+
+  defp compile_post_ellipsis(other, literals, depth, acc) do
+    {Enum.reverse(acc), compile_pattern(other, literals, depth)}
+  end
+
+  # ---------------------------------------------------------------------------
+  # Pattern variable collection
+  # ---------------------------------------------------------------------------
+
+  defp collect_pvars(:wild, acc), do: acc
+  defp collect_pvars(:null, acc), do: acc
+  defp collect_pvars({:literal, _}, acc), do: acc
+  defp collect_pvars({:const, _}, acc), do: acc
+
+  defp collect_pvars({:pvar, name, depth}, acc) do
+    if Map.has_key?(acc, name) do
+      raise Error, reason: :duplicate_pattern_var
+    else
+      Map.put(acc, name, depth)
+    end
+  end
+
+  defp collect_pvars({:list, head, tail}, acc) do
+    acc = Enum.reduce(head, acc, &collect_pvars/2)
+    collect_pvars(tail, acc)
+  end
+
+  defp collect_pvars({:list_ell, pre, ell, post, tail}, acc) do
+    acc = Enum.reduce(pre, acc, &collect_pvars/2)
+    acc = collect_pvars(ell, acc)
+    acc = Enum.reduce(post, acc, &collect_pvars/2)
+    collect_pvars(tail, acc)
+  end
+
+  defp collect_pvars({:vector, items}, acc) do
+    Enum.reduce(items, acc, &collect_pvars/2)
+  end
+
+  defp collect_pvars({:vector_ell, pre, ell, post}, acc) do
+    acc = Enum.reduce(pre, acc, &collect_pvars/2)
+    acc = collect_pvars(ell, acc)
+    Enum.reduce(post, acc, &collect_pvars/2)
+  end
+
+  # ---------------------------------------------------------------------------
+  # Template compilation
+  # ---------------------------------------------------------------------------
+
+  defp compile_template({:sym, @ellipsis}, _pvars) do
+    raise Error, reason: {:bad_template, "stray ellipsis"}
+  end
+
+  defp compile_template({:sym, name}, pvars) do
+    case Map.fetch(pvars, name) do
+      {:ok, depth} -> {:t_pvar, name, depth}
+      :error -> {:t_sym, name}
+    end
+  end
+
+  defp compile_template(:null, _pvars), do: {:t_list, [], :null}
+
+  # `(quote datum)` in a template emits `(quote datum)` verbatim. The
+  # datum is data — its non-pattern-variable identifiers must NOT
+  # pick up hygiene marks so a quoted symbol comes out the way the
+  # author wrote it. Pattern variables inside the datum do still
+  # substitute (the standard `case` macro relies on `'(d ...)` to
+  # produce a list of the literal datums for `memv`).
+  defp compile_template({:pair, {:sym, "quote"}, {:pair, datum, :null}}, pvars) do
+    {:t_quote, compile_quoted_datum(datum, pvars)}
+  end
+
+  defp compile_template({:pair, _, _} = list, pvars) do
+    compile_template_list(list, pvars, [])
+  end
+
+  defp compile_template({:vector, t}, pvars) do
+    items = Tuple.to_list(t) |> wrap_as_list()
+    {:t_list, list_items, _tail} = compile_template_list(items, pvars, [])
+    {:t_vector, list_items}
+  end
+
+  defp compile_template(other, _pvars), do: {:t_const, other}
+
+  defp compile_template_list({:pair, head, rest}, pvars, acc) do
+    item_tmpl = compile_template(head, pvars)
+    {n, after_dots} = count_template_ellipses(rest, 0)
+    compile_template_list(after_dots, pvars, [{item_tmpl, n} | acc])
+  end
+
+  defp compile_template_list(:null, _pvars, acc), do: {:t_list, Enum.reverse(acc), :null}
+
+  defp compile_template_list(other, pvars, acc) do
+    {:t_list, Enum.reverse(acc), compile_template(other, pvars)}
+  end
+
+  defp count_template_ellipses({:pair, {:sym, @ellipsis}, rest}, n) do
+    count_template_ellipses(rest, n + 1)
+  end
+
+  defp count_template_ellipses(rest, n), do: {n, rest}
+
+  # Walk a quoted datum into a parallel AST. Pattern variables within
+  # the datum are tagged for substitution (with their pattern depth
+  # preserved); every other identifier becomes a literal `:q_sym`
+  # whose name will be emitted verbatim, never with a hygiene mark.
+  # Ellipsis sequences (`(d ...)`) are recognised so a quoted spread
+  # behaves the same way a non-quoted spread does.
+  defp compile_quoted_datum({:sym, @ellipsis}, _pvars) do
+    raise Error, reason: {:bad_template, "stray ellipsis in quoted datum"}
+  end
+
+  defp compile_quoted_datum({:sym, name}, pvars) do
+    case Map.fetch(pvars, name) do
+      {:ok, depth} -> {:q_pvar, name, depth}
+      :error -> {:q_sym, name}
+    end
+  end
+
+  defp compile_quoted_datum(:null, _pvars), do: {:q_list, [], :q_null}
+
+  defp compile_quoted_datum({:pair, _, _} = list, pvars) do
+    compile_quoted_list(list, pvars, [])
+  end
+
+  defp compile_quoted_datum({:vector, t}, pvars) do
+    items =
+      t
+      |> Tuple.to_list()
+      |> wrap_as_list()
+      |> compile_quoted_list(pvars, [])
+
+    case items do
+      {:q_list, list_items, :q_null} -> {:q_vector, list_items}
+      _ -> raise Error, reason: {:bad_template, "vector quoted datum has dotted tail"}
+    end
+  end
+
+  defp compile_quoted_datum(other, _pvars), do: {:q_const, other}
+
+  defp compile_quoted_list({:pair, head, rest}, pvars, acc) do
+    item = compile_quoted_datum(head, pvars)
+    {n, after_dots} = count_template_ellipses(rest, 0)
+    compile_quoted_list(after_dots, pvars, [{item, n} | acc])
+  end
+
+  defp compile_quoted_list(:null, _pvars, acc), do: {:q_list, Enum.reverse(acc), :q_null}
+
+  defp compile_quoted_list(other, pvars, acc) do
+    {:q_list, Enum.reverse(acc), compile_quoted_datum(other, pvars)}
+  end
+
+  # ---------------------------------------------------------------------------
+  # Dispatch — try each rule in order
+  # ---------------------------------------------------------------------------
+
+  defp dispatch([], form, _mark) do
+    # Phase 7 raised `Schooner.Eval.Error` with `{:bad_special_form,
+    # name}` for malformed uses of derived forms. The macro layer
+    # mirrors that contract: a use that matches no `syntax-rules`
+    # clause is, from the caller's point of view, the same kind of
+    # failure as a malformed special-form invocation, so the regression
+    # tests carried over from phase 7 do not need to special-case the
+    # macro expander's exception class.
+    raise EvalError, reason: {:bad_special_form, form_keyword(form)}
+  end
+
+  defp dispatch([{cpat, ctmpl} | rest], form, mark) do
+    case match(cpat, form, %{}) do
+      {:ok, env} -> instantiate(ctmpl, env, mark)
+      :no_match -> dispatch(rest, form, mark)
+    end
+  end
+
+  defp form_keyword({:pair, {:sym, name}, _}), do: name
+  defp form_keyword(_), do: "<form>"
+
+  # ---------------------------------------------------------------------------
+  # Pattern matching
+  # ---------------------------------------------------------------------------
+
+  defp match(:wild, _input, env), do: {:ok, env}
+
+  # `:null` shows up both as a compiled pattern (from a `()` literal)
+  # and as the "no dotted tail" sentinel inside a `{:list, _, :null}`
+  # term. In either reading the matching rule is the same: only
+  # the empty list satisfies it.
+  defp match(:null, :null, env), do: {:ok, env}
+  defp match(:null, _, _), do: :no_match
+
+  defp match({:literal, name}, {:sym, sym}, env) do
+    if same_identifier?(sym, name), do: {:ok, env}, else: :no_match
+  end
+
+  defp match({:literal, _}, _, _), do: :no_match
+
+  defp match({:pvar, name, _depth}, input, env) do
+    {:ok, Map.put(env, name, input)}
+  end
+
+  defp match({:const, v}, input, env) do
+    if Value.eqv?(v, input), do: {:ok, env}, else: :no_match
+  end
+
+  defp match({:list, head_pats, tail_pat}, input, env) do
+    case match_each(head_pats, input, env) do
+      {:ok, env2, rest} -> match(tail_pat, rest, env2)
+      :no_match -> :no_match
+    end
+  end
+
+  defp match({:list_ell, pre, ell, post, tail}, input, env) do
+    match_list_ell(pre, ell, post, tail, input, env)
+  end
+
+  defp match({:vector, items}, {:vector, t}, env) do
+    list = wrap_as_list(Tuple.to_list(t))
+
+    case match_each(items, list, env) do
+      {:ok, env2, :null} -> {:ok, env2}
+      _ -> :no_match
+    end
+  end
+
+  defp match({:vector_ell, pre, ell, post}, {:vector, t}, env) do
+    list = wrap_as_list(Tuple.to_list(t))
+    match_list_ell(pre, ell, post, :null, list, env)
+  end
+
+  defp match(_, _, _), do: :no_match
+
+  defp match_each([], rest, env), do: {:ok, env, rest}
+
+  defp match_each([p | rest_pats], {:pair, h, t}, env) do
+    case match(p, h, env) do
+      {:ok, env2} -> match_each(rest_pats, t, env2)
+      :no_match -> :no_match
+    end
+  end
+
+  defp match_each(_, _, _), do: :no_match
+
+  defp match_list_ell(pre_pats, ell_pat, post_pats, tail_pat, input, env) do
+    case match_each(pre_pats, input, env) do
+      {:ok, env2, rest_after_pre} ->
+        match_after_pre(ell_pat, post_pats, tail_pat, rest_after_pre, env2)
+
+      :no_match ->
+        :no_match
+    end
+  end
+
+  defp match_after_pre(ell_pat, post_pats, tail_pat, input, env) do
+    {items, tail_input} = collect_proper(input)
+    num_post = length(post_pats)
+
+    if length(items) < num_post do
+      :no_match
+    else
+      {ell_items, post_items} = Enum.split(items, length(items) - num_post)
+
+      with {:ok, ell_bindings} <- match_ellipsis(ell_pat, ell_items),
+           env2 <- merge_bindings(env, ell_bindings),
+           rest_form <- list_with_tail(post_items, tail_input),
+           {:ok, env3, leftover} <- match_each(post_pats, rest_form, env2),
+           {:ok, env4} <- match(tail_pat, leftover, env3) do
+        {:ok, env4}
+      else
+        _ -> :no_match
+      end
+    end
+  end
+
+  defp collect_proper(:null), do: {[], :null}
+
+  defp collect_proper({:pair, h, t}) do
+    {rest, tail} = collect_proper(t)
+    {[h | rest], tail}
+  end
+
+  defp collect_proper(other), do: {[], other}
+
+  defp list_with_tail([], tail), do: tail
+  defp list_with_tail([h | t], tail), do: {:pair, h, list_with_tail(t, tail)}
+
+  defp match_ellipsis(ell_pat, items) do
+    pvars = collect_pvars(ell_pat, %{}) |> Map.keys()
+    initial = Map.new(pvars, &{&1, []})
+
+    items
+    |> Enum.reduce_while({:ok, initial}, &accumulate_ellipsis_iter(&1, &2, ell_pat, pvars))
+    |> finalise_ellipsis()
+  end
+
+  defp accumulate_ellipsis_iter(item, {:ok, acc}, ell_pat, pvars) do
+    case match(ell_pat, item, %{}) do
+      {:ok, item_env} -> {:cont, {:ok, push_ellipsis_iter(acc, item_env, pvars)}}
+      :no_match -> {:halt, :no_match}
+    end
+  end
+
+  defp push_ellipsis_iter(acc, item_env, pvars) do
+    Enum.reduce(pvars, acc, fn name, a ->
+      Map.update!(a, name, fn list -> [Map.get(item_env, name) | list] end)
+    end)
+  end
+
+  defp finalise_ellipsis({:ok, acc}) do
+    {:ok, Map.new(acc, fn {k, list} -> {k, {:ellipsis_list, Enum.reverse(list)}} end)}
+  end
+
+  defp finalise_ellipsis(:no_match), do: :no_match
+
+  defp merge_bindings(env, ell_bindings) do
+    Enum.reduce(ell_bindings, env, fn {name, value}, acc -> Map.put(acc, name, value) end)
+  end
+
+  defp same_identifier?(name, name), do: true
+
+  defp same_identifier?(name1, name2) do
+    base1 = base_name(name1)
+    base2 = base_name(name2)
+    base1 == base2
+  end
+
+  defp base_name(name) do
+    case strip_mark(name) do
+      {:ok, base} -> base
+      :error -> name
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Template instantiation
+  # ---------------------------------------------------------------------------
+
+  defp instantiate(:null, _env, _mark), do: :null
+
+  defp instantiate({:t_sym, name}, _env, mark) do
+    if MapSet.member?(@core_keywords, name) do
+      {:sym, name}
+    else
+      {:sym, mark_name(name, mark)}
+    end
+  end
+
+  defp instantiate({:t_pvar, name, _depth}, env, _mark) do
+    case Map.fetch(env, name) do
+      {:ok, {:ellipsis_list, _}} ->
+        raise Error, reason: {:bad_template, "pattern variable `#{name}` used outside ellipsis"}
+
+      {:ok, value} ->
+        value
+
+      :error ->
+        raise Error, reason: {:bad_template, "unbound pattern variable `#{name}`"}
+    end
+  end
+
+  defp instantiate({:t_const, value}, _env, _mark), do: value
+
+  defp instantiate({:t_quote, q_datum}, env, _mark) do
+    {:pair, {:sym, "quote"}, {:pair, instantiate_quoted(q_datum, env), :null}}
+  end
+
+  defp instantiate({:t_list, items, tail}, env, mark) do
+    head_forms = expand_template_items(items, env, mark)
+    tail_form = instantiate(tail, env, mark)
+    list_with_tail(head_forms, tail_form)
+  end
+
+  defp instantiate({:t_vector, items}, env, mark) do
+    forms = expand_template_items(items, env, mark)
+    {:vector, List.to_tuple(forms)}
+  end
+
+  defp instantiate_quoted(:q_null, _env), do: :null
+  defp instantiate_quoted({:q_sym, name}, _env), do: {:sym, name}
+  defp instantiate_quoted({:q_const, v}, _env), do: v
+
+  defp instantiate_quoted({:q_pvar, name, _depth}, env) do
+    case Map.fetch(env, name) do
+      {:ok, {:ellipsis_list, _}} ->
+        raise Error,
+          reason: {:bad_template, "pattern variable `#{name}` used outside ellipsis (in quote)"}
+
+      {:ok, value} ->
+        value
+
+      :error ->
+        raise Error, reason: {:bad_template, "unbound pattern variable `#{name}`"}
+    end
+  end
+
+  defp instantiate_quoted({:q_list, items, tail}, env) do
+    head_data = expand_quoted_items(items, env)
+    list_with_tail(head_data, instantiate_quoted(tail, env))
+  end
+
+  defp instantiate_quoted({:q_vector, items}, env) do
+    {:vector, items |> expand_quoted_items(env) |> List.to_tuple()}
+  end
+
+  defp expand_quoted_items([], _env), do: []
+
+  defp expand_quoted_items([{q, 0} | rest], env) do
+    [instantiate_quoted(q, env) | expand_quoted_items(rest, env)]
+  end
+
+  defp expand_quoted_items([{q, n} | rest], env) when n >= 1 do
+    expand_quoted_ellipsis(q, n, env) ++ expand_quoted_items(rest, env)
+  end
+
+  defp expand_quoted_ellipsis(q, 0, env), do: [instantiate_quoted(q, env)]
+
+  defp expand_quoted_ellipsis(q, n, env) when n >= 1 do
+    pvars_used = quoted_pvars_at_depth(q, n)
+
+    if pvars_used == [] do
+      raise Error, reason: {:ellipsis_no_pattern_var, "quoted template"}
+    end
+
+    count = ellipsis_iteration_count(pvars_used, env)
+
+    Enum.flat_map(0..(count - 1)//1, fn i ->
+      expand_quoted_ellipsis(q, n - 1, ellipsis_sub_env(env, pvars_used, i))
+    end)
+  end
+
+  defp expand_template_items([], _env, _mark), do: []
+
+  defp expand_template_items([{tmpl, 0} | rest], env, mark) do
+    [instantiate(tmpl, env, mark) | expand_template_items(rest, env, mark)]
+  end
+
+  defp expand_template_items([{tmpl, n} | rest], env, mark) when n >= 1 do
+    expand_ellipsis(tmpl, n, env, mark) ++ expand_template_items(rest, env, mark)
+  end
+
+  defp expand_ellipsis(tmpl, 0, env, mark), do: [instantiate(tmpl, env, mark)]
+
+  defp expand_ellipsis(tmpl, n, env, mark) when n >= 1 do
+    pvars_used = template_pvars_at_depth(tmpl, n)
+
+    if pvars_used == [] do
+      raise Error, reason: {:ellipsis_no_pattern_var, "template"}
+    end
+
+    count = ellipsis_iteration_count(pvars_used, env)
+    iterate_ellipsis(tmpl, n, env, mark, pvars_used, count)
+  end
+
+  defp iterate_ellipsis(_tmpl, _n, _env, _mark, _pvars, 0), do: []
+
+  defp iterate_ellipsis(tmpl, n, env, mark, pvars_used, count) do
+    Enum.flat_map(0..(count - 1)//1, fn i ->
+      expand_ellipsis(tmpl, n - 1, ellipsis_sub_env(env, pvars_used, i), mark)
+    end)
+  end
+
+  defp ellipsis_sub_env(env, pvars_used, i) do
+    Enum.reduce(pvars_used, env, fn name, acc ->
+      {:ellipsis_list, list} = Map.fetch!(acc, name)
+      Map.put(acc, name, Enum.at(list, i))
+    end)
+  end
+
+  defp ellipsis_iteration_count(pvars_used, env) do
+    counts = Enum.map(pvars_used, &count_for_pvar(&1, env))
+
+    case Enum.uniq(counts) do
+      [count] -> count
+      [] -> 0
+      _ -> raise Error, reason: {:ellipsis_count_mismatch, hd(pvars_used)}
+    end
+  end
+
+  defp count_for_pvar(name, env) do
+    case Map.fetch(env, name) do
+      {:ok, {:ellipsis_list, list}} -> length(list)
+      {:ok, _} -> raise Error, reason: {:bad_template, "pvar `#{name}` not under ellipsis"}
+      :error -> raise Error, reason: {:bad_template, "pvar `#{name}` unbound"}
+    end
+  end
+
+  # All template-side pattern variables of depth ≥ `min_depth`. Used to
+  # decide which pvars drive an ellipsis: only those whose pattern depth
+  # is at least the number of enclosing ellipses are eligible.
+  defp template_pvars_at_depth(:null, _min), do: []
+  defp template_pvars_at_depth({:t_pvar, name, depth}, min) when depth >= min, do: [name]
+  defp template_pvars_at_depth({:t_pvar, _, _}, _min), do: []
+  defp template_pvars_at_depth({:t_sym, _}, _min), do: []
+  defp template_pvars_at_depth({:t_const, _}, _min), do: []
+
+  defp template_pvars_at_depth({:t_quote, q}, min), do: quoted_pvars_at_depth(q, min)
+
+  defp template_pvars_at_depth({:t_list, items, tail}, min) do
+    items_pvars =
+      Enum.flat_map(items, fn {tmpl, n} ->
+        template_pvars_at_depth(tmpl, min + n)
+      end)
+
+    items_pvars ++ template_pvars_at_depth(tail, min)
+  end
+
+  defp template_pvars_at_depth({:t_vector, items}, min) do
+    Enum.flat_map(items, fn {tmpl, n} ->
+      template_pvars_at_depth(tmpl, min + n)
+    end)
+  end
+
+  defp quoted_pvars_at_depth(:q_null, _min), do: []
+  defp quoted_pvars_at_depth({:q_sym, _}, _min), do: []
+  defp quoted_pvars_at_depth({:q_const, _}, _min), do: []
+  defp quoted_pvars_at_depth({:q_pvar, name, depth}, min) when depth >= min, do: [name]
+  defp quoted_pvars_at_depth({:q_pvar, _, _}, _min), do: []
+
+  defp quoted_pvars_at_depth({:q_list, items, tail}, min) do
+    items_pvars =
+      Enum.flat_map(items, fn {q, n} ->
+        quoted_pvars_at_depth(q, min + n)
+      end)
+
+    items_pvars ++ quoted_pvars_at_depth(tail, min)
+  end
+
+  defp quoted_pvars_at_depth({:q_vector, items}, min) do
+    Enum.flat_map(items, fn {q, n} -> quoted_pvars_at_depth(q, min + n) end)
+  end
+
+  defp mark_name(name, mark) do
+    name <> @mark_separator <> Integer.to_string(mark)
+  end
+end

--- a/test/schooner/expander/syntax_rules_test.exs
+++ b/test/schooner/expander/syntax_rules_test.exs
@@ -1,0 +1,240 @@
+defmodule Schooner.Expander.SyntaxRulesTest do
+  # Phase 9 — pattern matcher and template instantiator tests in
+  # isolation. The full transformer is exercised via `compile/1`
+  # against synthetic forms; we never go through the runtime so
+  # failures here pin behaviour at the macro layer regardless of
+  # what the rest of the pipeline does.
+  #
+  # Free identifiers in templates pick up a per-expansion hygiene
+  # mark, so structural comparisons strip those marks via `unmark/1`
+  # before equality. The mark itself is what `strip_mark/1` does at
+  # the evaluator's fallback lookup; here we just want to assert the
+  # template's *shape* matches the spec.
+  use ExUnit.Case, async: true
+
+  alias Schooner.Expander.SyntaxRules
+  alias Schooner.Reader
+
+  defp transformer(source) do
+    [spec] = Reader.read_string(source)
+    SyntaxRules.compile(spec)
+  end
+
+  defp form(source) do
+    [datum] = Reader.read_string(source)
+    datum
+  end
+
+  defp expand(transformer, source), do: transformer.(form(source))
+
+  defp unmark({:sym, name}) do
+    case SyntaxRules.strip_mark(name) do
+      {:ok, base} -> {:sym, base}
+      :error -> {:sym, name}
+    end
+  end
+
+  defp unmark({:pair, h, t}), do: {:pair, unmark(h), unmark(t)}
+
+  defp unmark({:vector, t}),
+    do: {:vector, t |> Tuple.to_list() |> Enum.map(&unmark/1) |> List.to_tuple()}
+
+  defp unmark(other), do: other
+
+  defp assert_form_equal(result, expected_source) do
+    assert unmark(result) == form(expected_source)
+  end
+
+  describe "patterns: literals, wildcards, identifiers" do
+    test "wildcard matches anything" do
+      t = transformer("(syntax-rules () ((_ _) 'matched))")
+      assert_form_equal(expand(t, "(use 1)"), "'matched")
+      assert_form_equal(expand(t, "(use foo)"), "'matched")
+      assert_form_equal(expand(t, "(use (a b c))"), "'matched")
+    end
+
+    test "literal identifier in pattern matches by name only" do
+      t = transformer("(syntax-rules (=>) ((_ a => b) (list a b)))")
+      assert_form_equal(expand(t, "(use 1 => 2)"), "(list 1 2)")
+
+      assert_raise Schooner.Eval.Error, fn -> expand(t, "(use 1 -> 2)") end
+    end
+
+    test "constant pattern matches by eqv?" do
+      t =
+        transformer("""
+        (syntax-rules ()
+          ((_ 0) 'zero)
+          ((_ x) (cons 'other x)))
+        """)
+
+      assert_form_equal(expand(t, "(n 0)"), "'zero")
+      assert_form_equal(expand(t, "(n 1)"), "(cons 'other 1)")
+      # Floats and integers are not eqv? in Schooner — a different
+      # exactness must therefore fall through to the next rule.
+      assert_form_equal(expand(t, "(n 0.0)"), "(cons 'other 0.0)")
+    end
+  end
+
+  describe "patterns: lists" do
+    test "fixed-length list pattern" do
+      t = transformer("(syntax-rules () ((_ a b c) (list c b a)))")
+      assert_form_equal(expand(t, "(use 1 2 3)"), "(list 3 2 1)")
+      assert_raise Schooner.Eval.Error, fn -> expand(t, "(use 1 2)") end
+      assert_raise Schooner.Eval.Error, fn -> expand(t, "(use 1 2 3 4)") end
+    end
+
+    test "dotted (improper) pattern binds the cdr" do
+      t = transformer("(syntax-rules () ((_ a . rest) (list a rest)))")
+      assert_form_equal(expand(t, "(use 1 2 3)"), "(list 1 (2 3))")
+      assert_form_equal(expand(t, "(use 1)"), "(list 1 ())")
+    end
+
+    test "empty-list literal in pattern" do
+      t =
+        transformer("""
+        (syntax-rules ()
+          ((_ ()) 'empty)
+          ((_ xs) (cons 'non-empty xs)))
+        """)
+
+      assert_form_equal(expand(t, "(use ())"), "'empty")
+      assert_form_equal(expand(t, "(use (1 2))"), "(cons 'non-empty (1 2))")
+    end
+  end
+
+  describe "patterns: ellipsis" do
+    test "trailing ellipsis collects every remaining arg" do
+      t = transformer("(syntax-rules () ((_ x ...) (list x ...)))")
+      assert_form_equal(expand(t, "(u)"), "(list)")
+      assert_form_equal(expand(t, "(u 1)"), "(list 1)")
+      assert_form_equal(expand(t, "(u 1 2 3)"), "(list 1 2 3)")
+    end
+
+    test "ellipsis with surrounding fixed elements" do
+      t = transformer("(syntax-rules () ((_ a b ... z) (list a (list b ...) z)))")
+      assert_form_equal(expand(t, "(u 1 2)"), "(list 1 (list) 2)")
+      assert_form_equal(expand(t, "(u 1 2 3 4 5)"), "(list 1 (list 2 3 4) 5)")
+    end
+
+    test "nested ellipsis preserves the outer/inner structure" do
+      t =
+        transformer("""
+        (syntax-rules ()
+          ((_ (a ...) ...) (list (list a ...) ...)))
+        """)
+
+      assert_form_equal(
+        expand(t, "(u (1 2) (3 4 5) ())"),
+        "(list (list 1 2) (list 3 4 5) (list))"
+      )
+    end
+
+    test "two pattern variables under one ellipsis stay paired" do
+      t = transformer("(syntax-rules () ((_ (a b) ...) (list (cons a b) ...)))")
+
+      assert_form_equal(
+        expand(t, "(u (1 2) (3 4))"),
+        "(list (cons 1 2) (cons 3 4))"
+      )
+    end
+  end
+
+  describe "patterns: vectors" do
+    test "fixed vector pattern matches by length" do
+      t = transformer("(syntax-rules () ((_ #(a b)) (cons a b)))")
+      assert_form_equal(expand(t, "(u #(1 2))"), "(cons 1 2)")
+      assert_raise Schooner.Eval.Error, fn -> expand(t, "(u #(1 2 3))") end
+    end
+
+    test "vector pattern with ellipsis collects items" do
+      t = transformer("(syntax-rules () ((_ #(x ...)) (list x ...)))")
+      assert_form_equal(expand(t, "(u #(1 2 3))"), "(list 1 2 3)")
+      assert_form_equal(expand(t, "(u #())"), "(list)")
+    end
+  end
+
+  describe "templates: pattern variables" do
+    test "pvar is replaced by its bound subform verbatim" do
+      t = transformer("(syntax-rules () ((_ x) (list x x x)))")
+      assert_form_equal(expand(t, "(u (a b))"), "(list (a b) (a b) (a b))")
+    end
+
+    test "pvar used outside ellipsis when it was bound under ellipsis raises" do
+      t = transformer("(syntax-rules () ((_ x ...) (list x)))")
+      assert_raise Schooner.Expander.Error, fn -> expand(t, "(u 1 2 3)") end
+    end
+  end
+
+  describe "templates: hygiene marking" do
+    test "free identifier in template carries a per-expansion mark" do
+      t = transformer("(syntax-rules () ((_ x) (foo x)))")
+      result = expand(t, "(u 7)")
+      assert {:pair, {:sym, marked}, {:pair, 7, :null}} = result
+      assert {:ok, "foo"} = SyntaxRules.strip_mark(marked)
+    end
+
+    test "core keywords in template are emitted unmarked" do
+      t = transformer("(syntax-rules () ((_ x) (lambda (x) x)))")
+      result = expand(t, "(u y)")
+      assert {:pair, {:sym, "lambda"}, _} = result
+    end
+
+    test "two expansions of the same template get distinct marks" do
+      t = transformer("(syntax-rules () ((_) foo))")
+      {:sym, name1} = expand(t, "(u)")
+      {:sym, name2} = expand(t, "(u)")
+      assert name1 != name2
+      assert SyntaxRules.strip_mark(name1) == {:ok, "foo"}
+      assert SyntaxRules.strip_mark(name2) == {:ok, "foo"}
+    end
+  end
+
+  describe "templates: quote" do
+    test "non-pattern-variable identifier inside quote emits a literal symbol" do
+      t = transformer("(syntax-rules () ((_) 'literal-name))")
+      assert_form_equal(expand(t, "(u)"), "'literal-name")
+    end
+
+    test "pattern variable inside quote substitutes the bound subform" do
+      t = transformer("(syntax-rules () ((_ x) '(wrapping x)))")
+      assert_form_equal(expand(t, "(u 99)"), "'(wrapping 99)")
+    end
+
+    test "ellipsis inside quote produces a quoted spread" do
+      t = transformer("(syntax-rules () ((_ x ...) '(items x ...)))")
+      assert_form_equal(expand(t, "(u a b c)"), "'(items a b c)")
+    end
+  end
+
+  describe "compile errors" do
+    test "duplicate pattern variable raises" do
+      assert_raise Schooner.Expander.Error, fn ->
+        transformer("(syntax-rules () ((_ x x) x))")
+      end
+    end
+
+    test "two ellipses in one list raise" do
+      assert_raise Schooner.Expander.Error, fn ->
+        transformer("(syntax-rules () ((_ a ... b ...) (list a b)))")
+      end
+    end
+
+    test "stray ellipsis in template is rejected at compile time" do
+      assert_raise Schooner.Expander.Error, fn ->
+        transformer("(syntax-rules () ((_ x) ...))")
+      end
+    end
+  end
+
+  describe "strip_mark/1" do
+    test "round-trips a marked name back to its base" do
+      marked = "foo" <> SyntaxRules.mark_separator() <> "42"
+      assert SyntaxRules.strip_mark(marked) == {:ok, "foo"}
+    end
+
+    test "returns :error on a name without a mark" do
+      assert SyntaxRules.strip_mark("foo") == :error
+    end
+  end
+end

--- a/test/schooner/expander/syntax_rules_test.exs
+++ b/test/schooner/expander/syntax_rules_test.exs
@@ -229,7 +229,11 @@ defmodule Schooner.Expander.SyntaxRulesTest do
 
   describe "strip_mark/1" do
     test "round-trips a marked name back to its base" do
-      marked = "foo" <> SyntaxRules.mark_separator() <> "42"
+      # The mark separator is a NUL byte: invalid in r7rs identifiers
+      # so it can never collide with a user-written name. The exact
+      # encoding is internal to SyntaxRules; we synthesise one here
+      # purely to confirm strip_mark is the inverse of marking.
+      marked = "foo" <> <<0>> <> "42"
       assert SyntaxRules.strip_mark(marked) == {:ok, "foo"}
     end
 

--- a/test/schooner/expander_test.exs
+++ b/test/schooner/expander_test.exs
@@ -1,0 +1,311 @@
+defmodule Schooner.ExpanderTest do
+  # Phase 9 — hygienic `syntax-rules` expander. End-to-end tests that
+  # exercise the expander through `Schooner.run/1`. Tests for the
+  # pattern matcher, template instantiator, and individual transformer
+  # behaviour live in dedicated files alongside this one.
+  use ExUnit.Case, async: true
+
+  alias Schooner.Eval.Error
+  alias Schooner.Value
+
+  defp run(source), do: Schooner.run(source)
+
+  describe "define-syntax" do
+    test "user-defined macro expands at top level" do
+      assert run("""
+             (define-syntax greet
+               (syntax-rules ()
+                 ((_ x) (cons 'hello x))))
+             (greet 'world)
+             """) == {:pair, Value.symbol("hello"), Value.symbol("world")}
+    end
+
+    test "redefining a macro replaces the previous transformer" do
+      assert run("""
+             (define-syntax m (syntax-rules () ((_ x) (* x 10))))
+             (define-syntax m (syntax-rules () ((_ x) (+ x 100))))
+             (m 7)
+             """) == 107
+    end
+
+    test "no matching rule raises a Schooner.Eval.Error" do
+      e =
+        assert_raise Error, fn ->
+          run("""
+          (define-syntax bin (syntax-rules () ((_ a b) (cons a b))))
+          (bin 1)
+          """)
+        end
+
+      assert e.reason == {:bad_special_form, "bin"}
+    end
+
+    test "literals match by name only" do
+      # `=>` and `else` are r7rs literals in `cond` / `case`; here we
+      # define our own macro that uses `=>` as a literal to confirm
+      # the matcher distinguishes literals from pattern variables.
+      assert run("""
+             (define-syntax arrow
+               (syntax-rules (=>)
+                 ((_ x => y) (list 'matched x y))
+                 ((_ x y) (list 'not-matched x y))))
+             (list (arrow 1 => 2) (arrow 1 2))
+             """) ==
+               Value.list([
+                 Value.list([Value.symbol("matched"), 1, 2]),
+                 Value.list([Value.symbol("not-matched"), 1, 2])
+               ])
+    end
+
+    test "the macro's keyword identifier in head position is treated as a wildcard" do
+      assert run("""
+             (define-syntax foo
+               (syntax-rules ()
+                 ((foo x) (list 'kw x))))
+             (foo 5)
+             """) == Value.list([Value.symbol("kw"), 5])
+    end
+  end
+
+  describe "ellipsis" do
+    test "single-level ellipsis splices a list of values into a list template" do
+      assert run("""
+             (define-syntax mk-list
+               (syntax-rules ()
+                 ((_ x ...) (list x ...))))
+             (mk-list 1 2 3 4)
+             """) == Value.list([1, 2, 3, 4])
+    end
+
+    test "ellipsis with leading and trailing fixed elements" do
+      assert run("""
+             (define-syntax bracketed
+               (syntax-rules ()
+                 ((_ a middle ... z)
+                  (list 'first a 'middles (list middle ...) 'last z))))
+             (bracketed 10 20 30 40 50)
+             """) ==
+               Value.list([
+                 Value.symbol("first"),
+                 10,
+                 Value.symbol("middles"),
+                 Value.list([20, 30, 40]),
+                 Value.symbol("last"),
+                 50
+               ])
+    end
+
+    test "nested ellipsis preserves the list-of-lists shape" do
+      assert run("""
+             (define-syntax pairs
+               (syntax-rules ()
+                 ((_ (a b) ...) (list (list a b) ...))))
+             (pairs (1 2) (3 4) (5 6))
+             """) ==
+               Value.list([
+                 Value.list([1, 2]),
+                 Value.list([3, 4]),
+                 Value.list([5, 6])
+               ])
+    end
+
+    test "two pattern variables driven by the same ellipsis stay aligned" do
+      assert run("""
+             (define-syntax zipped
+               (syntax-rules ()
+                 ((_ (a b) ...) (list (cons a b) ...))))
+             (zipped (1 'x) (2 'y) (3 'z))
+             """) ==
+               Value.list([
+                 {:pair, 1, Value.symbol("x")},
+                 {:pair, 2, Value.symbol("y")},
+                 {:pair, 3, Value.symbol("z")}
+               ])
+    end
+
+    test "ellipsis under a different parent ellipsis flattens correctly" do
+      assert run("""
+             (define-syntax flatten-2
+               (syntax-rules ()
+                 ((_ (x ...) ...) (list x ... ...))))
+             (flatten-2 (1 2) (3 4 5) (6))
+             """) == Value.list([1, 2, 3, 4, 5, 6])
+    end
+  end
+
+  describe "hygiene" do
+    test "template-introduced binder does not capture a user identifier" do
+      # If `t` in the template were not alpha-renamed, the inner
+      # `(let ((t e1)) ...)` would shadow the user's `t` and the test
+      # would observe `#f` instead of `'oops`.
+      assert run("""
+             (define-syntax my-or
+               (syntax-rules ()
+                 ((_) #f)
+                 ((_ e) e)
+                 ((_ e1 e2 ...)
+                  (let ((t e1)) (if t t (my-or e2 ...))))))
+             (let ((t 'oops)) (my-or #f t))
+             """) == Value.symbol("oops")
+    end
+
+    test "user identifier passed into a macro template is not bound by the macro's lambda" do
+      assert run("""
+             (define-syntax wrap
+               (syntax-rules ()
+                 ((_ e) (let ((y 99)) e))))
+             (let ((y 7)) (wrap y))
+             """) == 7
+    end
+
+    test "free template reference resolves to the runtime binding at use site" do
+      assert run("""
+             (define-syntax inc
+               (syntax-rules ()
+                 ((_ x) (+ x 1))))
+             (inc 41)
+             """) == 42
+    end
+
+    test "macro keyword can call itself recursively without losing meaning" do
+      assert run("""
+             (define-syntax sum
+               (syntax-rules ()
+                 ((_) 0)
+                 ((_ x y ...) (+ x (sum y ...)))))
+             (sum 1 2 3 4 5)
+             """) == 15
+    end
+  end
+
+  describe "let-syntax / letrec-syntax" do
+    test "let-syntax binds a macro within its body and falls out of scope after" do
+      assert run("""
+             (let-syntax ((double (syntax-rules () ((_ x) (+ x x)))))
+               (double 21))
+             """) == 42
+
+      assert_raise Error, fn ->
+        run("""
+        (let-syntax ((double (syntax-rules () ((_ x) (+ x x))))) (double 1))
+        (double 2)
+        """)
+      end
+    end
+
+    test "letrec-syntax allows mutually recursive macros" do
+      # A pair of macros that ping-pong over a syntactic list at
+      # expansion time. Macros operate on syntax, not on values, so
+      # the recursion has to bottom out on a structural pattern (the
+      # empty list `()`) rather than a runtime computation. With
+      # `let-syntax` only one would resolve; `letrec-syntax` makes
+      # both visible in each other's templates.
+      assert run("""
+             (letrec-syntax
+                 ((m1 (syntax-rules ()
+                        ((_ ()) 'done-m1)
+                        ((_ (x rest ...)) (m2 (rest ...)))))
+                  (m2 (syntax-rules ()
+                        ((_ ()) 'done-m2)
+                        ((_ (x rest ...)) (m1 (rest ...))))))
+               (m1 (a b c d)))
+             """) == Value.symbol("done-m1")
+    end
+
+    test "let-syntax inner shadowing does not leak to outer use" do
+      assert run("""
+             (define-syntax m (syntax-rules () ((_ x) (* x 10))))
+             (let-syntax ((m (syntax-rules () ((_ x) (+ x 100)))))
+               (m 5))
+             """) == 105
+
+      assert run("""
+             (define-syntax m (syntax-rules () ((_ x) (* x 10))))
+             (let-syntax ((m (syntax-rules () ((_ x) (+ x 100)))))
+               (m 5))
+             (m 5)
+             """) == 50
+    end
+  end
+
+  describe "core-form interaction" do
+    test "lambda parameters shadow an outer macro binding" do
+      # If `m` were treated as a macro at the call site, the lambda
+      # would expand `m` to `99`. Because lambda introduces a runtime
+      # variable named `m`, the application within the body must
+      # resolve to the parameter, not to the macro.
+      assert run("""
+             (define-syntax m (syntax-rules () ((_) 99)))
+             ((lambda (m) (m)) (lambda () 'param))
+             """) == Value.symbol("param")
+    end
+
+    test "quote bodies are not expanded" do
+      # If the expander walked into quoted data, the user-written
+      # `let` symbol would be expanded to the macro's body. Quotation
+      # must short-circuit that walk.
+      assert run("""
+             '(let ((x 1)) x)
+             """) ==
+               Value.list([
+                 Value.symbol("let"),
+                 Value.list([Value.list([Value.symbol("x"), 1])]),
+                 Value.symbol("x")
+               ])
+    end
+
+    test "vector quasiquote with macro use inside an unquote still expands" do
+      assert run("""
+             (define-syntax inc (syntax-rules () ((_ x) (+ x 1))))
+             `#(1 ,(inc 2) 3)
+             """) == Value.vector([1, 3, 3])
+    end
+  end
+
+  describe "torture: or as a user-defined macro" do
+    test "shadows the bootstrap or and obeys short-circuit semantics" do
+      # The `or` defined here has the same semantics as the bootstrap
+      # `or`; what we are pinning is that it does not break under
+      # capture-prone identifiers.
+      assert run("""
+             (define-syntax local-or
+               (syntax-rules ()
+                 ((_) #f)
+                 ((_ e) e)
+                 ((_ e1 e2 ...)
+                  (let ((t e1)) (if t t (local-or e2 ...))))))
+             (let ((t 'oops))
+               (list (local-or #f #f t)
+                     (local-or #f t)
+                     (local-or t 'unused)))
+             """) ==
+               Value.list([Value.symbol("oops"), Value.symbol("oops"), Value.symbol("oops")])
+    end
+  end
+
+  describe "torture: cond with =>" do
+    test "expands and evaluates without re-evaluating the test expression" do
+      # If the macro re-evaluated the test, the counter incremented
+      # via the (lambda) hack here would record more than one tick.
+      # We can't observe side effects without mutation, but we can
+      # confirm the result with a function that *would* show
+      # divergence if multiply applied.
+      assert run("""
+             (cond ((+ 1 2) => (lambda (x) (* x 10))))
+             """) == 30
+    end
+  end
+
+  describe "internal definition interaction" do
+    test "macro that expands to internal define inside a lambda body" do
+      assert run("""
+             (define-syntax def-fn
+               (syntax-rules ()
+                 ((_ name body) (define name (lambda () body)))))
+             ((lambda ()
+                (def-fn pi-ish 314)
+                (pi-ish)))
+             """) == 314
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- New `Schooner.Expander` runs between `Reader` and `Eval`, walks the datum AST, and reduces every user-level derived form to the core forms (`quote`, `if`, `lambda`, `define`, `begin`, `letrec*`, application, variable).
- `Schooner.Expander.SyntaxRules` compiles `syntax-rules` into a transformer with a full pattern matcher (literals, `_`, constants, dotted lists, vector patterns, ellipsis incl. nested) and a hygienic template instantiator (per-expansion mark on every non-pattern-variable identifier; eval-time fallback strips the mark for free runtime references).
- Bootstrap macros for `cond`, `case`, `when`, `unless`, `and`, `or`, `let`, `let*`, `letrec`, named `let`, and `do` ship in `Schooner.Expander.Derived` and load into the syntax env once (cached via `:persistent_term`). Phase 7's full derived-form test suite re-runs verbatim through the macro layer.
- `Schooner.Eval` shed ~250 lines of throwaway derived-form branches and grew a one-shot mark-strip fallback in variable lookup. `letrec*` is intentionally retained as a core form because it backs internal-`define` splicing and a fully-macroised replacement would need either mutation or a hand-built fix-point combinator.

50 new tests cover the matcher, instantiator, hygiene (capture in both directions), and torture cases (`or` shadowing the bootstrap, `cond` with `=>`, mutually recursive macros via `letrec-syntax`, nested ellipsis). All 553 tests pass; `mix precommit` clean.

The second commit applies a `/simplify` pass: drops three unused public functions, replaces hand-rolled list helpers with `Schooner.Value.list/1`, fixes an O(K·N²) `Enum.at`-per-iteration sub-env build in `expand_ellipsis` to O(K·N) lockstep peel, and short-circuits `strip_mark/1` with `:binary.match/2` for the common unmarked-name path.

## Test plan

- [x] All 553 tests pass through the macro layer (`mix test`).
- [x] Phase 7's `eval_derived_test.exs` runs unchanged — same assertions, now exercised via `define-syntax` bootstrap macros.
- [x] Phase 4's TCO regression tests (100k-deep recursion via named `let`, `letrec`, `if`, `begin`) still pass.
- [x] Phase 8's internal-define / rec-frame-slot-leak tests still pass.
- [x] `mix precommit` (compile --warnings-as-errors, format, credo --strict, test) green.