### PR TITLE
Phase 11: exception system (raise / guard / with-exception-handler)

### DIFF
--- a/lib/schooner.ex
+++ b/lib/schooner.ex
@@ -16,6 +16,7 @@ defmodule Schooner do
 
   alias Schooner.Env
   alias Schooner.Eval
+  alias Schooner.Eval.ExceptionState
   alias Schooner.Expander
   alias Schooner.Primitives
   alias Schooner.Reader
@@ -34,6 +35,7 @@ defmodule Schooner do
     |> Primitives.Cxr.register_into()
     |> Primitives.Char.register_into()
     |> Primitives.Record.register_into()
+    |> Primitives.Exceptions.register_into()
   end
 
   @doc """
@@ -49,9 +51,21 @@ defmodule Schooner do
   """
   @spec eval(binary(), Env.t()) :: Value.t()
   def eval(source, %Env{} = env) when is_binary(source) do
-    source
-    |> Reader.read_string()
-    |> Expander.expand_program(Expander.bootstrap_env())
-    |> Enum.reduce(:unspecified, fn form, _acc -> Eval.eval(form, env) end)
+    # Snapshot/restore the per-process handler stack so each top-level
+    # call starts clean. Without this, a script that pushes a handler
+    # then escapes via a host-side throw (e.g. a test that catches
+    # `Schooner.Error`) would leak handlers into the next call in the
+    # same process.
+    prev = ExceptionState.snapshot()
+    ExceptionState.reset()
+
+    try do
+      source
+      |> Reader.read_string()
+      |> Expander.expand_program(Expander.bootstrap_env())
+      |> Enum.reduce(:unspecified, fn form, _acc -> Eval.eval(form, env) end)
+    after
+      ExceptionState.restore(prev)
+    end
   end
 end

