### PR TITLE
Phase 10: define-record-type with per-form type identity

### DIFF
--- a/lib/schooner.ex
+++ b/lib/schooner.ex
@@ -33,6 +33,7 @@ defmodule Schooner do
     |> Primitives.Base.register_into()
     |> Primitives.Cxr.register_into()
     |> Primitives.Char.register_into()
+    |> Primitives.Record.register_into()
   end
 
   @doc """

--- a/lib/schooner/env.ex
+++ b/lib/schooner/env.ex
@@ -70,10 +70,24 @@ defmodule Schooner.Env do
   defp lex_lookup([], _name), do: :error
 
   defp lex_lookup([{:rec, ref} | rest], name) do
-    case Map.fetch(Process.get(ref), name) do
-      {:ok, @rec_uninitialised} -> {:uninitialised, name}
-      {:ok, _} = ok -> ok
-      :error -> lex_lookup(rest, name)
+    # `Process.get(ref)` returns `nil` once `with_rec_frame` has
+    # released the slot, but closures created during the binding
+    # form's body may still hold this dead frame in their captured
+    # env. Fall through to the surrounding scope so a name that
+    # resolves elsewhere (a global, an outer frame) still resolves
+    # cleanly; an `unbound` raise from the outer `eval` is the only
+    # observable difference for a name whose only binding *was* the
+    # dead frame.
+    case Process.get(ref) do
+      nil ->
+        lex_lookup(rest, name)
+
+      frame ->
+        case Map.fetch(frame, name) do
+          {:ok, @rec_uninitialised} -> {:uninitialised, name}
+          {:ok, _} = ok -> ok
+          :error -> lex_lookup(rest, name)
+        end
     end
   end
 

--- a/lib/schooner/eval.ex
+++ b/lib/schooner/eval.ex
@@ -359,6 +359,16 @@ defmodule Schooner.Eval do
 
   defp scan_defines(:null, acc), do: {Enum.reverse(acc), :null}
 
+  # r7rs §5.3.3: a `(begin <form> ...)` at the head of a body is
+  # spliced into the body in place. This is what lets
+  # `define-record-type` work in an internal-definition position —
+  # the expander emits a `(begin (define ...) (define ...) ...)`
+  # for each record type and the splicing here makes those defines
+  # behave as if they were written at the body level directly.
+  defp scan_defines({:pair, {:pair, {:sym, "begin"}, inner}, rest}, acc) do
+    scan_defines(splice_append(inner, rest, "begin"), acc)
+  end
+
   defp scan_defines({:pair, form, rest}, acc) do
     case parse_internal_define(form) do
       nil ->
@@ -386,6 +396,10 @@ defmodule Schooner.Eval do
   defp parse_internal_define(_), do: nil
 
   defp check_no_more_defines(:null), do: :ok
+
+  defp check_no_more_defines({:pair, {:pair, {:sym, "begin"}, inner}, rest}) do
+    check_no_more_defines(splice_append(inner, rest, "begin"))
+  end
 
   defp check_no_more_defines({:pair, form, rest}) do
     if parse_internal_define(form) != nil do

--- a/lib/schooner/expander.ex
+++ b/lib/schooner/expander.ex
@@ -27,6 +27,7 @@ defmodule Schooner.Expander do
   alias Schooner.Expander.Derived
   alias Schooner.Expander.SyntaxEnv
   alias Schooner.Expander.SyntaxRules
+  alias Schooner.Primitives.Record, as: RecordPrim
   alias Schooner.Reader
   alias Schooner.Value
 
@@ -34,7 +35,11 @@ defmodule Schooner.Expander do
   # user-facing recursive bindings and the internal-define splicing
   # done at evaluation time, and a fully-macroised replacement would
   # need either mutation or a hand-built fix-point combinator.
-  @core_specials MapSet.new(~w(quote if lambda define begin set! letrec*))
+  # `define-record-type` joins the core set because it has to mint a
+  # fresh type identity at expansion time and embed it as a literal
+  # in the bindings it generates — `syntax-rules` templates are pure
+  # substitution and can't introduce a fresh constant per use.
+  @core_specials MapSet.new(~w(quote if lambda define begin set! letrec* define-record-type))
 
   @doc """
   Expand a list of top-level forms in `env`. Returns a list of
@@ -151,6 +156,10 @@ defmodule Schooner.Expander do
 
   def expand({:pair, {:sym, "quasiquote"}, _tail} = form, env) do
     expand_quasiquote(form, env, 1)
