### PR TITLE
Phase 12: escape continuations & dynamic-wind

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -258,6 +258,7 @@ Records as `{:record, type_id, fields_tuple}`. Type IDs are gensyms generated at
 - `call-with-current-continuation` / `call/cc` returns a single-use escape procedure implemented via a fresh `throw` tag and a top-level `catch` reinstalled at each `call/cc` site. Invoking the procedure throws; the matching `catch` returns its argument as the value of the original `call/cc` call.
 - `dynamic-wind`: maintain a wind stack. On every escape (continuation invocation, exception raise, normal return out of a `dynamic-wind`), compute the difference between current and target wind stacks and run the appropriate `before` / `after` thunks.
 - Document explicitly: continuations are single-shot upward only. Calling a continuation after its dynamic extent has ended raises a Schooner-specific error.
+- **Forward-compatibility note.** The single-shot restriction is intentionally a documented error rather than undefined behaviour — full first-class `call/cc` is planned for v2.0 (see "Deferred to v2.0" below). Lifting an error case is non-breaking, so v1 scripts that respect the restriction will continue to work unchanged on v2.
 
 **Tests:**
 
@@ -297,8 +298,9 @@ Records as `{:record, type_id, fields_tuple}`. Type IDs are gensyms generated at
 {:ok, value} = Schooner.eval_string("(+ 1 (now-ms))", env)
 ```
 
-- `Schooner.compile/1` produces a fully expanded core AST for caching.
-- `Schooner.Host` defines the marshalling rules: Scheme `{:string, b}` ↔ Elixir binary, lists ↔ lists, integers/floats unwrapped, vectors ↔ tuples, symbols stay tagged. Anything not representable raises a marshalling error at the boundary.
+- `Schooner.compile/1` produces a fully expanded core AST for caching. The returned term is **opaque** (wrap as `%Schooner.Compiled{}` or document "treat as opaque") — embedders must not pattern-match on its internals. This is the seam that lets the v2.0 evaluator rewrite swap representations without breaking the public API.
+- `Schooner.Host` defines the marshalling rules: Scheme `{:string, b}` ↔ Elixir binary, lists ↔ lists, integers/floats unwrapped, vectors ↔ tuples, symbols stay tagged. Anything not representable raises a marshalling error at the boundary. **Closures, records of host-unknown types, and continuations are explicitly not marshallable** — listing continuations now (even though v1's escape-only continuations cannot meaningfully cross the boundary) makes the rule stable across the v2.0 multi-shot upgrade.
+- **Host-boundary continuation barrier.** A Scheme procedure invoked from a host function executes inside a continuation barrier: capturing a continuation across the boundary and invoking it after the host call has returned is a Schooner error. Under v1's escape-only model this case is unreachable, so the rule is documentation-only; under v2.0's first-class `call/cc` it becomes load-bearing. Documenting it in v1 keeps v2 from having to introduce a new error case retroactively.
 - The host is responsible for resource limits — document the recommended pattern (run `Schooner.eval/2` inside a spawned process with `:max_heap_size` and a timeout `:after`).
 
 **Tests:**
@@ -341,10 +343,15 @@ The primary verification is the per-phase test suite called out in each phase ab
 
 - Mutation: `set!`, `set-car!`, `set-cdr!`, `string-set!`, `vector-set!`, `bytevector-u8-set!`, record-type mutators.
 - Numeric tower beyond integer/float exactness tags.
-- Multi-shot `call/cc`.
 - File I/O, the port abstraction, `(scheme file)`, `(scheme load)`, `(scheme repl)`, `(scheme process-context)`, `(scheme eval)`, `(scheme complex)`, `(scheme r5rs)`.
 - Datum labels in the reader.
 - A REPL binary. (Easy follow-up if wanted, but not core.)
+
+### Deferred to v2.0
+
+Items intentionally not in v1 but planned as a future major-version change. v1 documents and tests the restricted behaviour so that lifting the restriction in v2 is non-breaking for embedders who respected the v1 contract.
+
+- **Full first-class `call/cc`.** Multi-shot continuations, re-entry after the original `call/cc` has returned, and `dynamic-wind` re-entry semantics (`before` thunks fire on re-entry, not just `after` on escape). Requires replacing the direct mutual-tail-call evaluator with either a CPS transform or an explicit-continuation-frame trampoline, plus host-boundary barrier enforcement (the documentation-only rule from phase 14 becomes load-bearing).
 
 ## Follow-ups after MVP
 
@@ -352,3 +359,4 @@ The primary verification is the per-phase test suite called out in each phase ab
 - Performance pass: bind-time variable resolution (de Bruijn indices or precomputed lookup paths), primitive inlining, constant folding during expansion.
 - Optional: a minimal `(scheme time)` and `(scheme eval)` exposed only when the host opts in.
 - Optional: source-mapped error traces from `eval` back to original reader positions.
+- **v2.0: full first-class `call/cc`.** Evaluator rewrite to CPS or explicit-continuation-frame trampoline; multi-shot continuations; `dynamic-wind` re-entry firing `before` thunks on re-entry; host-boundary barrier enforcement (turn the v1 documentation-only rule into a runtime check); new test surface — generators, `amb`, yin-yang puzzle, captured-continuation-loop OOM regression, captured-continuation interaction with `with-exception-handler`. Re-run all phase 4 TCO regressions under the new evaluator shape.

--- a/lib/schooner.ex
+++ b/lib/schooner.ex
@@ -16,6 +16,7 @@ defmodule Schooner do
 
   alias Schooner.Env
   alias Schooner.Eval
+  alias Schooner.Eval.ContinuationState
   alias Schooner.Eval.ExceptionState
   alias Schooner.Expander
   alias Schooner.Primitives
@@ -36,6 +37,7 @@ defmodule Schooner do
     |> Primitives.Char.register_into()
     |> Primitives.Record.register_into()
     |> Primitives.Exceptions.register_into()
+    |> Primitives.Continuations.register_into()
   end
 
   @doc """
@@ -51,13 +53,15 @@ defmodule Schooner do
   """
   @spec eval(binary(), Env.t()) :: Value.t()
   def eval(source, %Env{} = env) when is_binary(source) do
-    # Snapshot/restore the per-process handler stack so each top-level
+    # Snapshot/restore the per-process control state so each top-level
     # call starts clean. Without this, a script that pushes a handler
-    # then escapes via a host-side throw (e.g. a test that catches
-    # `Schooner.Error`) would leak handlers into the next call in the
-    # same process.
-    prev = ExceptionState.snapshot()
+    # or registers a `call/cc` tag then escapes via a host-side throw
+    # (e.g. a test that catches `Schooner.Error`) would leak state into
+    # the next call in the same process.
+    prev_handlers = ExceptionState.snapshot()
+    prev_conts = ContinuationState.snapshot()
     ExceptionState.reset()
+    ContinuationState.reset()
 
     try do
       source
@@ -65,7 +69,8 @@ defmodule Schooner do
       |> Expander.expand_program(Expander.bootstrap_env())
       |> Enum.reduce(:unspecified, fn form, _acc -> Eval.eval(form, env) end)
     after
-      ExceptionState.restore(prev)
+      ExceptionState.restore(prev_handlers)
+      ContinuationState.restore(prev_conts)
     end
   end
 end

--- a/lib/schooner/eval/continuation_state.ex
+++ b/lib/schooner/eval/continuation_state.ex
@@ -1,0 +1,76 @@
+defmodule Schooner.Eval.ContinuationState do
+  @moduledoc """
+  Per-process registry of currently-live escape-continuation tags.
+
+  When `call/cc` is entered it mints a fresh `make_ref/0` tag, installs
+  a `try ... catch :throw, {:schooner_continuation, ^tag, value}` around
+  the call to the user procedure, and registers the tag here. The
+  reified continuation value is a Schooner primitive that, when applied,
+  consults this registry: if the tag is still live the primitive throws
+  `{:schooner_continuation, tag, value}` and the matching `catch`
+  returns; if the tag is gone the primitive raises
+  `Schooner.Eval.Error` with reason `:continuation_expired`.
+
+  This is what makes Schooner's continuations *escape-only* in a
+  user-observable way — invoking a captured continuation after its
+  dynamic extent has ended is a documented error rather than undefined
+  behaviour. See PLAN.md phase 12 and the v2.0 follow-up note: lifting
+  this restriction (multi-shot, full re-entry) is non-breaking for
+  scripts that respect the v1 contract because it removes an error case
+  rather than adding one.
+
+  The set is reset by `Schooner.eval/2` at the start of every top-level
+  call, mirroring `Schooner.Eval.ExceptionState`.
+  """
+
+  @key {__MODULE__, :live}
+
+  @doc "Reset the live-tag set for a fresh top-level evaluation."
+  @spec reset() :: :ok
+  def reset do
+    Process.delete(@key)
+    :ok
+  end
+
+  @doc "Snapshot the live-tag set; used by re-entrant top-level evals."
+  @spec snapshot() :: MapSet.t(reference())
+  def snapshot, do: get_set()
+
+  @spec restore(MapSet.t(reference())) :: :ok
+  def restore(set) do
+    if MapSet.size(set) == 0 do
+      Process.delete(@key)
+    else
+      Process.put(@key, set)
+    end
+
+    :ok
+  end
+
+  @doc "Mark `tag` as live for the duration of an active `call/cc` extent."
+  @spec register(reference()) :: :ok
+  def register(tag) when is_reference(tag) do
+    Process.put(@key, MapSet.put(get_set(), tag))
+    :ok
+  end
+
+  @doc "Mark `tag` as gone — the surrounding `call/cc` has exited."
+  @spec deregister(reference()) :: :ok
+  def deregister(tag) when is_reference(tag) do
+    new_set = MapSet.delete(get_set(), tag)
+
+    if MapSet.size(new_set) == 0 do
+      Process.delete(@key)
+    else
+      Process.put(@key, new_set)
+    end
+
+    :ok
+  end
+
+  @doc "Is `tag` currently inside an active `call/cc` extent?"
+  @spec live?(reference()) :: boolean()
+  def live?(tag) when is_reference(tag), do: MapSet.member?(get_set(), tag)
+
+  defp get_set, do: Process.get(@key, MapSet.new())
+end

--- a/lib/schooner/eval/error.ex
+++ b/lib/schooner/eval/error.ex
@@ -24,6 +24,11 @@ defmodule Schooner.Eval.Error do
   defp format(:define_after_expression), do: "internal `define` after a non-definition expression"
   defp format(:empty_body), do: "body must contain at least one expression"
 
+  defp format(:continuation_expired) do
+    "continuation invoked after its dynamic extent has ended " <>
+      "(Schooner continuations are escape-only — see PLAN.md phase 12)"
+  end
+
   defp format({:rec_uninitialised, name}) do
     "letrec binding `#{name}` referenced before its init has been evaluated"
   end