--- a/lib/schooner/error.ex
+++ b/lib/schooner/error.ex
@@ -2,10 +2,10 @@ defmodule Schooner.Error do
   @moduledoc """
   Host-side exception raised when a Scheme `raise` / `raise-continuable`
   / `error` is not caught by any installed `with-exception-handler` or
-  `guard`. The struct carries the original Scheme value verbatim so the
-  host can inspect it; for the common case of an error object the
-  `:message` and `:irritants` fields are pre-extracted to make
-  pattern-matching from Elixir straightforward.
+  `guard`. The struct carries the original Scheme value verbatim in
+  `:value`; for an error object the host can pattern-match
+  `{:error_obj, kind, message, irritants}` directly, or use
+  `irritants/1` for the common case.
 
   This is distinct from `Schooner.Eval.Error` and
   `Schooner.Primitive.Error`, which signal evaluator/primitive failures
@@ -16,20 +16,23 @@ defmodule Schooner.Error do
 
   alias Schooner.Value
 
-  defexception [:value, :message, :irritants]
+  @type t :: %__MODULE__{value: Value.t(), message: binary() | nil}
+
+  defexception [:value, :message]
 
   @impl true
   def exception(opts) do
     value = Keyword.fetch!(opts, :value)
-
-    irritants =
-      case value do
-        {:error_obj, _kind, _msg, irrs} -> irrs
-        _ -> []
-      end
-
-    %__MODULE__{value: value, message: format(value), irritants: irritants}
+    %__MODULE__{value: value, message: format(value)}
   end
+
+  @doc """
+  Return the irritants of `error`'s wrapped value when it is an error
+  object; `[]` for any other raised value.
+  """
+  @spec irritants(t()) :: [Value.t()]
+  def irritants(%__MODULE__{value: {:error_obj, _, _, irrs}}), do: irrs
+  def irritants(%__MODULE__{}), do: []
 
   defp format({:error_obj, _kind, message, irritants}) do
     msg_text =

--- a/lib/schooner/error.ex
+++ b/lib/schooner/error.ex
@@ -1,0 +1,52 @@
+defmodule Schooner.Error do
+  @moduledoc """
+  Host-side exception raised when a Scheme `raise` / `raise-continuable`
+  / `error` is not caught by any installed `with-exception-handler` or
+  `guard`. The struct carries the original Scheme value verbatim so the
+  host can inspect it; for the common case of an error object the
+  `:message` and `:irritants` fields are pre-extracted to make
+  pattern-matching from Elixir straightforward.
+
+  This is distinct from `Schooner.Eval.Error` and
+  `Schooner.Primitive.Error`, which signal evaluator/primitive failures
+  that the host gets directly without crossing the Scheme exception
+  machinery. Phase 11 only routes explicit `raise` calls through here;
+  evaluator/primitive errors continue to propagate as before.
+  """
+
+  alias Schooner.Value
+
+  defexception [:value, :message, :irritants]
+
+  @impl true
+  def exception(opts) do
+    value = Keyword.fetch!(opts, :value)
+
+    irritants =
+      case value do
+        {:error_obj, _kind, _msg, irrs} -> irrs
+        _ -> []
+      end
+
+    %__MODULE__{value: value, message: format(value), irritants: irritants}
+  end
+
+  defp format({:error_obj, _kind, message, irritants}) do
+    msg_text =
+      case message do
+        {:string, s} -> s
+        other -> Value.write(other)
+      end
+
+    case irritants do
+      [] ->
+        "uncaught Scheme error: #{msg_text}"
+
+      list ->
+        rendered = list |> Enum.map(&Value.write/1) |> Enum.intersperse(" ")
+        IO.iodata_to_binary(["uncaught Scheme error: ", msg_text, ": ", rendered])
+    end
+  end
+
+  defp format(other), do: "uncaught Scheme raise: #{Value.write(other)}"
+end

--- a/lib/schooner/eval.ex
+++ b/lib/schooner/eval.ex
@@ -29,6 +29,7 @@ defmodule Schooner.Eval do
 
   alias Schooner.Env
   alias Schooner.Eval.Error
+  alias Schooner.Eval.ExceptionState
   alias Schooner.Expander.SyntaxRules
   alias Schooner.Value
 
@@ -51,6 +52,7 @@ defmodule Schooner.Eval do
   def eval({:pair, {:sym, "begin"}, tail}, env), do: eval_sequence(tail, env)
   def eval({:pair, {:sym, "letrec*"}, tail}, env), do: eval_letrec_star(tail, env)
   def eval({:pair, {:sym, "quasiquote"}, tail}, env), do: eval_quasiquote_top(tail, env)
+  def eval({:pair, {:sym, "guard"}, tail}, env), do: eval_guard(tail, env)
   def eval({:pair, head, tail}, env), do: eval_apply(head, tail, env)
 
   def eval(value, _env), do: value
@@ -415,4 +417,92 @@ defmodule Schooner.Eval do
     binding = {:pair, {:sym, name}, {:pair, init, :null}}
     {:pair, binding, build_letrec_bindings(rest)}
   end
+
+  # ---------------------------------------------------------------------------
+  # guard
+  # ---------------------------------------------------------------------------
+
+  # `guard` is a core form rather than a `syntax-rules` macro because
+  # it has to escape the body once a clause matches, and the only
+  # tools available pre-`call/cc` (phase 12) are Elixir `throw` /
+  # `catch`. The handler is wrapped as a `:primitive` so
+  # `apply_proc/2` invokes it with the same machinery as a user
+  # handler — `with-exception-handler` and `guard` are
+  # indistinguishable from the raise side.
+  defp eval_guard({:pair, {:pair, {:sym, var}, clauses_form}, body}, env)
+       when is_binary(var) and body != :null do
+    tag = make_ref()
+    handler = build_guard_handler(var, clauses_form, env, tag)
+    # Snapshot/restore the whole stack rather than `pop`ing once in
+    # the after-clause: by the time we exit (matched-and-thrown,
+    # re-raised, or normal-return) the handler may already have been
+    # popped by `ExceptionState.raise_value/1`, and a blind pop
+    # would discard an outer handler we didn't install.
+    prev = ExceptionState.snapshot()
+    ExceptionState.push(handler)
+
+    try do
+      eval_body(body, env)
+    catch
+      :throw, {:schooner_guard, ^tag, value} -> value
+    after
+      ExceptionState.restore(prev)
+    end
+  end
+
+  defp eval_guard(_, _env), do: raise(Error, reason: {:bad_special_form, "guard"})
+
+  defp build_guard_handler(var, clauses_form, env, tag) do
+    Value.primitive("%guard-handler", 1, fn [raised] ->
+      handler_env = Env.extend(env, [{var, raised}])
+
+      case eval_guard_clauses(clauses_form, handler_env) do
+        {:matched, value} -> throw({:schooner_guard, tag, value})
+        :no_match -> ExceptionState.raise_value(raised)
+      end
+    end)
+  end
+
+  defp eval_guard_clauses(:null, _env), do: :no_match
+
+  defp eval_guard_clauses({:pair, {:pair, {:sym, "else"}, body}, _rest}, env)
+       when body != :null do
+    {:matched, eval_body(body, env)}
+  end
+
+  defp eval_guard_clauses({:pair, clause, rest}, env) do
+    case eval_guard_clause(clause, env) do
+      :no_match -> eval_guard_clauses(rest, env)
+      {:matched, _} = m -> m
+    end
+  end
+
+  defp eval_guard_clauses(_, _env), do: raise(Error, reason: {:bad_special_form, "guard"})
+
+  defp eval_guard_clause({:pair, test, :null}, env) do
+    case eval(test, env) do
+      {:bool, false} -> :no_match
+      val -> {:matched, val}
+    end
+  end
+
+  defp eval_guard_clause({:pair, test, {:pair, {:sym, "=>"}, {:pair, proc_expr, :null}}}, env) do
+    case eval(test, env) do
+      {:bool, false} ->
+        :no_match
+
+      val ->
+        proc = eval(proc_expr, env)
+        {:matched, apply_proc(proc, [val])}
+    end
+  end
+
+  defp eval_guard_clause({:pair, test, body}, env) when body != :null do
+    case eval(test, env) do
+      {:bool, false} -> :no_match
+      _ -> {:matched, eval_body(body, env)}
+    end
+  end
+
+  defp eval_guard_clause(_, _env), do: raise(Error, reason: {:bad_special_form, "guard"})
 end

--- a/lib/schooner/eval/exception_state.ex
+++ b/lib/schooner/eval/exception_state.ex
@@ -49,6 +49,11 @@ defmodule Schooner.Eval.ExceptionState do
   def snapshot, do: get_stack()
 
   @spec restore([Value.t()]) :: :ok
+  def restore([]) do
+    Process.delete(@key)
+    :ok
+  end
+
   def restore(stack) when is_list(stack) do
     Process.put(@key, stack)
     :ok

--- a/lib/schooner/eval/exception_state.ex
+++ b/lib/schooner/eval/exception_state.ex
@@ -1,0 +1,110 @@
+defmodule Schooner.Eval.ExceptionState do
+  @moduledoc """
+  Per-process handler stack for Scheme `raise` / `raise-continuable` /
+  `with-exception-handler` / `guard`.
+
+  The stack is held in the process dictionary because Schooner's
+  environment value is immutable: there's no way to thread a mutable
+  handler list through `apply_proc`/`eval` without breaking the
+  tail-call invariant. Each handler is a Schooner procedure value
+  (closure or primitive) so `Eval.apply_proc/2` can invoke it
+  uniformly.
+
+  The stack is reset at the start of every top-level
+  `Schooner.eval/2` call so that residue from a previous invocation
+  in the same process — e.g. after a host-side test caught a
+  `Schooner.Error` — does not influence subsequent runs.
+  """
+
+  @key {__MODULE__, :handlers}
+
+  alias Schooner.Error, as: HostError
+  alias Schooner.Eval
+  alias Schooner.Value
+
+  @doc "Reset the handler stack for a fresh top-level evaluation."
+  @spec reset() :: :ok
+  def reset do
+    Process.delete(@key)
+    :ok
+  end
+
+  @doc "Push `handler` (a Scheme procedure value) onto the stack."
+  @spec push(Value.t()) :: :ok
+  def push(handler) do
+    Process.put(@key, [handler | get_stack()])
+    :ok
+  end
+
+  @doc """
+  Snapshot/restore the entire stack — every handler-installer
+  (`with-exception-handler`, `guard`, the top-level embedding entry)
+  saves the stack on entry and restores it on every exit path. A
+  blind pop in the `after` clause would be wrong: `raise_value/1`
+  itself pops handlers as it walks the chain, so by the time the
+  `after` runs the just-installed handler may already be gone, and
+  popping would discard an outer handler we didn't install.
+  """
+  @spec snapshot() :: [Value.t()]
+  def snapshot, do: get_stack()
+
+  @spec restore([Value.t()]) :: :ok
+  def restore(stack) when is_list(stack) do
+    Process.put(@key, stack)
+    :ok
+  end
+
+  @doc """
+  Raise `value`. Pops the topmost handler (so the handler runs in
+  the *parent* dynamic extent — its own raises walk further up) and
+  invokes it. If the handler returns normally the raise is
+  non-continuable, so we re-raise a secondary error in the parent
+  extent. With no handler installed, escapes to the host as
+  `Schooner.Error`.
+  """
+  @spec raise_value(Value.t()) :: no_return()
+  def raise_value(value) do
+    case get_stack() do
+      [] ->
+        Kernel.raise(HostError, value: value)
+
+      [handler | rest] ->
+        Process.put(@key, rest)
+        _ = Eval.apply_proc(handler, [value])
+        raise_value(secondary_error(value))
+    end
+  end
+
+  @doc """
+  Raise `value` continuably. The handler runs in the parent dynamic
+  extent; if it returns normally, that return value becomes the
+  value of `(raise-continuable value)` and the original handler
+  stack is restored so the call site sees the same dynamic extent
+  it had before the raise. If the handler escapes (e.g. via a
+  matching `guard` clause throwing) the popped handler is *not*
+  re-installed — its dynamic extent is gone.
+  """
+  @spec raise_continuable(Value.t()) :: Value.t()
+  def raise_continuable(value) do
+    case get_stack() do
+      [] ->
+        Kernel.raise(HostError, value: value)
+
+      [handler | rest] = stack ->
+        Process.put(@key, rest)
+        result = Eval.apply_proc(handler, [value])
+        Process.put(@key, stack)
+        result
+    end
+  end
+
+  defp get_stack, do: Process.get(@key, [])
+
+  defp secondary_error(original) do
+    Value.error_object(
+      :user,
+      Value.string("exception handler returned from a non-continuable raise"),
+      [original]
+    )
+  end
+end

--- a/lib/schooner/expander.ex
+++ b/lib/schooner/expander.ex
@@ -39,7 +39,9 @@ defmodule Schooner.Expander do
   # fresh type identity at expansion time and embed it as a literal
   # in the bindings it generates — `syntax-rules` templates are pure
   # substitution and can't introduce a fresh constant per use.
-  @core_specials MapSet.new(~w(quote if lambda define begin set! letrec* define-record-type))
+  @core_specials MapSet.new(
+                   ~w(quote if lambda define begin set! letrec* define-record-type guard)
+                 )
 
   @doc """
   Expand a list of top-level forms in `env`. Returns a list of
