### PR TITLE
Tests: close coverage gaps to take overall ≥ 90%

### DIFF
--- a/test/schooner/eval_test.exs
+++ b/test/schooner/eval_test.exs
@@ -112,6 +112,28 @@ defmodule Schooner.EvalTest do
       assert match?({:arity_mismatch, _, {:at_least, 2}, 1}, e.reason)
     end
 
+    test "evaluator rejects malformed lambda parameter lists with :invalid_params" do
+      # Synthesise a `(lambda 1 1)` form directly — the expander
+      # rejects this kind of shape, but Eval.parse_params/1 has its
+      # own catch-all that we want to pin behaviour on.
+      bad_head = {:pair, {:sym, "lambda"}, {:pair, 1, {:pair, 1, :null}}}
+      e = assert_raise Error, fn -> Schooner.Eval.eval(bad_head, Schooner.standard_env()) end
+      assert e.reason == :invalid_params
+
+      # Non-symbol inside the parameter list reaches collect_params/3.
+      bad_param =
+        {:pair, {:sym, "lambda"},
+         {:pair, {:pair, {:sym, "x"}, {:pair, 1, :null}}, {:pair, {:sym, "x"}, :null}}}
+
+      e = assert_raise Error, fn -> Schooner.Eval.eval(bad_param, Schooner.standard_env()) end
+      assert e.reason == :invalid_params
+    end
+
+    test "at-least arity mismatch on dotted-rest lambda raises with {:at_least, _}" do
+      e = assert_raise Error, fn -> run("((lambda (a b . r) r) 1)") end
+      assert match?({:arity_mismatch, _, {:at_least, 2}, 1}, e.reason)
+    end
+
     test "lambda with empty body raises" do
       e = assert_raise Error, fn -> run("(lambda (x))") end
       assert e.reason == {:bad_special_form, "lambda"}
@@ -170,6 +192,21 @@ defmodule Schooner.EvalTest do
       env = Env.new() |> Env.define("inc", primitive_inc())
       e = assert_raise Error, fn -> Schooner.eval("(inc 1 2)", env) end
       assert match?({:arity_mismatch, "inc", {:exact, 1}, 2}, e.reason)
+    end
+
+    test "improper application form raises :improper_application" do
+      # Reader-level dotted application is rejected by the reader, so
+      # synthesise the malformed form directly. `(+ 1 . 2)` reaches
+      # eval_args/3 with a non-list tail and trips its catch-all.
+      err =
+        assert_raise Error, fn ->
+          Schooner.Eval.eval(
+            {:pair, {:sym, "+"}, {:pair, 1, 2}},
+            Schooner.standard_env()
+          )
+        end
+
+      assert err.reason == :improper_application
     end
   end
 

--- a/test/schooner/expander/syntax_rules_test.exs
+++ b/test/schooner/expander/syntax_rules_test.exs
@@ -225,6 +225,28 @@ defmodule Schooner.Expander.SyntaxRulesTest do
         transformer("(syntax-rules () ((_ x) ...))")
       end
     end
+
+    test "syntax-rules with a non-list literals form is rejected" do
+      assert_raise Schooner.Expander.Error, fn -> transformer("(syntax-rules 1 ((_) 'x))") end
+    end
+
+    test "syntax-rules with non-symbol literal entries is rejected" do
+      assert_raise Schooner.Expander.Error, fn -> transformer("(syntax-rules (1) ((_) 'x))") end
+    end
+
+    test "syntax-rules with a malformed rule shape is rejected" do
+      assert_raise Schooner.Expander.Error, fn -> transformer("(syntax-rules () (foo))") end
+    end
+
+    test "syntax-rules called on a non-pair spec is rejected" do
+      assert_raise Schooner.Expander.Error, fn -> SyntaxRules.compile(:null) end
+    end
+
+    test "no matching rule reports the form's keyword" do
+      t = transformer("(syntax-rules () ((_ x y) (list x y)))")
+      e = assert_raise Schooner.Eval.Error, fn -> expand(t, "(use 1)") end
+      assert e.reason == {:bad_special_form, "use"}
+    end
   end
 
   describe "strip_mark/1" do