--- a/lib/schooner/primitives/continuations.ex
+++ b/lib/schooner/primitives/continuations.ex
@@ -1,0 +1,138 @@
+defmodule Schooner.Primitives.Continuations do
+  @moduledoc """
+  Escape continuations and `dynamic-wind` from `(scheme base)`:
+  `call/cc`, `call-with-current-continuation`, and `dynamic-wind`.
+
+  ## Escape-only `call/cc`
+
+  Schooner's continuations are *single-shot upward only*. `call/cc`
+  reifies the current continuation as a Schooner procedure that, when
+  invoked, escapes back to the original call site. The implementation
+  mints a fresh `make_ref/0` tag at every `call/cc` entry, installs a
+  `try ... catch` matching that tag, and registers the tag with
+  `Schooner.Eval.ContinuationState` for the dynamic extent of the
+  procedure call. Invoking the continuation throws
+  `{:schooner_continuation, tag, value}`; the matching `catch` returns
+  the value as the result of the original `call/cc`.
+
+  Once the `call/cc` exits — by any path: matched escape, normal
+  return, raised exception, or another continuation invocation that
+  walks past us — its `after` clause deregisters the tag. A subsequent
+  invocation of the now-stale continuation procedure observes the tag
+  is gone and raises `Schooner.Eval.Error` with reason
+  `:continuation_expired` rather than letting the throw propagate
+  uncaught into Erlang. This is a documented deviation from r7rs
+  (which mandates fully reusable continuations); lifting it to
+  multi-shot full first-class `call/cc` is the planned v2.0 change
+  per PLAN.md.
+
+  ## `dynamic-wind` without an explicit wind stack
+
+  Under escape-only continuations, every escape from inside a
+  `dynamic-wind` body unwinds via `:erlang.throw/1` (the continuation
+  procedure throws) or `Kernel.raise/1` (an exception escapes). Both
+  fire the surrounding `try/after` clauses in innermost-first order
+  as the stack unwinds, which is exactly the r7rs semantics for
+  running `after` thunks on escape. A separate wind-stack data
+  structure is therefore unnecessary at v1 — the `try/after`
+  primitive fan-in already gives us the right ordering for free.
+
+  v2.0's first-class `call/cc` does need an explicit wind stack
+  (capturing a continuation must snapshot the wind frames so re-entry
+  can re-fire `before` thunks). Until then, this module is just the
+  binding layer over `try/after`.
+  """
+
+  alias Schooner.Env
+  alias Schooner.Eval
+  alias Schooner.Eval.ContinuationState
+  alias Schooner.Eval.Error
+  alias Schooner.Primitive.Error, as: PrimError
+  alias Schooner.Value
+
+  @doc """
+  Define every continuation primitive on `env`. Returns the same env
+  (the global table is mutated in place — consistent with
+  `Env.define/3`).
+  """
+  @spec register_into(Env.t()) :: Env.t()
+  def register_into(%Env{} = env) do
+    Enum.reduce(specs(), env, fn {name, arity, fun}, acc ->
+      Env.define(acc, name, Value.primitive(name, arity, fun))
+    end)
+  end
+
+  defp specs do
+    [
+      {"call-with-current-continuation", 1, &call_cc/1},
+      {"call/cc", 1, &call_cc/1},
+      {"dynamic-wind", 3, &dynamic_wind/1}
+    ]
+  end
+
+  # ---------------------------------------------------------------------------
+  # call/cc
+  # ---------------------------------------------------------------------------
+
+  defp call_cc([proc]) do
+    require_procedure!("call/cc", proc)
+    tag = make_ref()
+    cont = make_continuation(tag)
+    ContinuationState.register(tag)
+
+    try do
+      Eval.apply_proc(proc, [cont])
+    catch
+      :throw, {:schooner_continuation, ^tag, value} -> value
+    after
+      ContinuationState.deregister(tag)
+    end
+  end
+
+  # The reified continuation procedure. When applied with one argument
+  # it consults the live-tag registry: if the surrounding `call/cc` is
+  # still on the stack, throw the matched tag; otherwise raise a
+  # documented Schooner error rather than letting an unmatched throw
+  # escape. Captured by reference so this file owns the throw-tag
+  # vocabulary end-to-end.
+  defp make_continuation(tag) do
+    Value.primitive("continuation", 1, fn [value] ->
+      if ContinuationState.live?(tag) do
+        throw({:schooner_continuation, tag, value})
+      else
+        raise Error, reason: :continuation_expired
+      end
+    end)
+  end
+
+  # ---------------------------------------------------------------------------
+  # dynamic-wind
+  # ---------------------------------------------------------------------------
+
+  # `before` runs once on entry. `thunk` is the body whose value is
+  # returned. `after` runs on every exit path: normal return,
+  # exception, or escape via a continuation invocation. The `after`
+  # thunk evaluates *outside* its own `dynamic-wind` extent — that's
+  # what `try/after` gives us, and matches r7rs.
+  defp dynamic_wind([before_thunk, thunk, after_thunk]) do
+    require_procedure!("dynamic-wind", before_thunk)
+    require_procedure!("dynamic-wind", thunk)
+    require_procedure!("dynamic-wind", after_thunk)
+
+    _ = Eval.apply_proc(before_thunk, [])
+
+    try do
+      Eval.apply_proc(thunk, [])
+    after
+      _ = Eval.apply_proc(after_thunk, [])
+    end
+  end
+
+  defp require_procedure!(op, v) do
+    if Value.procedure?(v) do
+      :ok
+    else
+      raise PrimError, reason: {:type_error, op, "procedure", v}
+    end
+  end
+end