@@ -161,6 +163,8 @@ defmodule Schooner.Expander do
   def expand({:pair, {:sym, "define-record-type"}, tail}, env) do
     expand_define_record_type(tail, env)
   end
+
+  def expand({:pair, {:sym, "guard"}, tail}, env), do: expand_guard(tail, env)
 
   def expand({:pair, {:sym, name}, _args} = form, env) do
     case lookup_with_fallback(env, name) do
@@ -410,6 +414,49 @@ defmodule Schooner.Expander do
   defp make_define_form(name, params, body) do
     Value.list([{:sym, "define"}, Value.list([{:sym, name} | params]), body])
   end
+
+  # `guard` is a core form rather than a `syntax-rules` macro because
+  # it must escape the body via Elixir `throw`/`catch` once a clause
+  # matches — `call/cc` (phase 12) is the macro-friendly alternative
+  # but does not yet exist. The expander walks the variable shadow,
+  # the clause tests/bodies, and the body so that user macros inside
+  # any of those positions get a chance to expand.
+  defp expand_guard({:pair, {:pair, {:sym, var}, clauses_form}, body}, env)
+       when body != :null and is_binary(var) do
+    inner = SyntaxEnv.push_variables(env, [var])
+    expanded_clauses = expand_guard_clauses(clauses_form, inner)
+    expanded_body = expand_each(body, env)
+
+    {:pair, {:sym, "guard"}, {:pair, {:pair, {:sym, var}, expanded_clauses}, expanded_body}}
+  end
+
+  defp expand_guard(_, _env), do: raise(Error, reason: {:bad_special_form, "guard"})
+
+  defp expand_guard_clauses(:null, _env), do: :null
+
+  defp expand_guard_clauses({:pair, clause, rest}, env) do
+    {:pair, expand_guard_clause(clause, env), expand_guard_clauses(rest, env)}
+  end
+
+  defp expand_guard_clauses(_, _env), do: raise(Error, reason: {:bad_special_form, "guard"})
+
+  # `else` clauses keep their literal head; everything after is a
+  # body sequence that gets recursively expanded. `=>` clauses keep
+  # the literal arrow and expand the test and the proc expression.
+  # Bare `(test)` and `(test e1 e2 ...)` expand the test plus body.
+  defp expand_guard_clause({:pair, {:sym, "else"}, body}, env) when body != :null do
+    {:pair, {:sym, "else"}, expand_each(body, env)}
+  end
+
+  defp expand_guard_clause({:pair, test, {:pair, {:sym, "=>"}, {:pair, proc, :null}}}, env) do
+    {:pair, expand(test, env), {:pair, {:sym, "=>"}, {:pair, expand(proc, env), :null}}}
+  end
+
+  defp expand_guard_clause({:pair, test, body}, env) do
+    {:pair, expand(test, env), expand_each(body, env)}
+  end
+
+  defp expand_guard_clause(_, _env), do: raise(Error, reason: {:bad_special_form, "guard"})
 
   defp expand_let_syntax({:pair, bindings_form, body}, env) when body != :null do
     bindings = parse_syntax_bindings(bindings_form, env, "let-syntax")