--- a/test/schooner/expander_test.exs
+++ b/test/schooner/expander_test.exs
@@ -296,6 +296,57 @@ defmodule Schooner.ExpanderTest do
     end
   end
 
+  describe "malformed special forms raise during expansion" do
+    test "set! is rejected at expansion time" do
+      e = assert_raise Error, fn -> run("(set! x 1)") end
+      assert e.reason == {:bad_special_form, "set!"}
+    end
+
+    test "malformed lambda parameter list (non-symbol element)" do
+      e = assert_raise Error, fn -> run("(lambda (x . 1) x)") end
+      assert e.reason == {:bad_special_form, "lambda"}
+    end
+
+    test "malformed letrec*" do
+      e = assert_raise Error, fn -> run("(letrec* ((x)) x)") end
+      assert e.reason == {:bad_special_form, "letrec*"}
+
+      e = assert_raise Error, fn -> run("(letrec* (x) x)") end
+      assert e.reason == {:bad_special_form, "letrec*"}
+    end
+
+    test "malformed guard" do
+      # No clause list at all.
+      e = assert_raise Error, fn -> run("(guard 1 2)") end
+      assert e.reason == {:bad_special_form, "guard"}
+
+      # Bad clause shape (clauses not a proper list).
+      e = assert_raise Error, fn -> run("(guard (e . 1) 2)") end
+      assert e.reason == {:bad_special_form, "guard"}
+    end
+
+    test "malformed let-syntax / letrec-syntax bindings" do
+      e = assert_raise Error, fn -> run("(let-syntax 1 'x)") end
+      assert e.reason == {:bad_special_form, "let-syntax"}
+
+      e = assert_raise Error, fn -> run("(letrec-syntax 1 'x)") end
+      assert e.reason == {:bad_special_form, "letrec-syntax"}
+    end
+
+    test "malformed define-record-type forms" do
+      e = assert_raise Error, fn -> run("(define-record-type 1 (mk x) p? (x g))") end
+      assert e.reason == {:bad_special_form, "define-record-type"}
+
+      # Bad constructor spec.
+      e = assert_raise Error, fn -> run("(define-record-type pt 1 pt? (x x-of))") end
+      assert e.reason == {:bad_special_form, "define-record-type"}
+
+      # Bad field-spec list.
+      e = assert_raise Error, fn -> run("(define-record-type pt (mk x) pt? 1)") end
+      assert e.reason == {:bad_special_form, "define-record-type"}
+    end
+  end
+
   describe "internal definition interaction" do
     test "macro that expands to internal define inside a lambda body" do
       assert run("""

--- a/test/schooner/lexer_test.exs
+++ b/test/schooner/lexer_test.exs
@@ -77,6 +77,16 @@ defmodule Schooner.LexerTest do
     test "unknown char name raises" do
       assert_raise Error, fn -> Lexer.tokenise(~S(#\notachar)) end
     end
+
+    test "trailing #\\ with no character is an unterminated literal" do
+      err = assert_raise Error, fn -> Lexer.tokenise("#\\") end
+      assert err.reason == :unterminated_char_literal
+    end
+
+    test "#\\xZZ is a named-char lookup, not a hex escape" do
+      err = assert_raise Error, fn -> Lexer.tokenise(~S(#\xZZ)) end
+      assert match?({:unknown_char_name, "xZZ"}, err.reason)
+    end
   end
 
   describe "strings" do
@@ -123,6 +133,21 @@ defmodule Schooner.LexerTest do
 
       assert err.reason == :empty_hex_escape
     end
+
+    test "alarm and bar escapes" do
+      assert [{:string, <<7>>, _}] = Lexer.tokenise(~S("\a"))
+      assert [{:string, "|", _}] = Lexer.tokenise(~S("\|"))
+    end
+
+    test "raw CR and CRLF inside string become \\n" do
+      assert [{:string, "a\nb", _}] = Lexer.tokenise("\"a\rb\"")
+      assert [{:string, "a\nb", _}] = Lexer.tokenise("\"a\r\nb\"")
+    end
+
+    test "unterminated hex escape (no terminator) raises" do
+      err = assert_raise Error, fn -> Lexer.tokenise(~S("\x41")) end
+      assert err.reason in [:unterminated_hex_escape, :unterminated_string]
+    end
   end
 
   describe "identifiers" do
@@ -155,6 +180,14 @@ defmodule Schooner.LexerTest do
         assert_raise Error, fn -> Lexer.tokenise("|hello") end
 
       assert err.reason == :unterminated_bar_identifier
+    end
+
+    test "bar identifier supports \\n \\t \\xHH; \\\\ escapes and embedded newlines" do
+      assert [{:ident, "a\nb", _}] = Lexer.tokenise(~S(|a\nb|))
+      assert [{:ident, "a\tb", _}] = Lexer.tokenise(~S(|a\tb|))
+      assert [{:ident, "A", _}] = Lexer.tokenise(~S(|\x41;|))
+      assert [{:ident, "a\nb", _}] = Lexer.tokenise("|a\nb|")
+      assert [{:ident, "a\nb", _}] = Lexer.tokenise("|a\r\nb|")
     end
 
     test "unicode identifiers" do
@@ -216,6 +249,18 @@ defmodule Schooner.LexerTest do
       assert_raise Error, fn -> Lexer.tokenise("#x1.5") end
     end
 
+    test "empty body after #-prefix is invalid_numeric_literal" do
+      err = assert_raise Error, fn -> Lexer.tokenise("#x") end
+      assert err.reason == :invalid_numeric_literal
+    end
+
+    test "non-finite float specials are recognised as float tokens" do
+      assert [{:float, {:float_special, :pos_inf}, _}] = Lexer.tokenise("+inf.0")
+      assert [{:float, {:float_special, :neg_inf}, _}] = Lexer.tokenise("-inf.0")
+      assert [{:float, {:float_special, :nan}, _}] = Lexer.tokenise("+nan.0")
+      assert [{:float, {:float_special, :nan}, _}] = Lexer.tokenise("-nan.0")
+    end
+
     test "arbitrary-precision integers" do
       big = String.duplicate("9", 80)
       assert [{:integer, n, _}] = Lexer.tokenise(big)
@@ -247,6 +292,15 @@ defmodule Schooner.LexerTest do
 
     test "block comment can span lines" do
       assert [{:integer, 1, {3, 3}}] = Lexer.tokenise("#| a\nb\n|#1")
+    end
+
+    test "line comment ends at lone CR or CRLF as well as LF" do
+      assert [{:integer, 1, {2, 1}}] = Lexer.tokenise("; oops\r\n1")
+      assert [{:integer, 1, {2, 1}}] = Lexer.tokenise("; oops\r1")
+    end
+
+    test "block comment handles CR/CRLF/LF newlines without losing track of depth" do
+      assert [{:integer, 1, _}] = Lexer.tokenise("#|\r\n a \n b \r |# 1")
     end
 
     test "unterminated block comment raises with opening position" do
@@ -304,6 +358,16 @@ defmodule Schooner.LexerTest do
 
     test "lone hash is an error" do
       assert_raise Error, fn -> Lexer.tokenise("#") end
+    end
+
+    test "unknown #-form raises invalid_hash_form" do
+      err = assert_raise Error, fn -> Lexer.tokenise("#?") end
+      assert match?({:invalid_hash_form, ?\?}, err.reason)
+    end
+
+    test "leading dot followed by garbage is an invalid token" do
+      err = assert_raise Error, fn -> Lexer.tokenise(".+@") end
+      assert match?({:invalid_token, _}, err.reason)
     end
   end
 end

--- a/test/schooner/primitives/base_test.exs
+++ b/test/schooner/primitives/base_test.exs
@@ -642,4 +642,279 @@ defmodule Schooner.Primitives.BaseTest do
       end
     end
   end
+
+  # ---------------------------------------------------------------------------
+  # min / max — the *first*-argument special branches
+  # ---------------------------------------------------------------------------
+
+  describe "non-finite min/max — first-argument specials" do
+    @pos_inf {:float_special, :pos_inf}
+    @neg_inf {:float_special, :neg_inf}
+
+    test "(min +inf.0 1) — first-arg pos_inf path" do
+      assert run("(min +inf.0 1)") === 1.0
+    end
+
+    test "(max +inf.0 1) — first-arg pos_inf path" do
+      assert run("(max +inf.0 1)") == @pos_inf
+    end
+
+    test "(max 1 -inf.0) — second-arg neg_inf path" do
+      assert run("(max 1 -inf.0)") === 1.0
+    end
+
+    test "(min 1 +inf.0) and (min -inf.0 1) reach both swapped clauses" do
+      assert run("(min -inf.0 1)") == @neg_inf
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # expt — exponent-as-zero / unit-base / non-integer-exponent paths
+  # ---------------------------------------------------------------------------
+
+  describe "expt edge cases" do
+    @pos_inf {:float_special, :pos_inf}
+    @neg_inf {:float_special, :neg_inf}
+    @nan {:float_special, :nan}
+
+    test "anything to +0.0 / -0.0 is 1.0 (matches both signed-zero clauses)" do
+      assert run("(expt +inf.0 0.0)") === 1.0
+      assert run("(expt +nan.0 (- 0.0))") === 1.0
+    end
+
+    test "1.0 base short-circuits to 1.0 even when exp is special" do
+      assert run("(expt 1.0 +inf.0)") === 1.0
+    end
+
+    test "(expt +inf.0 +inf.0) and (expt -inf.0 +inf.0) — exp has zero finite-sign" do
+      # finite_exp_sign(+inf.0) is 0, so both fall through to the NaN clause.
+      assert run("(expt +inf.0 +inf.0)") == @nan
+      assert run("(expt -inf.0 +inf.0)") == @nan
+    end
+
+    test "(expt -1.0 +inf.0) and (expt -1.0 -inf.0) — |base|==1 hits the NaN tail" do
+      assert run("(expt -1.0 +inf.0)") == @nan
+      assert run("(expt -1.0 -inf.0)") == @nan
+    end
+
+    test "(expt -inf.0 odd-float) preserves the negative sign" do
+      assert run("(expt -inf.0 3.0)") == @neg_inf
+    end
+
+    test "(expt +inf.0 0.5) — positive float exponent" do
+      assert run("(expt +inf.0 0.5)") == @pos_inf
+      assert run("(expt +inf.0 -0.5)") === 0.0
+    end
+
+    test "(expt 5 0) — int_pow base case" do
+      assert run("(expt 5 0)") === 1
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # inexact->exact / exact division / sqrt edge cases
+  # ---------------------------------------------------------------------------
+
+  describe "exactness conversion edge cases" do
+    test "inexact->exact is identity on integers" do
+      assert run("(inexact->exact 5)") === 5
+    end
+
+    test "inexact->exact rejects non-numbers" do
+      e = assert_raise PError, fn -> run(~S|(inexact->exact "abc")|) end
+      assert match?({:type_error, "inexact->exact", "number", _}, e.reason)
+    end
+
+    test "(sqrt 0) is the exact zero" do
+      assert run("(sqrt 0)") === 0
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Mixed-exactness comparisons exercise the `is_float(a) or is_float(b)`
+  # branch of every numeric comparator.
+  # ---------------------------------------------------------------------------
+
+  describe "mixed-exactness comparison branches" do
+    test "<, >, <=, >= all promote one int operand to float" do
+      assert run("(< 1 1.5)") == Value.bool(true)
+      assert run("(> 2.0 1)") == Value.bool(true)
+      assert run("(<= 1 1.0)") == Value.bool(true)
+      assert run("(>= 2 1.5)") == Value.bool(true)
+      assert run("(<= -inf.0 -inf.0)") == Value.bool(true)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # signum — both negative and zero branches via `modulo`
+  # ---------------------------------------------------------------------------
+
+  describe "modulo — exercises every branch of signum/1" do
+    test "(modulo 0 5) hits the zero branch" do
+      assert run("(modulo 0 5)") === 0
+    end
+
+    test "(modulo 5 -3) — negative divisor adjusts the result" do
+      assert run("(modulo 5 -3)") === -1
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # do_member / do_assoc — improper list and bad alist entry
+  # ---------------------------------------------------------------------------
+
+  describe "member / assoc on malformed lists" do
+    test "member raises :improper_list when the search runs off a dotted tail" do
+      e = assert_raise PError, fn -> run("(member 9 '(1 2 . 3))") end
+      assert match?({:improper_list, "member", _}, e.reason)
+    end
+
+    test "assoc raises type_error for a non-pair entry" do
+      e = assert_raise PError, fn -> run("(assoc 9 '((1 . a) 2 (3 . c)))") end
+      assert match?({:type_error, "assoc", "pair as alist entry", _}, e.reason)
+    end
+
+    test "assoc raises :improper_list when the alist itself is dotted" do
+      e = assert_raise PError, fn -> run("(assoc 9 '((1 . a) . 3))") end
+      assert match?({:improper_list, "assoc", _}, e.reason)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Type errors on primitives that take a single non-aggregate first arg
+  # ---------------------------------------------------------------------------
+
+  describe "type errors on aggregates" do
+    test "vector ops reject non-vector arg" do
+      for {op, src} <- [
+            {"vector-length", "(vector-length 1)"},
+            {"vector-ref", "(vector-ref 1 0)"},
+            {"vector->list", "(vector->list 1)"},
+            {"vector-copy", "(vector-copy 1)"}
+          ] do
+        e = assert_raise PError, fn -> run(src) end
+        assert match?({:type_error, ^op, "vector", _}, e.reason)
+      end
+    end
+
+    test "make-vector with too many args" do
+      e = assert_raise PError, fn -> run("(make-vector 3 0 0)") end
+      assert match?({:type_error, "make-vector", "1 or 2 arguments", :too_many}, e.reason)
+    end
+
+    test "bytevector ops reject non-bytevector arg" do
+      for {op, src} <- [
+            {"bytevector-length", "(bytevector-length 1)"},
+            {"bytevector-u8-ref", "(bytevector-u8-ref 1 0)"},
+            {"bytevector-copy", "(bytevector-copy 1)"},
+            {"utf8->string", "(utf8->string 1)"},
+            {"bytevector-append", "(bytevector-append 1)"}
+          ] do
+        e = assert_raise PError, fn -> run(src) end
+        assert match?({:type_error, ^op, "bytevector", _}, e.reason)
+      end
+    end
+
+    test "make-bytevector / bytevector-copy / utf8->string with too many args" do
+      for {op, src} <- [
+            {"make-bytevector", "(make-bytevector 3 0 0)"},
+            {"bytevector-copy", "(bytevector-copy #u8(1 2 3) 0 1 2)"},
+            {"utf8->string", "(utf8->string #u8(1) 0 1 2)"},
+            {"string->utf8", ~S|(string->utf8 "x" 0 1 2)|}
+          ] do
+        e = assert_raise PError, fn -> run(src) end
+        assert match?({:type_error, ^op, _, :too_many}, e.reason)
+      end
+    end
+
+    test "string->utf8 rejects non-string arg" do
+      e = assert_raise PError, fn -> run("(string->utf8 1)") end
+      assert match?({:type_error, "string->utf8", "string", _}, e.reason)
+    end
+
+    test "string ops reject non-string arg" do
+      for {op, src} <- [
+            {"string-length", "(string-length 1)"},
+            {"string-ref", "(string-ref 1 0)"},
+            {"substring", "(substring 1 0 0)"},
+            {"string->list", "(string->list 1)"},
+            {"string-upcase", "(string-upcase 1)"},
+            {"string-downcase", "(string-downcase 1)"},
+            {"string-copy", "(string-copy 1)"}
+          ] do
+        e = assert_raise PError, fn -> run(src) end
+        assert match?({:type_error, ^op, "string", _}, e.reason)
+      end
+    end
+
+    test "make-string / string-copy / string->list with too many args" do
+      for {op, src} <- [
+            {"make-string", ~S|(make-string 3 #\a #\b)|},
+            {"string-copy", ~S|(string-copy "abc" 0 1 2)|},
+            {"string->list", ~S|(string->list "abc" 0 1 2)|}
+          ] do
+        e = assert_raise PError, fn -> run(src) end
+        assert match?({:type_error, ^op, _, :too_many}, e.reason)
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # The 2-arg forms of bytevector-copy / utf8->string / string->utf8 /
+  # string->list / string-copy reach the `[v, start]` clause specifically.
+  # ---------------------------------------------------------------------------
+
+  describe "two-argument start-only slice forms" do
+    test "bytevector-copy with start only" do
+      assert run("(bytevector-copy #u8(1 2 3 4) 1)") == Value.bytevector(<<2, 3, 4>>)
+    end
+
+    test "utf8->string / string->utf8 with start only" do
+      assert run("(utf8->string #u8(97 98 99) 1)") == Value.string("bc")
+      assert run(~S|(string->utf8 "abc" 1)|) == Value.bytevector(<<?b, ?c>>)
+    end
+
+    test "string->list with start only" do
+      assert run(~S|(string->list "abcd" 2)|) == Value.list([Value.char(?c), Value.char(?d)])
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Improper-list inputs to list->vector / list->string — exercises
+  # do_scheme_list_to_elixir's improper_list clause.
+  # ---------------------------------------------------------------------------
+
+  describe "list->vector / list->string on improper lists" do
+    test "list->vector raises :improper_list" do
+      e = assert_raise PError, fn -> run("(list->vector '(1 2 . 3))") end
+      assert match?({:improper_list, "list->vector", _}, e.reason)
+    end
+
+    test "list->string raises :improper_list" do
+      e = assert_raise PError, fn -> run(~S|(list->string '(#\a . #\b))|) end
+      assert match?({:improper_list, "list->string", _}, e.reason)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Off-the-end range failures for substring / string->list / string-copy
+  # exercise the `:end` raise paths in slice_codepoints and collect_n.
+  # ---------------------------------------------------------------------------
+
+  describe "string slice off-the-end failures" do
+    test "substring with start past the end" do
+      e = assert_raise PError, fn -> run(~S|(substring "abc" 5 5)|) end
+      assert match?({:index_out_of_range, "substring", _, _}, e.reason)
+    end
+
+    test "string->list with start past the end" do
+      e = assert_raise PError, fn -> run(~S|(string->list "abc" 5)|) end
+      assert match?({:index_out_of_range, "string->list", _, _}, e.reason)
+    end
+
+    test "string->list with stop past the end (collect_n exhausts source)" do
+      e = assert_raise PError, fn -> run(~S|(string->list "abc" 0 10)|) end
+      assert match?({:index_out_of_range, "string->list", _, _}, e.reason)
+    end
+  end
 end

--- a/test/schooner/primitives/char_test.exs
+++ b/test/schooner/primitives/char_test.exs
@@ -55,6 +55,12 @@ defmodule Schooner.Primitives.CharTest do
     test "char-ci<?" do
       assert run(~S|(char-ci<? #\A #\b #\C)|) == Value.bool(true)
     end
+
+    test "char-ci<=? / char-ci>? / char-ci>=?" do
+      assert run(~S|(char-ci<=? #\A #\a #\b)|) == Value.bool(true)
+      assert run(~S|(char-ci>? #\C #\b #\A)|) == Value.bool(true)
+      assert run(~S|(char-ci>=? #\B #\b #\A)|) == Value.bool(true)
+    end
   end
 
   describe "case mappings" do
@@ -70,6 +76,11 @@ defmodule Schooner.Primitives.CharTest do
 
     test "ß has no single-codepoint upcase — char-upcase leaves it unchanged" do
       assert run(~s|(char-upcase #\\ß)|) == Value.char(0x00DF)
+    end
+
+    test "char-foldcase on a multi-codepoint fold leaves the original char unchanged" do
+      # ß folds to "ss" — two codepoints — so char-foldcase keeps ß.
+      assert run(~s|(char-foldcase #\\ß)|) == Value.char(0x00DF)
     end
   end
 
@@ -100,6 +111,29 @@ defmodule Schooner.Primitives.CharTest do
       assert run(~S|(char-lower-case? #\a)|) == Value.bool(true)
       assert run(~S|(char-lower-case? #\A)|) == Value.bool(false)
     end
+
+    test "non-ASCII categories use the Unicode regexes" do
+      # Latin letter with diacritic — alphabetic and lower-case.
+      assert run(~s|(char-alphabetic? #\\é)|) == Value.bool(true)
+      assert run(~s|(char-lower-case? #\\é)|) == Value.bool(true)
+      assert run(~s|(char-upper-case? #\\é)|) == Value.bool(false)
+
+      # Latin capital N-tilde — upper-case.
+      assert run(~s|(char-upper-case? #\\Ñ)|) == Value.bool(true)
+
+      # Arabic-Indic digit five — numeric outside ?0..?9.
+      assert run("(char-numeric? (integer->char #x0665))") == Value.bool(true)
+
+      # No-break space — whitespace outside the ASCII set.
+      assert run("(char-whitespace? (integer->char #x00A0))") == Value.bool(true)
+
+      # Emoji — neither alphabetic nor numeric nor whitespace nor cased.
+      assert run("(char-alphabetic? (integer->char #x1F600))") == Value.bool(false)
+      assert run("(char-numeric? (integer->char #x1F600))") == Value.bool(false)
+      assert run("(char-whitespace? (integer->char #x1F600))") == Value.bool(false)
+      assert run("(char-upper-case? (integer->char #x1F600))") == Value.bool(false)
+      assert run("(char-lower-case? (integer->char #x1F600))") == Value.bool(false)
+    end
   end
 
   describe "type errors" do
@@ -111,6 +145,37 @@ defmodule Schooner.Primitives.CharTest do
     test "case mapping rejects non-char arg" do
       e = assert_raise PError, fn -> run("(char-upcase 1)") end
       assert match?({:type_error, "char-upcase", "char", _}, e.reason)
+    end
+
+    test "char->integer rejects non-char arg" do
+      e = assert_raise PError, fn -> run("(char->integer 1)") end
+      assert match?({:type_error, "char->integer", "char", _}, e.reason)
+    end
+
+    test "integer->char rejects non-integer arg" do
+      e = assert_raise PError, fn -> run(~S|(integer->char "x")|) end
+      assert match?({:type_error, "integer->char", "integer", _}, e.reason)
+    end
+
+    test "char-downcase / char-foldcase reject non-char arg" do
+      e = assert_raise PError, fn -> run("(char-downcase 1)") end
+      assert match?({:type_error, "char-downcase", "char", _}, e.reason)
+
+      e = assert_raise PError, fn -> run("(char-foldcase 1)") end
+      assert match?({:type_error, "char-foldcase", "char", _}, e.reason)
+    end
+
+    test "category predicates reject non-char arg" do
+      for op <- [
+            "char-alphabetic?",
+            "char-numeric?",
+            "char-whitespace?",
+            "char-upper-case?",
+            "char-lower-case?"
+          ] do
+        e = assert_raise PError, fn -> run("(#{op} 1)") end
+        assert match?({:type_error, ^op, "char", _}, e.reason)
+      end
     end
   end
 end

--- a/test/schooner/value_test.exs
+++ b/test/schooner/value_test.exs
@@ -93,6 +93,24 @@ defmodule Schooner.ValueTest do
       refute Value.record?({:vector, {1, 2}})
       assert Value.eof?(:eof)
       assert Value.unspecified?(:unspecified)
+      refute Value.unspecified?(:null)
+      refute Value.unspecified?({:bool, false})
+    end
+
+    test "error_object? / error_kind?" do
+      err = {:error_obj, :user, {:string, "boom"}, []}
+      assert Value.error_object?(err)
+      refute Value.error_object?({:string, "boom"})
+      assert Value.error_kind?(err, :user)
+      refute Value.error_kind?(err, :read)
+      refute Value.error_kind?({:string, "x"}, :user)
+    end
+
+    test "integer? on non-finite floats is false (ArgumentError fallback)" do
+      # `trunc/1` raises ArgumentError on non-finite floats; the
+      # `integer?` rescue clause turns that into `false`.
+      refute Value.integer?({:float_special, :nan})
+      refute Value.integer?({:float_special, :pos_inf})
     end
 
     test "truthiness — only #f is false" do
@@ -166,6 +184,18 @@ defmodule Schooner.ValueTest do
       refute Value.equal?(1, 1.0)
       assert Value.equal?(Value.symbol("x"), Value.symbol("x"))
     end
+
+    test "equal? — NaN on the right side is also never equal" do
+      refute Value.equal?(1, {:float_special, :nan})
+      refute Value.equal?({:float_special, :pos_inf}, {:float_special, :nan})
+    end
+
+    test "equal? on differently-sized vectors and records is false" do
+      refute Value.equal?(Value.vector([1, 2]), Value.vector([1, 2, 3]))
+      a = Value.record({:type, "p"}, {1, 2})
+      b = Value.record({:type, "p"}, {1, 2, 3})
+      refute Value.equal?(a, b)
+    end
   end
 
   describe "write / display" do
@@ -193,6 +223,11 @@ defmodule Schooner.ValueTest do
       assert Value.write(Value.symbol("123abc")) == "|123abc|"
     end
 
+    test "symbols — backslash and DEL force bar quoting and escape inside" do
+      assert Value.write(Value.symbol("a\\b")) == "|a\\\\b|"
+      assert Value.write(Value.symbol(<<?a, 0x7F, ?b>>)) == <<?|, ?a, 0x7F, ?b, ?|>>
+    end
+
     test "strings" do
       assert Value.write(Value.string("hi")) == "\"hi\""
       assert Value.write(Value.string("a\"b")) == "\"a\\\"b\""
@@ -200,6 +235,13 @@ defmodule Schooner.ValueTest do
       assert Value.write(Value.string("a\nb")) == "\"a\\nb\""
       assert Value.display(Value.string("hi")) == "hi"
       assert Value.display(Value.string("a\nb")) == "a\nb"
+    end
+
+    test "strings — every named-escape char and the unicode escape" do
+      assert Value.write(Value.string("a\rb")) == "\"a\\rb\""
+      assert Value.write(Value.string("a\tb")) == "\"a\\tb\""
+      assert Value.write(Value.string("a\bb")) == "\"a\\bb\""
+      assert Value.write(Value.string(<<?a, 0x01, ?b>>)) == "\"a\\x1;b\""
     end
 
     test "characters" do
@@ -237,6 +279,22 @@ defmodule Schooner.ValueTest do
 
       p = Value.primitive("+", {:at_least, 0}, fn _ -> 0 end)
       assert Value.write(p) == "#<primitive +>"
+    end
+
+    test "record without a {:record_type, name, _} type-id falls back to inspect" do
+      r = Value.record({:type, "p"}, {1, 2})
+      assert Value.write(r) == "#<record #{inspect({:type, "p"})}>"
+    end
+
+    test "error objects render kind, message, and irritants" do
+      e = {:error_obj, :user, {:string, "boom"}, []}
+      assert Value.write(e) == "#<error \"boom\">"
+
+      with_irrs = {:error_obj, :read, {:string, "bad input"}, [1, Value.symbol("x")]}
+      assert Value.write(with_irrs) == "#<read-error \"bad input\" 1 x>"
+
+      file_kind = {:error_obj, :file, {:string, "missing"}, []}
+      assert Value.write(file_kind) == "#<file-error \"missing\">"
     end
 
     test "display falls through to write for non-string/char aggregates" do


### PR DESCRIPTION
## Summary

- Overall line coverage was **86.55%**, below the project's 90% threshold. This PR adds tests against the public API for previously-untested error paths, type-error branches, and rendering edge cases — bringing overall coverage to **93.69%**.
- Tests are added to existing per-module files (no new test files), keeping the existing organisation intact.

Per-module gains:

| Module | Before | After |
| --- | --- | --- |
| `Schooner.Primitives.Char` | 69.35% | 98.39% |
| `Schooner.Primitives.Base` | 87.39% | 97.79% |
| `Schooner.Value` | 87.82% | 98.72% |
| `Schooner.Lexer` | 86.02% | 95.34% |
| `Schooner.Eval` | 88.13% | 90.00% |
| `Schooner.Eval.Error` | 88.24% | 100% |
| `Schooner.Expander` | 87.80% | 92.07% |
| `Schooner.Expander.SyntaxRules` | 79.25% | 80.50% |

## Note: pre-existing bug surfaced

While writing the expander tests I noticed `lib/schooner/expander.ex:167` raises `Schooner.Eval.Error` with reason `:nested_define_syntax_unsupported`, but only `Schooner.Expander.Error.format/1` recognises that reason — calling `Exception.message/1` on the resulting struct crashes with a `FunctionClauseError`. Not fixed here; happy to follow up in a separate PR.

## Test plan

- [x] `mix precommit` clean (compile/format/credo/test)
- [x] `mix test --cover` reports overall ≥ 90% (93.69%)
- [x] 747 tests, 0 failures