+  end
+
+  def expand({:pair, {:sym, "define-record-type"}, tail}, env) do
+    expand_define_record_type(tail, env)
   end
 
   def expand({:pair, {:sym, name}, _args} = form, env) do
@@ -304,6 +313,103 @@ defmodule Schooner.Expander do
 
   defp parse_letrec_bindings(_, _),
     do: raise(Error, reason: {:bad_special_form, "letrec*"})
+
+  # ---------------------------------------------------------------------------
+  # define-record-type
+  # ---------------------------------------------------------------------------
+
+  # `define-record-type` is a core form rather than a macro because
+  # it has to mint a fresh type identity at expansion time and embed
+  # it as a literal in the bindings it generates — `syntax-rules`
+  # templates are pure substitution and can't introduce a fresh
+  # constant per use.
+  defp expand_define_record_type(form, env) do
+    {name, {ctor_name, ctor_fields}, pred_name, fields} = parse_record_type(form)
+    type_id = fresh_record_type_id(name)
+    field_names = Enum.map(fields, fn {fname, _accessor} -> fname end)
+
+    defs = [
+      record_constructor_def(ctor_name, ctor_fields, field_names, type_id),
+      record_predicate_def(pred_name, type_id)
+      | record_accessor_defs(fields, type_id)
+    ]
+
+    expand({:pair, {:sym, "begin"}, Value.list(defs)}, env)
+  end
+
+  defp fresh_record_type_id(name) when is_binary(name) do
+    {:record_type, name, :erlang.unique_integer([:positive])}
+  end
+
+  defp parse_record_type(
+         {:pair, {:sym, name}, {:pair, ctor_spec, {:pair, {:sym, pred_name}, field_specs_form}}}
+       )
+       when is_binary(name) and is_binary(pred_name) do
+    {name, parse_record_ctor(ctor_spec), pred_name,
+     parse_record_field_specs(field_specs_form, [])}
+  end
+
+  defp parse_record_type(_), do: raise(Error, reason: {:bad_special_form, "define-record-type"})
+
+  defp parse_record_ctor({:pair, {:sym, ctor_name}, fields_form}) when is_binary(ctor_name) do
+    {ctor_name, parse_record_ctor_fields(fields_form, [])}
+  end
+
+  defp parse_record_ctor(_), do: raise(Error, reason: {:bad_special_form, "define-record-type"})
+
+  defp parse_record_ctor_fields(:null, acc), do: Enum.reverse(acc)
+
+  defp parse_record_ctor_fields({:pair, {:sym, name}, rest}, acc) when is_binary(name) do
+    parse_record_ctor_fields(rest, [name | acc])
+  end
+
+  defp parse_record_ctor_fields(_, _),
+    do: raise(Error, reason: {:bad_special_form, "define-record-type"})
+
+  defp parse_record_field_specs(:null, acc), do: Enum.reverse(acc)
+
+  defp parse_record_field_specs(
+         {:pair, {:pair, {:sym, fname}, {:pair, {:sym, accessor}, :null}}, rest},
+         acc
+       )
+       when is_binary(fname) and is_binary(accessor) do
+    parse_record_field_specs(rest, [{fname, accessor} | acc])
+  end
+
+  defp parse_record_field_specs(_, _),
+    do: raise(Error, reason: {:bad_special_form, "define-record-type"})
+
+  defp record_constructor_def(ctor_name, ctor_fields, field_names, type_id) do
+    ctor_set = MapSet.new(ctor_fields)
+    arg_syms = Enum.map(ctor_fields, &{:sym, &1})
+
+    field_values =
+      Enum.map(field_names, fn fname ->
+        if MapSet.member?(ctor_set, fname), do: {:sym, fname}, else: :unspecified
+      end)
+
+    body = Value.list([{:sym, RecordPrim.instance_name()}, type_id | field_values])
+    make_define_form(ctor_name, arg_syms, body)
+  end
+
+  defp record_predicate_def(pred_name, type_id) do
+    body = Value.list([{:sym, RecordPrim.predicate_name()}, type_id, {:sym, "v"}])
+    make_define_form(pred_name, [{:sym, "v"}], body)
+  end
+
+  defp record_accessor_defs(fields, type_id) do
+    Enum.with_index(fields, fn {_fname, accessor}, idx ->
+      body = Value.list([{:sym, RecordPrim.ref_name()}, type_id, {:sym, "v"}, idx])
+      make_define_form(accessor, [{:sym, "v"}], body)
+    end)
+  end
+
+  # Build `(define (<name> <param> ...) <body>)`. Centralises the
+  # `:pair`/`:null` skeleton the three record-machinery emitters
+  # would otherwise duplicate.
+  defp make_define_form(name, params, body) do
+    Value.list([{:sym, "define"}, Value.list([{:sym, name} | params]), body])
+  end
 
   defp expand_let_syntax({:pair, bindings_form, body}, env) when body != :null do
     bindings = parse_syntax_bindings(bindings_form, env, "let-syntax")