--- a/lib/schooner/primitives/exceptions.ex
+++ b/lib/schooner/primitives/exceptions.ex
@@ -1,0 +1,133 @@
+defmodule Schooner.Primitives.Exceptions do
+  @moduledoc """
+  Exception-system primitives from `(scheme base)`: `error`,
+  `raise`, `raise-continuable`, `with-exception-handler`, and the
+  predicate / accessor family for error objects (`error?`,
+  `error-object?`, `read-error?`, `file-error?`,
+  `error-object-message`, `error-object-irritants`).
+
+  Handler bookkeeping lives in `Schooner.Eval.ExceptionState` —
+  this module is the binding layer that exposes those operations
+  to Scheme code. The `guard` derived form is implemented as a
+  core form in `Schooner.Eval` because it needs to escape the
+  body via `throw`/`catch` once a clause matches; the throw tag
+  is internal so it cannot be observed from Scheme.
+  """
+
+  alias Schooner.Env
+  alias Schooner.Eval
+  alias Schooner.Eval.ExceptionState
+  alias Schooner.Primitive.Error
+  alias Schooner.Value
+
+  @doc """
+  Define every exception-system primitive on `env`. Returns the
+  same env (the global table is mutated in place — consistent with
+  `Env.define/3`).
+  """
+  @spec register_into(Env.t()) :: Env.t()
+  def register_into(%Env{} = env) do
+    Enum.reduce(specs(), env, fn {name, arity, fun}, acc ->
+      Env.define(acc, name, Value.primitive(name, arity, fun))
+    end)
+  end
+
+  defp specs do
+    [
+      {"error", {:at_least, 1}, &error/1},
+      {"error?", 1, &error_p/1},
+      {"error-object?", 1, &error_p/1},
+      {"read-error?", 1, &read_error_p/1},
+      {"file-error?", 1, &file_error_p/1},
+      {"error-object-message", 1, &error_message/1},
+      {"error-object-irritants", 1, &error_irritants/1},
+      {"raise", 1, &raise_/1},
+      {"raise-continuable", 1, &raise_continuable/1},
+      {"with-exception-handler", 2, &with_exception_handler/1}
+    ]
+  end
+
+  # ---------------------------------------------------------------------------
+  # error — construct an error object and raise it (non-continuable)
+  # ---------------------------------------------------------------------------
+
+  defp error([{:string, _} = msg | irritants]) do
+    obj = Value.error_object(:user, msg, irritants)
+    ExceptionState.raise_value(obj)
+  end
+
+  defp error([other | _]) do
+    raise Error, reason: {:type_error, "error", "string", other}
+  end
+
+  # ---------------------------------------------------------------------------
+  # Predicates
+  # ---------------------------------------------------------------------------
+
+  defp error_p([v]), do: Value.bool(Value.error_object?(v))
+  defp read_error_p([v]), do: Value.bool(Value.error_kind?(v, :read))
+  defp file_error_p([v]), do: Value.bool(Value.error_kind?(v, :file))
+
+  # ---------------------------------------------------------------------------
+  # Accessors
+  # ---------------------------------------------------------------------------
+
+  defp error_message([{:error_obj, _kind, message, _}]), do: message
+
+  defp error_message([other]) do
+    raise Error, reason: {:type_error, "error-object-message", "error object", other}
+  end
+
+  defp error_irritants([{:error_obj, _kind, _msg, irritants}]), do: Value.list(irritants)
+
+  defp error_irritants([other]) do
+    raise Error, reason: {:type_error, "error-object-irritants", "error object", other}
+  end
+
+  # ---------------------------------------------------------------------------
+  # raise / raise-continuable
+  # ---------------------------------------------------------------------------
+
+  defp raise_([value]), do: ExceptionState.raise_value(value)
+
+  defp raise_continuable([value]), do: ExceptionState.raise_continuable(value)
+
+  # ---------------------------------------------------------------------------
+  # with-exception-handler
+  # ---------------------------------------------------------------------------
+
+  # Both args must be procedures. Handler is pushed for the dynamic
+  # extent of the thunk's invocation; on every exit path the handler
+  # stack is restored to its state from before the call. We can't
+  # just `pop` once in the `after` clause because `raise_value`
+  # itself pops handlers as it walks the chain — so by the time the
+  # `after` runs, the handler we pushed may already be gone, and a
+  # blind pop would discard a handler installed *outside* this
+  # call. The snapshot/restore pattern collapses every escape path
+  # to the same observable: the stack on exit equals the stack on
+  # entry. The thunk call itself is *not* in tail position with
+  # respect to the surrounding code — that's an unavoidable cost of
+  # dynamic-extent handler installation, and is fixed at one BEAM
+  # stack frame per handler boundary regardless of how deep the body
+  # recurses (TCO inside the body still flattens tail self-calls).
+  defp with_exception_handler([handler, thunk]) do
+    require_procedure!("with-exception-handler", handler)
+    require_procedure!("with-exception-handler", thunk)
+    prev = ExceptionState.snapshot()
+    ExceptionState.push(handler)
+
+    try do
+      Eval.apply_proc(thunk, [])
+    after
+      ExceptionState.restore(prev)
+    end
+  end
+
+  defp require_procedure!(op, v) do
+    if Value.procedure?(v) do
+      :ok
+    else
+      raise Error, reason: {:type_error, op, "procedure", v}
+    end
+  end
+end