--- a/test/conformance/r7rs_section_6_10_continuations_test.exs
+++ b/test/conformance/r7rs_section_6_10_continuations_test.exs
@@ -1,0 +1,316 @@
+defmodule Schooner.Conformance.R7rsSection610ContinuationsTest do
+  # Worked examples from r7rs-small §6.10 (control features). Each
+  # test transcribes a `(form) ==> result` example from the spec or
+  # pins a property the spec calls out. Only the `call/cc` and
+  # `dynamic-wind` parts of §6.10 are exercised here; `apply`,
+  # `values`, and `call-with-values` are out of phase 12 scope.
+  #
+  # Schooner-specific deviations from §6.10:
+  #
+  #   - Continuations are escape-only and single-shot. r7rs requires
+  #     fully reusable first-class continuations; Schooner reifies
+  #     `call/cc` via `:erlang.throw/1` with a tag whose matching
+  #     `:erlang.catch` is reinstalled at every `call/cc` site, so
+  #     invoking a continuation after that catch is gone raises
+  #     `Schooner.Eval.Error{reason: :continuation_expired}` rather
+  #     than resuming the captured computation. This is the explicit
+  #     deviation called out in PLAN.md phase 12.
+  #
+  #   - The §6.10 `(connect talk1 disconnect connect talk2
+  #     disconnect)` example combines `set!` (out of scope), captured
+  #     continuation re-entry (out of scope), and `dynamic-wind`'s
+  #     `before` thunk firing on re-entry (out of scope). The
+  #     `set!`-free part of the deviation — invoking a saved
+  #     continuation after its extent ends — is asserted as a failing
+  #     case below to pin Schooner's behaviour.
+  #
+  #   - Lifting both restrictions (multi-shot `call/cc`, dynamic-wind
+  #     re-entry semantics) is the planned v2.0 change per PLAN.md's
+  #     "Deferred to v2.0" section.
+  use ExUnit.Case, async: true
+
+  alias Schooner.Env
+  alias Schooner.Primitives
+  alias Schooner.Value
+
+  @recorder_key {__MODULE__, :record}
+
+  defp run(source), do: Schooner.eval(source, recording_env())
+
+  defp recording_env do
+    Process.delete(@recorder_key)
+
+    Env.new()
+    |> Primitives.Base.register_into()
+    |> Primitives.Cxr.register_into()
+    |> Primitives.Char.register_into()
+    |> Primitives.Record.register_into()
+    |> Primitives.Exceptions.register_into()
+    |> Primitives.Continuations.register_into()
+    |> Env.define(
+      "record!",
+      Value.primitive("record!", 1, fn [v] ->
+        Process.put(@recorder_key, [v | Process.get(@recorder_key, [])])
+        :unspecified
+      end)
+    )
+    |> Env.define(
+      "get-record",
+      Value.primitive("get-record", 0, fn [] ->
+        Process.get(@recorder_key, []) |> Enum.reverse() |> Value.list()
+      end)
+    )
+  end
+
+  # ---------------------------------------------------------------------------
+  # §6.10 call-with-current-continuation
+  # ---------------------------------------------------------------------------
+
+  describe "§6.10 call-with-current-continuation" do
+    # Spec: `(call-with-current-continuation procedure?) ==> #t`
+    # The reified continuation is itself a procedure.
+    test "the captured continuation is a procedure" do
+      assert run("(call-with-current-continuation procedure?)") == Value.bool(true)
+    end
+
+    # Spec example, find-first-negative:
+    #   (call-with-current-continuation
+    #     (lambda (exit)
+    #       (for-each (lambda (x)
+    #                   (if (negative? x) (exit x)))
+    #                 '(54 0 37 -3 245 19))
+    #       #t))                                       ==> -3
+    test "early-exit with for-each finds the first negative element" do
+      assert run("""
+             (call-with-current-continuation
+               (lambda (exit)
+                 (for-each (lambda (x)
+                             (if (negative? x) (exit x)))
+                           '(54 0 37 -3 245 19))
+                 #t))
+             """) == -3
+    end
+
+    # Spec example, list-length:
+    #   (define list-length
+    #     (lambda (obj)
+    #       (call-with-current-continuation
+    #         (lambda (return)
+    #           (letrec ((r (lambda (obj)
+    #                         (cond ((null? obj) 0)
+    #                               ((pair? obj) (+ (r (cdr obj)) 1))
+    #                               (else (return #f))))))
+    #             (r obj))))))
+    #   (list-length '(1 2 3 4))   ==> 4
+    #   (list-length '(a b . c))   ==> #f
+    test "list-length: proper list returns its length" do
+      assert run("""
+             (define list-length
+               (lambda (obj)
+                 (call-with-current-continuation
+                   (lambda (return)
+                     (letrec ((r (lambda (obj)
+                                   (cond ((null? obj) 0)
+                                         ((pair? obj) (+ (r (cdr obj)) 1))
+                                         (else (return #f))))))
+                       (r obj))))))
+             (list-length '(1 2 3 4))
+             """) == 4
+    end
+
+    test "list-length: improper list short-circuits to #f via the captured continuation" do
+      assert run("""
+             (define list-length
+               (lambda (obj)
+                 (call-with-current-continuation
+                   (lambda (return)
+                     (letrec ((r (lambda (obj)
+                                   (cond ((null? obj) 0)
+                                         ((pair? obj) (+ (r (cdr obj)) 1))
+                                         (else (return #f))))))
+                       (r obj))))))
+             (list-length '(a b . c))
+             """) == Value.bool(false)
+    end
+
+    # Classic escape example folded into the standard r7rs commentary:
+    #   (+ 1 (call/cc (lambda (k) (+ 2 (k 3)))))   ==> 4
+    test "invoking the continuation discards the surrounding addition" do
+      assert run("(+ 1 (call/cc (lambda (k) (+ 2 (k 3)))))") == 4
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # §6.10 dynamic-wind
+  # ---------------------------------------------------------------------------
+
+  describe "§6.10 dynamic-wind" do
+    # The portable shape of the spec's `dynamic-wind` motivating
+    # example — without `set!`, we capture order via the host
+    # `record!` primitive instead. Asserts the spec's promise:
+    # `before` runs once on entry, `after` runs once on normal exit,
+    # and the value of the form is the value of `thunk`.
+    test "before fires on entry, after fires on normal exit, thunk's value is returned" do
+      assert run("""
+             (define result
+               (dynamic-wind
+                 (lambda () (record! 'before))
+                 (lambda () (record! 'thunk) 'value-of-thunk)
+                 (lambda () (record! 'after))))
+             (cons result (get-record))
+             """) ==
+               Value.pair(
+                 Value.symbol("value-of-thunk"),
+                 Value.list([
+                   Value.symbol("before"),
+                   Value.symbol("thunk"),
+                   Value.symbol("after")
+                 ])
+               )
+    end
+
+    # §6.10 prose: "The `after` procedure is called whenever
+    # execution leaves the dynamic extent of the call to `thunk`."
+    # An escape via `call/cc` is one such departure.
+    test "after fires when a continuation invocation escapes the body" do
+      assert run("""
+             (call/cc
+               (lambda (k)
+                 (dynamic-wind
+                   (lambda () (record! 'before))
+                   (lambda () (record! 'thunk) (k 'escaped))
+                   (lambda () (record! 'after)))))
+             (get-record)
+             """) ==
+               Value.list([
+                 Value.symbol("before"),
+                 Value.symbol("thunk"),
+                 Value.symbol("after")
+               ])
+    end
+
+    # The §6.10 prose extends to "leave the dynamic extent" via any
+    # mechanism, including a propagating exception — `after` thunks
+    # are part of the unwind path and must fire.
+    test "after fires when an exception escapes the body" do
+      assert run("""
+             (guard (c (#t 'caught))
+               (dynamic-wind
+                 (lambda () (record! 'before))
+                 (lambda () (record! 'thunk) (error "boom"))
+                 (lambda () (record! 'after))))
+             (get-record)
+             """) ==
+               Value.list([
+                 Value.symbol("before"),
+                 Value.symbol("thunk"),
+                 Value.symbol("after")
+               ])
+    end
+
+    # §6.10: nested dynamic-winds compose; on escape, after thunks
+    # run innermost-first.
+    test "nested dynamic-wind unwinds inside-out on escape" do
+      assert run("""
+             (call/cc
+               (lambda (k)
+                 (dynamic-wind
+                   (lambda () (record! 'before-outer))
+                   (lambda ()
+                     (dynamic-wind
+                       (lambda () (record! 'before-inner))
+                       (lambda () (k 'escaped))
+                       (lambda () (record! 'after-inner))))
+                   (lambda () (record! 'after-outer)))))
+             (get-record)
+             """) ==
+               Value.list([
+                 Value.symbol("before-outer"),
+                 Value.symbol("before-inner"),
+                 Value.symbol("after-inner"),
+                 Value.symbol("after-outer")
+               ])
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Documented Schooner deviations from §6.10
+  # ---------------------------------------------------------------------------
+
+  describe "documented deviations from §6.10" do
+    # r7rs requires that a continuation captured by `call/cc` may be
+    # invoked at any later point, possibly multiple times. Schooner
+    # does not support that: invoking after the `call/cc`'s dynamic
+    # extent has ended is a documented error. The form below — saving
+    # `k` and invoking it from outside — is the smallest test that
+    # would pass on a fully-conformant implementation but raises here.
+    #
+    # Lifting this restriction is the planned v2.0 change.
+    test "DEVIATION: invoking a saved continuation after its extent ends raises" do
+      err =
+        assert_raise Schooner.Eval.Error, fn ->
+          run("""
+          (define saved (call/cc (lambda (k) k)))
+          (saved 'should-not-arrive)
+          """)
+        end
+
+      assert err.reason == :continuation_expired
+    end
+
+    # A multi-shot use: invoking the same continuation twice. The
+    # first invocation succeeds (it's the escape that returns from
+    # the original `call/cc`); the second observes that the catch is
+    # gone and raises. r7rs requires both invocations to behave
+    # identically.
+    test "DEVIATION: second invocation of a single-shot continuation raises" do
+      err =
+        assert_raise Schooner.Eval.Error, fn ->
+          run("""
+          (define saved #f)
+          (define first-result
+            (call/cc
+              (lambda (k)
+                (define s k)
+                (cons 'first (s 'first-call)))))
+          ;; First call/cc returned 'first-call via k; the catch is now gone.
+          ;; A literal second call to k would raise — but `s` was bound
+          ;; inside the call/cc and is not reachable here without set!.
+          ;; Instead, demonstrate the same property with the canonical
+          ;; "return k from call/cc" pattern, which is what r7rs uses.
+          (define k2 (call/cc (lambda (k) k)))
+          (k2 'after-extent)
+          """)
+        end
+
+      assert err.reason == :continuation_expired
+    end
+
+    # The §6.10 `(connect talk1 disconnect ...)` example (paraphrased
+    # below in its dependency-stripped form) requires both `set!` and
+    # multi-shot continuation re-entry. `set!` is out of scope
+    # entirely; multi-shot is deferred to v2.0. We pin Schooner's
+    # observable behaviour: the script fails at parse time because
+    # `set!` is not a recognised form.
+    test "DEVIATION: §6.10 connect/disconnect example fails — uses set! and multi-shot k" do
+      # The full spec example uses `set!`; asserting the parse-time
+      # failure here pins the most-upstream blocking deviation.
+      assert_raise Schooner.Eval.Error, fn ->
+        run("""
+        (let ((path '())
+              (c #f))
+          (let ((add (lambda (s) (set! path (cons s path)))))
+            (dynamic-wind
+              (lambda () (add 'connect))
+              (lambda ()
+                (add (call-with-current-continuation
+                       (lambda (c0) (set! c c0) 'talk1))))
+              (lambda () (add 'disconnect)))
+            (if (< (length path) 4)
+                (c 'talk2)
+                (reverse path))))
+        """)
+      end
+    end
+  end
+end

