### PR TITLE
Populate Expander bootstrap_env at app start

### DIFF
--- a/lib/schooner/application.ex
+++ b/lib/schooner/application.ex
@@ -1,0 +1,33 @@
+defmodule Schooner.Application do
+  @moduledoc false
+
+  # Schooner's OTP application callback. Its only job is to populate
+  # `Schooner.Expander.bootstrap_env/0`'s `:persistent_term` cache
+  # eagerly, so that:
+  #
+  #   1. The first `Schooner.eval/2` call on the node does not pay the
+  #      bootstrap parse-and-expand cost, and
+  #
+  #   2. Concurrent first-evals cannot race the lazy `get → build →
+  #      put` path. The lazy path stores the env only if the key is
+  #      `:unset`, but two callers can observe `:unset` simultaneously,
+  #      both build (each minting fresh `make_ref/0` hygiene marks),
+  #      and both `put`. The second `put` is then an *update* of an
+  #      existing key, and `:persistent_term.put/2` triggers a global
+  #      literal-area GC across all processes when it replaces a
+  #      value. Eager init from `start/2` is a single-flight by
+  #      construction.
+  #
+  # `bootstrap_env/0` itself retains the lazy path for callers that
+  # use the library without starting the application (some test
+  # scenarios, embedding-by-direct-module-call); under normal
+  # operation that branch is dead.
+
+  use Application
+
+  @impl Application
+  def start(_type, _args) do
+    _ = Schooner.Expander.bootstrap_env()
+    Supervisor.start_link([], strategy: :one_for_one, name: Schooner.Supervisor)
+  end
+end

--- a/lib/schooner/expander.ex
+++ b/lib/schooner/expander.ex
@@ -56,9 +56,20 @@ defmodule Schooner.Expander do
 
   @doc """
   Return the cached bootstrap syntax env containing the derived-form
-  macros. Computed lazily on first call and cached via
-  `:persistent_term` so that subsequent runs do not re-parse the
-  bootstrap source.
+  macros.
+
+  Normally populated eagerly by `Schooner.Application.start/2` so that
+  the first `Schooner.eval/2` call on the node pays no bootstrap
+  parse-and-expand cost and concurrent first-evals cannot race the
+  put. A lazy fallback is retained for callers that use the library
+  without starting the OTP application (some test scenarios). Under
+  normal operation the fallback branch is dead.
+
+  The fallback is *not* race-safe: two callers observing `:unset`
+  simultaneously will both build and both `put`; the second `put`
+  becomes an update of an existing key, which triggers a global
+  literal-area GC across all processes. Eager init from
+  `Schooner.Application` avoids this by single-flighting the put.
   """
   @spec bootstrap_env() :: SyntaxEnv.t()
   def bootstrap_env do

--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,8 @@ defmodule Schooner.MixProject do
 
   def application do
     [
-      extra_applications: [:logger]
+      extra_applications: [:logger],
+      mod: {Schooner.Application, []}
     ]
   end
 


### PR DESCRIPTION
## Summary

- New `Schooner.Application` OTP callback module; `mix.exs` `application/0` now declares `mod: {Schooner.Application, []}`
- `start/2` calls `Schooner.Expander.bootstrap_env/0` once before any user code runs, populating the `:persistent_term` cache eagerly
- `bootstrap_env/0`'s lazy fallback retained for direct-module-use (some test scenarios); doc updated to explain the eager path is normal and the fallback is not race-safe

## Why

`bootstrap_env/0`'s lazy `get → build → put` path is racy. `make_ref/0` is called during expansion to mint hygiene marks, so two callers observing `:unset` concurrently produce two distinct envs and both `put`. The second `put` becomes an *update* of an existing key, and `:persistent_term.put/2` on update triggers a **global literal-area GC across all processes** to reclaim the obsolete term.

A first-time `put` of a new key does not trigger that scan, so eager init from `start/2` — a single-flight by construction — eliminates the race and the global GC entirely. As a bonus the first `Schooner.eval/2` on a node no longer pays the parse-and-expand cost.

## Test plan

- [x] `mix precommit` green: 671 tests / 23 properties / 0 failures, credo clean, no warnings
- [x] No new tests required — the existing test suite exercises every code path that touches `bootstrap_env/0`, and the change is observable only as a startup-timing / race-elimination property