### PR TITLE
Fix pair_value generator: wrap tuple literal in StreamData.tuple/1

### DIFF
--- a/test/support/value_generators.ex
+++ b/test/support/value_generators.ex
@@ -120,6 +120,6 @@ defmodule Schooner.Test.ValueGenerators do
 
   def pair_value(leaf, depth) do
     inner = compound_value(leaf, depth)
-    map({inner, inner}, fn {a, b} -> Value.pair(a, b) end)
+    map(tuple({inner, inner}), fn {a, b} -> Value.pair(a, b) end)
   end
 end


### PR DESCRIPTION
## Summary

`pair_value/2` in `test/support/value_generators.ex` passed a literal `{inner, inner}` tuple to `StreamData.map/2`, which expects a generator as its first argument. `StreamData` was auto-lifting the bare tuple at runtime, but the LSP / dialyzer (correctly) flagged the shape mismatch. Wrapping in `StreamData.tuple/1` makes the input a real generator that yields 2-tuples.

No behavioural change — all 579 tests still pass.

## Test plan

- [x] `mix test` green.
- [x] LSP no longer reports the mismatch on `pair_value/2`.