--- a/lib/schooner/value.ex
+++ b/lib/schooner/value.ex
@@ -33,6 +33,12 @@ defmodule Schooner.Value do
       `define-record-type`. Self-evaluating; compared with `===` so
       two definitions with the same record name in different
       lexical scopes produce distinct identities.
+    * Error object — `{:error_obj, kind, message, irritants}` where
+      `kind` is `:user | :read | :file`, `message` is a Scheme string
+      value, and `irritants` is an Elixir list of Scheme values
+      (rendered as a Scheme list by the accessor). Constructed by
+      `(error msg irritant ...)` and reachable via `error?`,
+      `error-object?`, `read-error?`, `file-error?`.
     * EOF — `:eof`
     * Unspecified — `:unspecified`
   """
@@ -49,6 +55,8 @@ defmodule Schooner.Value do
   @type record_v :: {:record, term(), tuple()}
   @type record_type_id_v :: {:record_type, binary(), pos_integer()}
   @type float_special_v :: {:float_special, :pos_inf | :neg_inf | :nan}
+  @type error_kind :: :user | :read | :file
+  @type error_obj_v :: {:error_obj, error_kind(), t(), [t()]}
   @type arity_spec :: non_neg_integer() | {:at_least, non_neg_integer()}
 
   @type t ::
@@ -67,6 +75,7 @@ defmodule Schooner.Value do
           | primitive_v()
           | record_v()
           | record_type_id_v()
+          | error_obj_v()
           | :eof
           | :unspecified
 
@@ -107,6 +116,12 @@ defmodule Schooner.Value do
 
   @spec record(term(), tuple()) :: record_v()
   def record(type_id, fields) when is_tuple(fields), do: {:record, type_id, fields}
+
+  @spec error_object(error_kind(), t(), [t()]) :: error_obj_v()
+  def error_object(kind, message, irritants)
+      when kind in [:user, :read, :file] and is_list(irritants) do
+    {:error_obj, kind, message, irritants}
+  end
 
   @doc "Build a Scheme list (proper, null-terminated) from an Elixir list."
   @spec list([t()]) :: t()
@@ -165,6 +180,14 @@ defmodule Schooner.Value do
   @spec record?(term()) :: boolean()
   def record?({:record, _, _}), do: true
   def record?(_), do: false
+
+  @spec error_object?(term()) :: boolean()
+  def error_object?({:error_obj, _, _, _}), do: true
+  def error_object?(_), do: false
+
+  @spec error_kind?(term(), error_kind()) :: boolean()
+  def error_kind?({:error_obj, kind, _, _}, kind), do: true
+  def error_kind?(_, _), do: false
 
   @spec eof?(term()) :: boolean()
   def eof?(:eof), do: true
@@ -313,6 +336,10 @@ defmodule Schooner.Value do
   defp render({:primitive, name, _, _}, _), do: ["#<primitive ", name, ">"]
   defp render({:record, {:record_type, name, _}, _}, _), do: ["#<record ", name, ">"]
   defp render({:record, type_id, _}, _), do: ["#<record ", inspect(type_id), ">"]
+
+  defp render({:error_obj, kind, message, irritants}, mode),
+    do: render_error(kind, message, irritants, mode)
+
   defp render({:float_special, :pos_inf}, _), do: "+inf.0"
   defp render({:float_special, :neg_inf}, _), do: "-inf.0"
   defp render({:float_special, :nan}, _), do: "+nan.0"
@@ -354,6 +381,17 @@ defmodule Schooner.Value do
 
   defp render_closure(nil), do: "#<procedure>"
   defp render_closure(name) when is_binary(name), do: ["#<procedure ", name, ">"]
+
+  defp render_error(kind, message, irritants, mode) do
+    msg = render(message, mode)
+    irrs = irritants |> Enum.map(&render(&1, mode)) |> Enum.intersperse(?\s)
+    tail = if irritants == [], do: [], else: [" ", irrs]
+    ["#<", error_kind_label(kind), " ", msg, tail, ">"]
+  end
+
+  defp error_kind_label(:user), do: "error"
+  defp error_kind_label(:read), do: "read-error"
+  defp error_kind_label(:file), do: "file-error"
 
   defp render_float(f) do
     s = :erlang.float_to_binary(f, [:short])

--- a/test/conformance/r7rs_section_6_11_exceptions_test.exs
+++ b/test/conformance/r7rs_section_6_11_exceptions_test.exs
@@ -1,0 +1,219 @@
+defmodule Schooner.Conformance.R7rsSection611ExceptionsTest do
+  # Worked examples from r7rs-small §6.11 (exceptions). Each test
+  # transcribes a `(form) ==> result` example from the spec or pins
+  # a property the spec calls out as required of an exception
+  # system.
+  #
+  # Schooner-specific deviations from §6.11:
+  #
+  #   - `with-exception-handler` and `guard` rely on Elixir
+  #     `throw`/`catch` rather than `call/cc` for the escape; from
+  #     the user's perspective the observable behaviour matches the
+  #     spec (escape-only continuations are sufficient for both).
+  #     Multi-shot `call/cc` is not supported (phase 12 caveat) and
+  #     no example here exercises it.
+  #   - A handler installed by `with-exception-handler` that
+  #     returns from a non-continuable `raise` triggers a secondary
+  #     error object whose message is implementation-defined; we
+  #     pin Schooner's wording in the unit suite, not here.
+  #   - `read-error?` and `file-error?` always return `#f` for
+  #     user-constructed error objects: Schooner has no port-based
+  #     reader and no file I/O (out-of-scope per the PLAN), so no
+  #     primitive currently raises with those kinds.
+  use ExUnit.Case, async: true
+
+  alias Schooner.Value
+
+  defp run(source), do: Schooner.run(source)
+
+  # ---------------------------------------------------------------------------
+  # §6.11 with-exception-handler
+  # ---------------------------------------------------------------------------
+
+  describe "§6.11 with-exception-handler / raise" do
+    test "spec example: raise inside with-exception-handler reaches the handler" do
+      # Spec example, adapted for Schooner (no display/newline; we
+      # collect the handler's observation into a list instead):
+      #
+      #   (with-exception-handler
+      #     (lambda (condition)
+      #       (cond ((string? condition)
+      #              (display condition))
+      #             (else
+      #              (display "a warning has been issued")))
+      #       42)
+      #     (lambda ()
+      #       (+ (raise-continuable "should be a number") 23)))
+      #         ==> a warning has been issued <or> the string itself, then 65
+      assert run(~S|
+               (with-exception-handler
+                 (lambda (condition)
+                   (cond ((string? condition) condition)
+                         (else 'warning))
+                   42)
+                 (lambda ()
+                   (+ (raise-continuable "should be a number") 23)))|) == 65
+    end
+
+    test "raise (non-continuable): handler return triggers secondary error" do
+      # Spec §6.11: "If the handler returns when called by raise,
+      # a secondary error is raised in the same dynamic environment
+      # as the handler." Schooner surfaces that secondary error as
+      # an error object whose only irritant is the original value.
+      assert run(~S|
+               (guard (c ((error-object? c)
+                          (car (error-object-irritants c))))
+                 (with-exception-handler
+                   (lambda (c) 'returned)
+                   (lambda () (raise 'orig))))|) == Value.symbol("orig")
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # §6.11 raise-continuable
+  # ---------------------------------------------------------------------------
+
+  describe "§6.11 raise-continuable" do
+    test "handler return value is the value of (raise-continuable obj)" do
+      assert run(~S|
+               (with-exception-handler
+                 (lambda (c) (* c 2))
+                 (lambda () (+ 1 (raise-continuable 5))))|) == 11
+    end
+
+    test "handler stack is restored after a continuable raise returns" do
+      # Two consecutive raises in the same dynamic extent must hit
+      # the same handler — the handler's dynamic extent is the
+      # whole `with-exception-handler` body, not just the first
+      # raise.
+      assert run(~S|
+               (with-exception-handler
+                 (lambda (c) (* c 10))
+                 (lambda ()
+                   (+ (raise-continuable 1)
+                      (raise-continuable 2))))|) == 30
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # §6.11 error / error-object accessors
+  # ---------------------------------------------------------------------------
+
+  describe "§6.11 error and accessors" do
+    test "spec example: (error \"...\" ...) raises a non-continuable error object" do
+      # (error "Not a list:" 'a) ==> a non-continuable error
+      assert run(~S|
+               (guard (c ((error-object? c)
+                          (list (error-object-message c)
+                                (error-object-irritants c))))
+                 (error "Not a list:" 'a))|) ==
+               Value.list([
+                 Value.string("Not a list:"),
+                 Value.list([Value.symbol("a")])
+               ])
+    end
+
+    test "error-object-message returns the original message" do
+      assert run(~S|
+               (guard (c (#t (error-object-message c)))
+                 (error "boom"))|) == Value.string("boom")
+    end
+
+    test "error-object-irritants returns the original list" do
+      assert run(~S|
+               (guard (c (#t (error-object-irritants c)))
+                 (error "boom" 1 'two "three"))|) ==
+               Value.list([1, Value.symbol("two"), Value.string("three")])
+    end
+
+    test "error-object? on non-errors returns #f" do
+      assert run("(error-object? 'x)") == Value.bool(false)
+      assert run(~S|(error-object? "string")|) == Value.bool(false)
+      assert run("(error-object? '())") == Value.bool(false)
+      assert run("(error-object? 42)") == Value.bool(false)
+    end
+
+    test "read-error? / file-error? are #f for user-created error objects" do
+      assert run(~S|
+               (guard (c (#t (list (error-object? c) (read-error? c) (file-error? c))))
+                 (error "boom"))|) ==
+               Value.list([Value.bool(true), Value.bool(false), Value.bool(false)])
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # §6.11 guard
+  # ---------------------------------------------------------------------------
+
+  describe "§6.11 guard" do
+    test "spec example: guard with a matching clause yields that clause's value" do
+      # (guard (condition
+      #          ((assq 'a condition) => cdr)
+      #          ((assq 'b condition)))
+      #   (raise (list (cons 'a 42))))
+      #     ==> 42
+      assert run(~S|
+               (guard (condition
+                        ((assq 'a condition) => cdr)
+                        ((assq 'b condition)))
+                 (raise (list (cons 'a 42))))|) == 42
+    end
+
+    test "spec example: guard returns the matching pair when => is absent" do
+      # (guard (condition
+      #          ((assq 'a condition) => cdr)
+      #          ((assq 'b condition)))
+      #   (raise (list (cons 'b 23))))
+      #     ==> (b . 23)
+      assert run(~S|
+               (guard (condition
+                        ((assq 'a condition) => cdr)
+                        ((assq 'b condition)))
+                 (raise (list (cons 'b 23))))|) == Value.pair(Value.symbol("b"), 23)
+    end
+
+    test "no clause matches: condition is re-raised in the surrounding handler" do
+      assert run(~S|
+               (guard (outer (#t (cons 'outer outer)))
+                 (guard (inner ((number? inner) 'inner-num))
+                   (raise 'sym)))|) == Value.pair(Value.symbol("outer"), Value.symbol("sym"))
+    end
+
+    test "else clause is the final catch-all" do
+      assert run(~S|
+               (guard (c ((number? c) 'num)
+                         (else 'fallback))
+                 (raise 'not-a-number))|) == Value.symbol("fallback")
+    end
+
+    test "guard body returning normally yields its value (no clauses fire)" do
+      assert run("(guard (c (#t 'never)) 1 2 3)") == 3
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # §6.11 raised values that are not error objects
+  # ---------------------------------------------------------------------------
+
+  describe "§6.11 arbitrary raised values" do
+    test "raise accepts any value, not just error objects" do
+      assert run(~S|(guard (c (#t c)) (raise 42))|) == 42
+
+      assert run(~S|(guard (c (#t c)) (raise '(a b c)))|) ==
+               Value.list([Value.symbol("a"), Value.symbol("b"), Value.symbol("c")])
+
+      assert run(~S|(guard (c (#t c)) (raise "string-condition"))|) ==
+               Value.string("string-condition")
+    end
+
+    test "error-object? distinguishes error objects from other raised values" do
+      assert run(~S|
+               (guard (c (#t (error-object? c)))
+                 (raise 42))|) == Value.bool(false)
+
+      assert run(~S|
+               (guard (c (#t (error-object? c)))
+                 (error "boom"))|) == Value.bool(true)
+    end
+  end
+end

--- a/test/schooner/primitives/exceptions_test.exs
+++ b/test/schooner/primitives/exceptions_test.exs
@@ -22,7 +22,7 @@ defmodule Schooner.Primitives.ExceptionsTest do
         end
 
       assert {:error_obj, :user, {:string, "boom"}, [1, {:sym, "two"}]} = e.value
-      assert e.irritants == [1, {:sym, "two"}]
+      assert Schooner.Error.irritants(e) == [1, {:sym, "two"}]
     end
 
     test "non-string message rejected" do
@@ -117,7 +117,7 @@ defmodule Schooner.Primitives.ExceptionsTest do
           run(~S|(error "message" 1 2)|)
         end
 
-      assert e.irritants == [1, 2]
+      assert Schooner.Error.irritants(e) == [1, 2]
       assert {:error_obj, :user, {:string, "message"}, _} = e.value
     end
   end

--- a/test/schooner/primitives/exceptions_test.exs
+++ b/test/schooner/primitives/exceptions_test.exs
@@ -1,0 +1,225 @@
+defmodule Schooner.Primitives.ExceptionsTest do
+  use ExUnit.Case, async: true
+
+  alias Schooner.Value
+
+  defp run(source), do: Schooner.run(source)
+
+  describe "error object construction" do
+    test "(error msg) constructs and raises an error object" do
+      e =
+        assert_raise Schooner.Error, fn ->
+          run(~S|(error "boom")|)
+        end
+
+      assert {:error_obj, :user, {:string, "boom"}, []} = e.value
+    end
+
+    test "(error msg irritant ...) carries irritants" do
+      e =
+        assert_raise Schooner.Error, fn ->
+          run(~S|(error "boom" 1 'two)|)
+        end
+
+      assert {:error_obj, :user, {:string, "boom"}, [1, {:sym, "two"}]} = e.value
+      assert e.irritants == [1, {:sym, "two"}]
+    end
+
+    test "non-string message rejected" do
+      assert_raise Schooner.Primitive.Error, fn -> run("(error 42)") end
+    end
+  end
+
+  describe "predicates" do
+    test "error-object? distinguishes error objects from other values" do
+      assert run(~S|(error-object? (guard (c (#t c)) (error "x")))|) == Value.bool(true)
+      assert run("(error-object? 'x)") == Value.bool(false)
+      assert run(~S|(error-object? "x")|) == Value.bool(false)
+      assert run("(error-object? '())") == Value.bool(false)
+    end
+
+    test "error? is the same predicate" do
+      assert run(~S|(error? (guard (c (#t c)) (error "x")))|) == Value.bool(true)
+      assert run("(error? 0)") == Value.bool(false)
+    end
+
+    test "read-error? / file-error? are false for user-created errors" do
+      assert run(~S|(read-error? (guard (c (#t c)) (error "x")))|) == Value.bool(false)
+      assert run(~S|(file-error? (guard (c (#t c)) (error "x")))|) == Value.bool(false)
+    end
+  end
+
+  describe "error-object-message / error-object-irritants" do
+    test "accessors return the original message and irritants" do
+      assert run(~S|
+               (define e (guard (c (#t c)) (error "msg" 1 2 3)))
+               (error-object-message e)|) == Value.string("msg")
+
+      assert run(~S|
+               (define e (guard (c (#t c)) (error "msg" 1 2 3)))
+               (error-object-irritants e)|) == Value.list([1, 2, 3])
+    end
+
+    test "non-error-object input raises a structured error" do
+      assert_raise Schooner.Primitive.Error, fn ->
+        run("(error-object-message 5)")
+      end
+    end
+  end
+
+  describe "raise" do
+    test "raise inside guard delivers the raised value to the handler" do
+      assert run(~S|(guard (c (#t c)) (raise 'oops))|) == Value.symbol("oops")
+    end
+
+    test "raise inside with-exception-handler invokes the handler" do
+      # The user-supplied handler is wrapped to call `error` so the
+      # outer guard sees a deterministic value — proves the handler
+      # ran and observed the raised value, since the alternative
+      # (handler not invoked) would propagate `(raise 'orig)` directly.
+      assert run(~S|
+               (guard (c ((error-object? c)
+                          (car (error-object-irritants c))))
+                 (with-exception-handler
+                   (lambda (c) (error "handler-saw" c))
+                   (lambda () (raise 'orig))))|) == Value.symbol("orig")
+    end
+
+    test "non-continuable raise returns secondary error to outer handler" do
+      # Inner with-exception-handler's handler returns normally, so a
+      # secondary error object with the original raised value as its
+      # irritant is raised in the outer dynamic extent.
+      assert run(~S|
+               (guard (c ((error-object? c)
+                          (cons (error-object-message c)
+                                (error-object-irritants c))))
+                 (with-exception-handler
+                   (lambda (c) 'handler-returned)
+                   (lambda () (raise 'orig))))|) ==
+               Value.pair(
+                 Value.string("exception handler returned from a non-continuable raise"),
+                 Value.list([Value.symbol("orig")])
+               )
+    end
+
+    test "unhandled raise propagates to the host as Schooner.Error" do
+      e =
+        assert_raise Schooner.Error, fn ->
+          run("(raise 'boom)")
+        end
+
+      assert e.value == Value.symbol("boom")
+    end
+
+    test "unhandled error object propagates with irritants attached" do
+      e =
+        assert_raise Schooner.Error, fn ->
+          run(~S|(error "message" 1 2)|)
+        end
+
+      assert e.irritants == [1, 2]
+      assert {:error_obj, :user, {:string, "message"}, _} = e.value
+    end
+  end
+
+  describe "raise-continuable" do
+    test "handler return value becomes the raise-continuable result" do
+      assert run(~S|
+               (with-exception-handler
+                 (lambda (c) (* c 10))
+                 (lambda () (+ 1 (raise-continuable 5))))|) == 51
+    end
+
+    test "handler stack is restored after raise-continuable returns" do
+      # After the first raise-continuable returns, the handler is
+      # still in place, so a second raise-continuable hits the same
+      # handler again.
+      assert run(~S|
+               (with-exception-handler
+                 (lambda (c) (* c 2))
+                 (lambda ()
+                   (+ (raise-continuable 3)
+                      (raise-continuable 4))))|) == 14
+    end
+  end
+
+  describe "guard" do
+    test "matching clause's value becomes the guard form's value" do
+      assert run(~S|
+               (guard (c ((symbol? c) 'got-symbol)
+                         ((number? c) 'got-number))
+                 (raise 42))|) == Value.symbol("got-number")
+    end
+
+    test "no clause matches → re-raise to outer handler" do
+      assert run(~S|
+               (guard (c ((symbol? c) 'outer-saw-symbol))
+                 (guard (c ((number? c) 'inner-saw-number))
+                   (raise 'oops)))|) == Value.symbol("outer-saw-symbol")
+    end
+
+    test "else clause acts as catch-all" do
+      assert run(~S|
+               (guard (c ((number? c) 'num)
+                         (else 'else-fired))
+                 (raise 'sym))|) == Value.symbol("else-fired")
+    end
+
+    test "=> arrow form receives the test value" do
+      assert run(~S|
+               (guard (c ((assv c '((a . 1) (b . 2))) => cdr)
+                         (else 'no-match))
+                 (raise 'b))|) == 2
+    end
+
+    test "guard body returning normally yields its value" do
+      assert run("(guard (c (#t 'ignored)) 1 2 3)") == 3
+    end
+
+    test "no clause matches and no outer handler → escapes to host" do
+      e =
+        assert_raise Schooner.Error, fn ->
+          run(~S|(guard (c ((symbol? c) 'sym)) (raise 99))|)
+        end
+
+      assert e.value == 99
+    end
+
+    test "var binds the raised value inside clauses" do
+      assert run(~S|
+               (guard (c (#t (cons 'got c)))
+                 (raise '(1 2 3)))|) == Value.pair(Value.symbol("got"), Value.list([1, 2, 3]))
+    end
+
+    test "nested guard escapes only the inner form" do
+      assert run(~S|
+               (+ 100
+                  (guard (c ((number? c) c))
+                    (raise 5)))|) == 105
+    end
+  end
+
+  describe "TCO + exceptions" do
+    test "handler installed across deeply nested tail calls is reached without stack growth" do
+      # 100k iterations of a tail-recursive loop, then raise. The
+      # handler is installed by the surrounding `with-exception-handler`;
+      # the BEAM stack must stay bounded both during the loop and
+      # during the raise's handler walk.
+      depth = 100_000
+
+      source = """
+      (guard (c (#t c))
+        (let loop ((n #{depth}))
+          (if (= n 0)
+              (raise 'reached)
+              (loop (- n 1)))))
+      """
+
+      result = run(source)
+      assert result == Value.symbol("reached")
+
+      {:total_heap_size, heap} = Process.info(self(), :total_heap_size)
+      assert heap < 5_000_000, "heap grew to #{heap} words — TCO likely broken"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Implements r7rs exception primitives: `error`, `raise`, `raise-continuable`, `with-exception-handler`, `guard`, plus the `error?` / `error-object?` / `read-error?` / `file-error?` / `error-object-message` / `error-object-irritants` family.
- Adds `:error_obj` value tag (`{kind, message, irritants}`) and `Schooner.Error` host-side exception so unhandled raises propagate to Elixir with the original Scheme value and irritants attached.
- Handler stack lives in the process dictionary (env is immutable) and uses snapshot/restore on every installer rather than popping in an `after` clause — `raise_value` itself pops handlers as it walks, so a blind pop would discard outer handlers.
- `guard` is a core form (not a `syntax-rules` macro) because matched clauses need to escape the body and `call/cc` doesn't land until phase 12; the escape uses an internal `throw`/`catch` tag.

## Test plan

- [x] `mix precommit` green (629 tests, 23 properties, no credo issues, format clean)
- [x] New `test/schooner/primitives/exceptions_test.exs` covers: error-object construction, every predicate/accessor, raise inside guard, raise inside `with-exception-handler` (observed via outer guard), non-continuable→secondary-error semantics, host propagation as `Schooner.Error` with irritants attached, `raise-continuable` handler-return + stack-restoration across consecutive raises, every `guard` clause shape (`(test e ...)`, `(test => proc)`, `else`, no-match re-raise, host escape), nested-guard isolation
- [x] 100k-deep TCO regression with a `guard` boundary asserts `total_heap_size < 5M` words after the loop+raise+match

## Notes

Out of scope (deliberately): converting `Schooner.Eval.Error` / `Schooner.Primitive.Error` into Scheme-catchable raises. The PLAN's phase-11 tests only require explicit `(raise ...)` paths.