--- a/lib/schooner/primitive/error.ex
+++ b/lib/schooner/primitive/error.ex
@@ -68,4 +68,8 @@ defmodule Schooner.Primitive.Error do
   defp format({:invalid_size, op, k}) do
     "`#{op}`: #{inspect(k)} is not a valid size"
   end
+
+  defp format({:wrong_record_type, op, type_name}) do
+    "`#{op}`: value is not a record of type `#{type_name}`"
+  end
 end

--- a/lib/schooner/primitives/record.ex
+++ b/lib/schooner/primitives/record.ex
@@ -1,0 +1,90 @@
+defmodule Schooner.Primitives.Record do
+  @moduledoc """
+  Runtime primitives that back the `define-record-type` form.
+
+  The expander emits calls to these primitives — they are not part
+  of the user-facing language proper. Each call carries the record
+  type's identity (a fresh `{:record_type, name, unique_int}` term
+  minted at expansion time) so the primitive can verify that the
+  value it was handed is actually an instance of that type before
+  doing anything else.
+
+  Since type identity comes from a per-expansion gensym, two
+  `define-record-type` forms with the same record name in
+  different lexical scopes mint different identities; the
+  predicate from one scope returns `#f` for an instance from the
+  other, even though the renderings look identical.
+  """
+
+  alias Schooner.Env
+  alias Schooner.Primitive.Error
+  alias Schooner.Value
+
+  # Names exposed publicly so the expander emits exactly the strings
+  # this module registers. Single source of truth — adding a new
+  # record primitive only requires updating `specs/0`.
+  @instance_name "%record-instance"
+  @predicate_name "%record-of?"
+  @ref_name "%record-ref"
+
+  @doc "Symbol name of the record-construction primitive."
+  @spec instance_name() :: binary()
+  def instance_name, do: @instance_name
+
+  @doc "Symbol name of the record-type-predicate primitive."
+  @spec predicate_name() :: binary()
+  def predicate_name, do: @predicate_name
+
+  @doc "Symbol name of the record-field-access primitive."
+  @spec ref_name() :: binary()
+  def ref_name, do: @ref_name
+
+  @doc """
+  Define every record-machinery primitive on `env`. Returns the
+  same env (the global table is mutated in place — consistent with
+  `Env.define/3`).
+  """
+  @spec register_into(Env.t()) :: Env.t()
+  def register_into(%Env{} = env) do
+    Enum.reduce(specs(), env, fn {name, arity, fun}, acc ->
+      Env.define(acc, name, Value.primitive(name, arity, fun))
+    end)
+  end
+
+  defp specs do
+    [
+      {@instance_name, {:at_least, 1}, &record_instance/1},
+      {@predicate_name, 2, &record_of?/1},
+      {@ref_name, 3, &record_ref/1}
+    ]
+  end
+
+  # Construct a record. The first arg is the type identity; the
+  # rest become the field tuple in order. The expander wraps this
+  # in a lambda so the user-facing constructor checks arity.
+  defp record_instance([type_id | fields]) do
+    Value.record(type_id, List.to_tuple(fields))
+  end
+
+  defp record_of?([type_id, {:record, instance_id, _}]) do
+    Value.bool(type_id === instance_id)
+  end
+
+  defp record_of?([_type_id, _]), do: Value.bool(false)
+
+  defp record_ref([type_id, {:record, instance_id, fields}, index])
+       when is_integer(index) and index >= 0 do
+    if type_id === instance_id do
+      elem(fields, index)
+    else
+      raise Error, reason: {:wrong_record_type, "%record-ref", type_name(type_id)}
+    end
+  end
+
+  defp record_ref([type_id, _other, _index]) do
+    raise Error, reason: {:wrong_record_type, "%record-ref", type_name(type_id)}
+  end
+
+  defp type_name({:record_type, name, _}), do: name
+  defp type_name(other), do: inspect(other)
+end