--- a/test/schooner/primitives/continuations_test.exs
+++ b/test/schooner/primitives/continuations_test.exs
@@ -1,0 +1,254 @@
+defmodule Schooner.Primitives.ContinuationsTest do
+  @moduledoc """
+  Phase 12 tests: escape continuations (`call/cc`,
+  `call-with-current-continuation`) and `dynamic-wind`.
+
+  Several tests assert ordering of side effects (e.g. that
+  `dynamic-wind`'s `after` thunk fires when a continuation crosses its
+  boundary). Schooner has no mutation in the value model, so the
+  tests use a host-injected `record!` primitive that pushes onto a
+  process-dictionary list, plus `get-record` to read it back as a
+  Scheme list. This is host-injection in the same vein as the
+  `zero-int?` / `sub1` helpers in `eval_tco_test.exs`.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Schooner.Env
+  alias Schooner.Primitives
+  alias Schooner.Value
+
+  @recorder_key {__MODULE__, :record}
+
+  defp run(source), do: Schooner.eval(source, recording_env())
+
+  defp recording_env do
+    Process.delete(@recorder_key)
+
+    Env.new()
+    |> Primitives.Base.register_into()
+    |> Primitives.Cxr.register_into()
+    |> Primitives.Char.register_into()
+    |> Primitives.Record.register_into()
+    |> Primitives.Exceptions.register_into()
+    |> Primitives.Continuations.register_into()
+    |> Env.define(
+      "record!",
+      Value.primitive("record!", 1, fn [v] ->
+        Process.put(@recorder_key, [v | Process.get(@recorder_key, [])])
+        :unspecified
+      end)
+    )
+    |> Env.define(
+      "get-record",
+      Value.primitive("get-record", 0, fn [] ->
+        Process.get(@recorder_key, []) |> Enum.reverse() |> Value.list()
+      end)
+    )
+    |> Env.define(
+      "zero-int?",
+      Value.primitive("zero-int?", 1, fn [n] -> Value.bool(n === 0) end)
+    )
+    |> Env.define("sub1", Value.primitive("sub1", 1, fn [n] -> n - 1 end))
+  end
+
+  # ---------------------------------------------------------------------------
+  # call/cc — escape behaviour
+  # ---------------------------------------------------------------------------
+
+  describe "call/cc" do
+    test "(call/cc (lambda (k) (+ 1 (k 42)))) returns 42" do
+      assert run("(call/cc (lambda (k) (+ 1 (k 42))))") == 42
+    end
+
+    test "call-with-current-continuation is the same primitive" do
+      assert run("(call-with-current-continuation (lambda (k) (+ 1 (k 42))))") == 42
+    end
+
+    test "call/cc returns the procedure's return value when k is not invoked" do
+      assert run("(call/cc (lambda (k) (+ 1 2)))") == 3
+    end
+
+    test "call/cc as early return from a deep tail-recursive loop" do
+      source = """
+      (call/cc
+        (lambda (k)
+          (define (loop n)
+            (if (zero-int? n)
+                (k 'escaped)
+                (loop (sub1 n))))
+          (loop 100000)))
+      """
+
+      assert run(source) == Value.symbol("escaped")
+    end
+
+    test "non-procedure argument is rejected" do
+      assert_raise Schooner.Primitive.Error, fn -> run("(call/cc 42)") end
+    end
+
+    test "nested call/cc — invoking the outer k from inside the inner extent" do
+      # Outer k captured first; inner call/cc enters; inner body invokes
+      # the outer k, which throws past the inner catch (different tag)
+      # all the way to the outer one. The inner extent ends as the
+      # throw unwinds — its `after` deregisters the inner tag.
+      source = """
+      (call/cc
+        (lambda (outer)
+          (call/cc
+            (lambda (inner)
+              (outer 'from-outer)))
+          'should-not-see-this))
+      """
+
+      assert run(source) == Value.symbol("from-outer")
+    end
+
+    test "nested call/cc — inner k escapes only the inner extent" do
+      source = """
+      (cons
+        (call/cc
+          (lambda (outer)
+            (call/cc (lambda (inner) (inner 'from-inner)))))
+        'after)
+      """
+
+      assert run(source) == Value.pair(Value.symbol("from-inner"), Value.symbol("after"))
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Continuation-after-extent — the documented Schooner deviation
+  # ---------------------------------------------------------------------------
+
+  describe "continuation invoked after dynamic extent has ended" do
+    test "raises Schooner.Eval.Error with reason :continuation_expired" do
+      # `(call/cc (lambda (k) k))` returns the continuation value
+      # itself, but by the time the call/cc returns its catch is gone
+      # and the tag has been deregistered. Invoking the saved value
+      # therefore must raise rather than escape uncaught.
+      source = """
+      (define saved (call/cc (lambda (k) k)))
+      (saved 'should-not-arrive)
+      """
+
+      err = assert_raise Schooner.Eval.Error, fn -> run(source) end
+      assert err.reason == :continuation_expired
+    end
+
+    test "escape error message mentions escape-only semantics" do
+      err =
+        assert_raise Schooner.Eval.Error, fn ->
+          run("""
+          (define k (call/cc (lambda (c) c)))
+          (k 0)
+          """)
+        end
+
+      assert err.message =~ "escape-only"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # dynamic-wind
+  # ---------------------------------------------------------------------------
+
+  describe "dynamic-wind" do
+    test "before runs on entry, after runs on normal exit, thunk's value is returned" do
+      source = """
+      (define result
+        (dynamic-wind
+          (lambda () (record! 'before))
+          (lambda () (record! 'thunk) 'thunk-value)
+          (lambda () (record! 'after))))
+      (cons result (get-record))
+      """
+
+      assert run(source) ==
+               Value.pair(
+                 Value.symbol("thunk-value"),
+                 Value.list([
+                   Value.symbol("before"),
+                   Value.symbol("thunk"),
+                   Value.symbol("after")
+                 ])
+               )
+    end
+
+    test "after fires when a continuation invocation escapes the body" do
+      source = """
+      (define result
+        (call/cc
+          (lambda (k)
+            (dynamic-wind
+              (lambda () (record! 'before))
+              (lambda () (record! 'thunk) (k 'escaped))
+              (lambda () (record! 'after))))))
+      (cons result (get-record))
+      """
+
+      assert run(source) ==
+               Value.pair(
+                 Value.symbol("escaped"),
+                 Value.list([
+                   Value.symbol("before"),
+                   Value.symbol("thunk"),
+                   Value.symbol("after")
+                 ])
+               )
+    end
+
+    test "after fires when an exception escapes the body" do
+      source = """
+      (define caught
+        (guard (c (#t c))
+          (dynamic-wind
+            (lambda () (record! 'before))
+            (lambda () (record! 'thunk) (error "boom"))
+            (lambda () (record! 'after)))))
+      (cons (error-object-message caught) (get-record))
+      """
+
+      assert run(source) ==
+               Value.pair(
+                 Value.string("boom"),
+                 Value.list([
+                   Value.symbol("before"),
+                   Value.symbol("thunk"),
+                   Value.symbol("after")
+                 ])
+               )
+    end
+
+    test "nested dynamic-wind unwinds inside-out on escape" do
+      source = """
+      (call/cc
+        (lambda (k)
+          (dynamic-wind
+            (lambda () (record! 'before-outer))
+            (lambda ()
+              (dynamic-wind
+                (lambda () (record! 'before-inner))
+                (lambda () (record! 'thunk) (k 'escaped))
+                (lambda () (record! 'after-inner))))
+            (lambda () (record! 'after-outer)))))
+      (get-record)
+      """
+
+      assert run(source) ==
+               Value.list([
+                 Value.symbol("before-outer"),
+                 Value.symbol("before-inner"),
+                 Value.symbol("thunk"),
+                 Value.symbol("after-inner"),
+                 Value.symbol("after-outer")
+               ])
+    end
+
+    test "non-procedure thunk is rejected" do
+      assert_raise Schooner.Primitive.Error, fn ->
+        run("(dynamic-wind 1 (lambda () 'x) (lambda () 'y))")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- `call/cc` / `call-with-current-continuation` as single-shot upward escape continuations, implemented via `:erlang.throw/1` with a fresh `make_ref/0` tag and a matching `try/catch` reinstalled at every `call/cc` site
- `dynamic-wind` implemented purely with `try/after` — every escape (continuation invocation, exception raise, normal return) unwinds through nested `try/after` clauses, firing `after` thunks innermost-first per r7rs §6.10
- New per-process `Schooner.Eval.ContinuationState` tracks live continuation tags so invocations after the surrounding `call/cc` has exited raise `Schooner.Eval.Error{reason: :continuation_expired}` rather than escaping uncaught into Erlang
- `Schooner.eval/2` resets and snapshot/restores `ContinuationState` alongside `ExceptionState` at the top-level boundary
- §6.10 conformance file with worked spec examples that pass, plus assertions on the documented multi-shot deviation (so v2.0's lift of the restriction will surface as failing tests here)

## Forward-compatibility (PLAN.md updates)

Phase 12 ships escape-only as planned, but PLAN.md gains the doc-stability prep for a future v2.0 multi-shot `call/cc`:

- Phase 12 carries a forward-compat note pinning the single-shot restriction as a documented error rather than UB — lifting an error case is non-breaking
- Phase 14 documents the host-boundary continuation barrier and that compiled ASTs / continuations are opaque-and-non-marshallable, so v2.0 can swap evaluator representations without a public-API break
- "Deferred to v2.0" subsection added under out-of-scope; follow-ups list gains a concrete v2.0 entry covering the evaluator rewrite, `dynamic-wind` re-entry semantics, host-boundary barrier enforcement, and the new test surface

## Test plan

- [x] `mix precommit` green: 671 tests / 23 properties / 0 failures, credo clean, no warnings
- [x] 14 unit tests in `test/schooner/primitives/continuations_test.exs` covering every phase 12 acceptance bullet
- [x] 12 conformance tests in `test/conformance/r7rs_section_6_10_continuations_test.exs` — 9 pass on escape-only, 3 pin the documented deviation
- [x] All phase 4 TCO regressions still pass — `call/cc` is one fixed `try/catch/after` frame at the boundary; tail recursion inside the captured procedure still flattens (verified by the 100k-deep early-exit test)