--- a/lib/schooner/value.ex
+++ b/lib/schooner/value.ex
@@ -28,6 +28,11 @@ defmodule Schooner.Value do
     * Closure — `{:closure, params, body, env, name_or_nil}`
     * Primitive — `{:primitive, name, arity, fun}`
     * Record — `{:record, type_id, fields_tuple}`
+    * Record type identity — `{:record_type, name, unique_int}` —
+      embedded as a literal in the bindings produced by
+      `define-record-type`. Self-evaluating; compared with `===` so
+      two definitions with the same record name in different
+      lexical scopes produce distinct identities.
     * EOF — `:eof`
     * Unspecified — `:unspecified`
   """
@@ -42,6 +47,7 @@ defmodule Schooner.Value do
   @type closure_v :: {:closure, term(), term(), term(), binary() | nil}
   @type primitive_v :: {:primitive, binary(), arity_spec(), (list() -> t())}
   @type record_v :: {:record, term(), tuple()}
+  @type record_type_id_v :: {:record_type, binary(), pos_integer()}
   @type float_special_v :: {:float_special, :pos_inf | :neg_inf | :nan}
   @type arity_spec :: non_neg_integer() | {:at_least, non_neg_integer()}
 
@@ -60,6 +66,7 @@ defmodule Schooner.Value do
           | closure_v()
           | primitive_v()
           | record_v()
+          | record_type_id_v()
           | :eof
           | :unspecified
 
@@ -304,6 +311,7 @@ defmodule Schooner.Value do
   defp render({:pair, _, _} = p, mode), do: render_pair(p, mode)
   defp render({:closure, _, _, _, name}, _), do: render_closure(name)
   defp render({:primitive, name, _, _}, _), do: ["#<primitive ", name, ">"]
+  defp render({:record, {:record_type, name, _}, _}, _), do: ["#<record ", name, ">"]
   defp render({:record, type_id, _}, _), do: ["#<record ", inspect(type_id), ">"]
   defp render({:float_special, :pos_inf}, _), do: "+inf.0"
   defp render({:float_special, :neg_inf}, _), do: "-inf.0"

--- a/test/conformance/r7rs_section_5_4_records_test.exs
+++ b/test/conformance/r7rs_section_5_4_records_test.exs
@@ -1,0 +1,105 @@
+defmodule Schooner.Conformance.R7rsSection54RecordsTest do
+  # Worked examples from r7rs-small §5.4 (record-type definitions).
+  # Each test transcribes a `(form) ==> result` example from the
+  # spec or pins a property the spec calls out as required of a
+  # `define-record-type` implementation.
+  #
+  # Schooner-specific deviations from §5.4:
+  #
+  #   - Field mutators (the third element of a `(field accessor
+  #     mutator)` clause) are not supported. The grammar accepts
+  #     only `(field accessor)`; a mutator clause is a syntax error.
+  #     This is the no-mutation constraint that runs through the
+  #     whole language, not a record-system limitation per se.
+  use ExUnit.Case, async: true
+
+  alias Schooner.Value
+
+  defp run(source), do: Schooner.run(source)
+
+  describe "§5.4 the canonical kons example" do
+    # Spec example:
+    #   (define-record-type <pare>
+    #     (kons x y)
+    #     pare?
+    #     (x kar)
+    #     (y kdr))
+    test "constructor produces a record; predicate distinguishes it from cons cells" do
+      assert run("""
+             (define-record-type <pare> (kons x y) pare? (x kar) (y kdr))
+             (define p (kons 1 2))
+             (list (pare? p) (pare? (cons 1 2)) (kar p) (kdr p))
+             """) ==
+               Value.list([
+                 Value.bool(true),
+                 Value.bool(false),
+                 1,
+                 2
+               ])
+    end
+
+    test "predicate rejects non-records" do
+      assert run("""
+             (define-record-type <pare> (kons x y) pare? (x kar) (y kdr))
+             (list (pare? 'p) (pare? "string") (pare? 99) (pare? '()))
+             """) ==
+               Value.list([
+                 Value.bool(false),
+                 Value.bool(false),
+                 Value.bool(false),
+                 Value.bool(false)
+               ])
+    end
+  end
+
+  describe "§5.4 partial constructor" do
+    test "constructor can mention only a subset of the declared fields" do
+      assert run("""
+             (define-record-type pt
+               (only-x x)
+               pt?
+               (x get-x)
+               (y get-y))
+             (define p (only-x 7))
+             (list (get-x p) (get-y p))
+             """) == Value.list([7, :unspecified])
+    end
+  end
+
+  describe "§5.4 type identity" do
+    test "two record-type definitions with the same name produce distinct types" do
+      # The spec is explicit that each `define-record-type` form
+      # introduces a *new* type, even if the syntactic name is the
+      # same as a previous definition.
+      assert run("""
+             (define-record-type same-name (mk-a) a?)
+             (define a-instance (mk-a))
+             (define-record-type same-name (mk-b) b?)
+             (define b-instance (mk-b))
+             (list (a? a-instance) (a? b-instance) (b? a-instance) (b? b-instance))
+             """) ==
+               Value.list([
+                 Value.bool(true),
+                 Value.bool(false),
+                 Value.bool(false),
+                 Value.bool(true)
+               ])
+    end
+  end
+
+  describe "§5.4 records and equality" do
+    test "two records of the same type are equal? when their fields are equal?" do
+      assert run("""
+             (define-record-type pt (mk x y) pt? (x px) (y py))
+             (equal? (mk 1 2) (mk 1 2))
+             """) == Value.bool(true)
+    end
+
+    test "records compare structurally when nested" do
+      assert run("""
+             (define-record-type box (mk-box v) box? (v unbox))
+             (equal? (mk-box (list 1 (mk-box 2))) (mk-box (list 1 (mk-box 2))))
+             """) == Value.bool(true)
+    end
+  end
+end

--- a/test/schooner/expander/record_test.exs
+++ b/test/schooner/expander/record_test.exs
@@ -1,0 +1,180 @@
+defmodule Schooner.Expander.RecordTest do
+  # Phase 10 — `define-record-type`. End-to-end tests through
+  # `Schooner.run/1` covering the constructor / predicate / accessor
+  # surface, partial constructors (per r7rs §5.4 a constructor's
+  # field list may be a subset of the record's fields), the per-form
+  # type-identity rule (two definitions with the same record name
+  # produce distinct types), nested records, and `write` rendering.
+  use ExUnit.Case, async: true
+
+  alias Schooner.Eval.Error
+  alias Schooner.Primitive.Error, as: PError
+  alias Schooner.Value
+
+  defp run(source), do: Schooner.run(source)
+
+  describe "constructor / predicate / accessors" do
+    test "the constructor returns a record; the predicate is #t for own type and #f otherwise" do
+      assert run("""
+             (define-record-type point (make-point x y) point? (x point-x) (y point-y))
+             (define p (make-point 3 4))
+             (list (point? p) (point? 5) (point? 'p) (point? '(3 4)))
+             """) ==
+               Value.list([
+                 Value.bool(true),
+                 Value.bool(false),
+                 Value.bool(false),
+                 Value.bool(false)
+               ])
+    end
+
+    test "each accessor returns the correct field" do
+      assert run("""
+             (define-record-type point (make-point x y) point? (x point-x) (y point-y))
+             (define p (make-point 3 4))
+             (list (point-x p) (point-y p))
+             """) == Value.list([3, 4])
+    end
+
+    test "an accessor on a wrong-type value raises a primitive error" do
+      assert_raise PError, fn ->
+        run("""
+        (define-record-type point (make-point x y) point? (x point-x) (y point-y))
+        (define-record-type circle (make-circle r) circle? (r circle-radius))
+        (define c (make-circle 5))
+        (point-x c)
+        """)
+      end
+    end
+
+    test "a record with no constructor fields produces a record whose fields are all unspecified" do
+      # No specific assertion on the `unspecified` value's shape —
+      # just that the predicate fires and the accessor doesn't crash.
+      assert run("""
+             (define-record-type empty-rec (make-empty) empty? (x empty-x))
+             (define e (make-empty))
+             (list (empty? e) (empty? 0))
+             """) == Value.list([Value.bool(true), Value.bool(false)])
+    end
+  end
+
+  describe "partial constructors" do
+    test "fields not mentioned in the constructor default to :unspecified" do
+      assert run("""
+             (define-record-type pt
+               (mk-x x)
+               pt?
+               (x get-x)
+               (y get-y))
+             (define p (mk-x 7))
+             (list (pt? p) (get-x p) (get-y p))
+             """) == Value.list([Value.bool(true), 7, :unspecified])
+    end
+
+    test "constructor argument order may differ from declared field order" do
+      assert run("""
+             (define-record-type pt
+               (make-pt y x)
+               pt?
+               (x get-x)
+               (y get-y))
+             (define p (make-pt 'wye 'eks))
+             (list (get-x p) (get-y p))
+             """) == Value.list([Value.symbol("eks"), Value.symbol("wye")])
+    end
+  end
+
+  describe "type identity is per-definition" do
+    test "two top-level definitions with the same record name produce distinct types" do
+      # Each `define-record-type` form mints a fresh type-id, so the
+      # second `point?` (re-bound to the second type's predicate)
+      # rejects an instance from the first type.
+      assert run("""
+             (define-record-type point (make-point x) point? (x point-x))
+             (define p1 (make-point 1))
+             (define-record-type point (make-point x) point? (x point-x))
+             (define p2 (make-point 2))
+             (list (point? p1) (point? p2))
+             """) == Value.list([Value.bool(false), Value.bool(true)])
+    end
+
+    test "definitions in distinct lexical scopes produce distinct types" do
+      assert run("""
+             (define mk-a
+               ((lambda ()
+                  (define-record-type a (a-mk x) a? (x a-get))
+                  a-mk)))
+             (define a? ((lambda ()
+                          (define-record-type a (a-mk x) a? (x a-get))
+                          a?)))
+             (a? (mk-a 99))
+             """) == Value.bool(false)
+    end
+  end
+
+  describe "structural equality" do
+    test "two record instances of the same type compare equal? when fields are equal?" do
+      assert run("""
+             (define-record-type pt (mk x y) pt? (x px) (y py))
+             (equal? (mk 1 2) (mk 1 2))
+             """) == Value.bool(true)
+    end
+
+    test "two record instances of the same type with differing fields are not equal?" do
+      assert run("""
+             (define-record-type pt (mk x y) pt? (x px) (y py))
+             (equal? (mk 1 2) (mk 1 99))
+             """) == Value.bool(false)
+    end
+
+    test "records of different types with same field shape are not equal?" do
+      assert run("""
+             (define-record-type a (mk-a x) a? (x a-x))
+             (define-record-type b (mk-b x) b? (x b-x))
+             (equal? (mk-a 5) (mk-b 5))
+             """) == Value.bool(false)
+    end
+
+    test "records nested inside lists, vectors, and other records compare structurally" do
+      assert run("""
+             (define-record-type pair-rec (mk a b) pair-rec? (a pr-a) (b pr-b))
+             (equal?
+               (list (mk 1 2) #(1 (mk 3 4)))
+               (list (mk 1 2) #(1 (mk 3 4))))
+             """) == Value.bool(true)
+    end
+  end
+
+  describe "write rendering" do
+    test "records render as #<record name>" do
+      env = Schooner.standard_env()
+
+      _ =
+        Schooner.eval(
+          """
+          (define-record-type pt (mk-pt x y) pt? (x pt-x) (y pt-y))
+          (define p (mk-pt 1 2))
+          """,
+          env
+        )
+
+      record = Schooner.eval("p", env)
+      assert is_tuple(record) and elem(record, 0) == :record
+      assert Value.write(record) == "#<record pt>"
+    end
+  end
+
+  describe "malformed forms" do
+    test "missing predicate raises a syntax error" do
+      assert_raise Error, fn ->
+        run("(define-record-type pt (mk x))")
+      end
+    end
+
+    test "non-symbol field name raises a syntax error" do
+      assert_raise Error, fn ->
+        run("(define-record-type pt (mk x) pt? (1 acc))")
+      end
+    end
+  end
+end

--- a/test/schooner/primitives/record_test.exs
+++ b/test/schooner/primitives/record_test.exs
@@ -1,0 +1,79 @@
+defmodule Schooner.Primitives.RecordTest do
+  # Phase 10 — direct tests for the record-machinery primitives that
+  # `define-record-type` lowers to. These pin behaviour at the
+  # primitive boundary regardless of what shape the expander emits.
+  use ExUnit.Case, async: true
+
+  alias Schooner.Env
+  alias Schooner.Primitive.Error, as: PError
+  alias Schooner.Primitives.Record
+  alias Schooner.Value
+
+  defp env do
+    Env.new()
+    |> Schooner.Primitives.Base.register_into()
+    |> Record.register_into()
+  end
+
+  defp run(source, env), do: Schooner.eval(source, env)
+
+  test "%record-instance constructs a record value with the given type id and fields" do
+    env = env()
+    type_id = {:record_type, "tag", :erlang.unique_integer([:positive])}
+
+    Env.define(env, "type-id", type_id)
+
+    assert run("(%record-instance type-id 1 2 3)", env) ==
+             Value.record(type_id, {1, 2, 3})
+  end
+
+  test "%record-instance with no fields builds a zero-field record" do
+    env = env()
+    type_id = {:record_type, "tag", :erlang.unique_integer([:positive])}
+
+    Env.define(env, "type-id", type_id)
+
+    assert run("(%record-instance type-id)", env) == Value.record(type_id, {})
+  end
+
+  test "%record-of? returns #t only when the type ids are eqv?" do
+    env = env()
+    id1 = {:record_type, "a", 1}
+    id2 = {:record_type, "a", 2}
+
+    Env.define(env, "id1", id1)
+    Env.define(env, "id2", id2)
+
+    assert run("(%record-of? id1 (%record-instance id1 0))", env) == Value.bool(true)
+    assert run("(%record-of? id2 (%record-instance id1 0))", env) == Value.bool(false)
+    assert run("(%record-of? id1 'not-a-record)", env) == Value.bool(false)
+    assert run("(%record-of? id1 #(0 1 2))", env) == Value.bool(false)
+  end
+
+  test "%record-ref returns the indexed field of a matching record" do
+    env = env()
+    id = {:record_type, "tag", 1}
+
+    Env.define(env, "id", id)
+
+    assert run("(%record-ref id (%record-instance id 'a 'b 'c) 0)", env) == Value.symbol("a")
+    assert run("(%record-ref id (%record-instance id 'a 'b 'c) 2)", env) == Value.symbol("c")
+  end
+
+  test "%record-ref raises Schooner.Primitive.Error on a wrong-type value" do
+    env = env()
+    id1 = {:record_type, "a", 1}
+    id2 = {:record_type, "a", 2}
+
+    Env.define(env, "id1", id1)
+    Env.define(env, "id2", id2)
+
+    assert_raise PError, fn ->
+      run("(%record-ref id1 (%record-instance id2 0) 0)", env)
+    end
+
+    assert_raise PError, fn ->
+      run("(%record-ref id1 'not-a-record 0)", env)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

`(define-record-type <name> (<ctor> <ctor-field> ...) <predicate> (<field> <accessor>) ...)` now binds a constructor, predicate, and one accessor per field. Each form mints a fresh type identity at expansion time (`{:record_type, name, unique_int}`) so two definitions with the same record name in different lexical scopes produce distinct types.

- New `Schooner.Primitives.Record` — `%record-instance`, `%record-of?`, `%record-ref` runtime primitives carrying the type identity through to the per-record type-check.
- `Schooner.Expander` recognises `define-record-type` as a core form and lowers it to a `(begin (define ...) ...)` over those primitives. Partial constructors default missing fields to `:unspecified` per r7rs §5.4.
- `Schooner.Eval`'s `desugar_body` splices a leading `(begin ...)` in an internal-definition position into the surrounding body (r7rs §5.3.3) — this is what makes `define-record-type` work inside a `lambda` body.
- `Schooner.Env.lex_lookup` skips a released rec-frame slot rather than crashing on `:maps.find/2` of `nil`. A closure created in a `letrec*` body that escapes the body (e.g. `make-counter` returning a record's `make-x` constructor) now resolves cleanly through the dead frame to the surrounding scope.
- `Schooner.Value.write` renders records as `#<record name>` rather than printing the gensym suffix.

## Tests

- `test/schooner/primitives/record_test.exs` — 5 direct primitive tests.
- `test/schooner/expander/record_test.exs` — 15 end-to-end tests (ctor / predicate / accessor / partial / type identity / scope distinctness / equality / nested / write / malformed).
- `test/conformance/r7rs_section_5_4_records_test.exs` — 6 worked examples from r7rs §5.4 including the canonical `<pare>` / `kons` example.

579 → 605 tests; `mix precommit` clean.

## Test plan

- [x] `mix test` green (605 tests, 0 failures).
- [x] `mix precommit` (compile, format, credo --strict, test) green.
- [x] Internal `define-record-type` works (closure escape from `letrec*` body no longer crashes).