### PR TITLE
Phase 13.9: implement (scheme case-lambda) and apply

### DIFF
--- a/lib/schooner.ex
+++ b/lib/schooner.ex
@@ -42,7 +42,7 @@ defmodule Schooner do
   @default_run_imports_forms Reader.read_string(
                                "(import (scheme base) (scheme cxr) (scheme char) " <>
                                  "(scheme inexact) (scheme write) (scheme read) " <>
-                                 "(scheme lazy))"
+                                 "(scheme case-lambda) (scheme lazy))"
                              )
 
   @doc """

--- a/lib/schooner/library/standard.ex
+++ b/lib/schooner/library/standard.ex
@@ -19,10 +19,10 @@ defmodule Schooner.Library.Standard do
     * `(scheme lazy)` → `Primitives.Lazy` plus the `delay` and
       `delay-force` macros from `priv/scheme/lazy.scm`.
 
-  `(scheme case-lambda)` is registered with empty exports — its macro
-  is deferred to a later sub-phase (the syntax-rules implementation
-  needs an arity-counting helper that the current matcher does not
-  yet support cleanly).
+  `(scheme case-lambda)` exposes the `case-lambda` macro defined in
+  `priv/scheme/case-lambda.scm`, which lowers to a chain of plain
+  `lambda`s wrapped in a rest-only outer lambda that dispatches by
+  arity at call time.
 
   Idempotent: calling `boot/0` repeatedly rebuilds and re-persists the
   same registry. The first call from `Schooner.Application.start/2` is
@@ -122,9 +122,11 @@ defmodule Schooner.Library.Standard do
   end
 
   defp scheme_case_lambda do
-    # Macro deferred. The library entry exists so importers do not
-    # error out at registration; the macros land in a later sub-phase.
-    Library.new(name: ["scheme", "case-lambda"], features: [:r7rs])
+    Library.new(
+      name: ["scheme", "case-lambda"],
+      exports: macros_from_priv("case-lambda.scm"),
+      features: [:r7rs]
+    )
   end
 
   defp scheme_lazy do

--- a/lib/schooner/primitives/base.ex
+++ b/lib/schooner/primitives/base.ex
@@ -627,7 +627,8 @@ defmodule Schooner.Primitives.Base do
       {"assv", 2, &assv_/1},
       {"assq", 2, &assq_/1},
       {"map", {:at_least, 2}, &map_/1},
-      {"for-each", {:at_least, 2}, &for_each_/1}
+      {"for-each", {:at_least, 2}, &for_each_/1},
+      {"apply", {:at_least, 2}, &apply_/1}
     ]
   end
 
@@ -767,6 +768,25 @@ defmodule Schooner.Primitives.Base do
 
   defp split_heads_tails([{:pair, h, t} | r], hs, ts),
     do: split_heads_tails(r, [h | hs], [t | ts])
+
+  # r7rs §6.10: `(apply proc arg1 ... argn list)`. The leading args are
+  # passed positionally, the trailing list is spliced. The tail call to
+  # `Eval.apply_proc/2` keeps the proper-tail-call invariant intact —
+  # an `apply` use in tail position behaves like a direct call.
+  defp apply_([proc | rest]) do
+    require_procedure!("apply", proc)
+    Eval.apply_proc(proc, build_apply_args(rest))
+  end
+
+  defp build_apply_args([list]) do
+    require_proper_list!("apply", list)
+    flatten_scheme_list(list, [])
+  end
+
+  defp build_apply_args([head | rest]), do: [head | build_apply_args(rest)]
+
+  defp flatten_scheme_list(:null, acc), do: Enum.reverse(acc)
+  defp flatten_scheme_list({:pair, h, t}, acc), do: flatten_scheme_list(t, [h | acc])
 
   # ---------------------------------------------------------------------------
   # Vectors

--- a/priv/scheme/case-lambda.scm
+++ b/priv/scheme/case-lambda.scm
@@ -1,0 +1,52 @@
+;; (scheme case-lambda) — r7rs §4.2.9
+;;
+;; case-lambda lowers to a chain of plain `lambda`s wrapped in a
+;; rest-only outer lambda that picks the first clause whose formals
+;; shape accepts the actual arity. The chain is built by recursive
+;; macro expansion: each rule consumes one clause and emits a
+;; `(case-lambda <remaining>)` use for the fall-through path, and the
+;; empty form bottoms out into a lambda that errors on call.
+;;
+;; The clause shapes are dispatched by pattern alone, in this order:
+;;
+;;   1. `(_)`                             — no clauses left → error
+;;   2. `((() body ...) ...)`             — empty fixed-arity formals
+;;   3. `(((p1 p2 ...) body ...) ...)`    — proper non-empty list
+;;   4. `(((p1 p2 ... . r) body ...) ...)` — dotted-rest, ≥1 fixed
+;;   5. `((rest body ...) ...)`           — bare-symbol rest-only
+;;
+;; The order matters: the proper-list pattern must come before the
+;; dotted-rest one (the latter would otherwise also match proper
+;; formals and bind `r` to the empty tail), and the bare-symbol
+;; pattern must come last (it matches anything as the first clause
+;; element). The proper-list pattern requires ≥1 element so the empty
+;; formals case has its own dedicated rule that avoids a runtime
+;; `(length '())`.
+;;
+;; Arity discrimination is at runtime via `(length args)` against the
+;; literal formals list — O(N) per clause attempt where N is the
+;; clause's fixed-arity. The issue's option (a) called out the cost;
+;; tests don't gate on it and the natural macro is markedly simpler
+;; than carrying a compile-time-known arity through a helper macro.
+
+(define-syntax case-lambda
+  (syntax-rules ()
+    ((_)
+     (lambda args (error "case-lambda: no matching clause" args)))
+    ((_ (() body ...) clause ...)
+     (lambda args
+       (if (null? args)
+           ((lambda () body ...))
+           (apply (case-lambda clause ...) args))))
+    ((_ ((p1 p2 ...) body ...) clause ...)
+     (lambda args
+       (if (= (length args) (length '(p1 p2 ...)))
+           (apply (lambda (p1 p2 ...) body ...) args)
+           (apply (case-lambda clause ...) args))))
+    ((_ ((p1 p2 ... . r) body ...) clause ...)
+     (lambda args
+       (if (>= (length args) (length '(p1 p2 ...)))
+           (apply (lambda (p1 p2 ... . r) body ...) args)
+           (apply (case-lambda clause ...) args))))
+    ((_ (rest body ...) clause ...)
+     (lambda rest body ...))))

--- a/test/schooner/library/standard_test.exs
+++ b/test/schooner/library/standard_test.exs
@@ -80,11 +80,12 @@ defmodule Schooner.Library.StandardTest do
     assert Map.keys(exports) == ["read"]
   end
 
-  test "(scheme case-lambda) is a stub pending its macro implementation" do
+  test "(scheme case-lambda) exports the case-lambda macro" do
     %{exports: exports} =
       Library.fetch!(Standard.build_registry(), ["scheme", "case-lambda"])
 
-    assert exports == %{}
+    assert Map.keys(exports) == ["case-lambda"]
+    assert match?({:macro, _}, Map.fetch!(exports, "case-lambda"))
   end
 
   test "(scheme lazy) exports primitives plus delay/delay-force macros" do

--- a/test/schooner/primitives/base_pairs_test.exs
+++ b/test/schooner/primitives/base_pairs_test.exs
@@ -193,4 +193,37 @@ defmodule Schooner.Primitives.BasePairsTest do
       assert match?({:type_error, "for-each", "procedure", _}, e.reason)
     end
   end
+
+  describe "apply" do
+    test "applies a procedure to a list of args" do
+      assert run("(apply + '(1 2 3 4))") == 10
+      assert run("(apply list '())") == :null
+    end
+
+    test "splices a trailing list after positional leading args" do
+      assert run("(apply + 1 2 '(3 4 5))") == 15
+
+      assert run("(apply list 'a 'b '(c d))") ==
+               Value.list([
+                 Value.symbol("a"),
+                 Value.symbol("b"),
+                 Value.symbol("c"),
+                 Value.symbol("d")
+               ])
+    end
+
+    test "works with closures" do
+      assert run("(apply (lambda (x y z) (* x y z)) '(2 3 4))") == 24
+    end
+
+    test "rejects a non-procedure first argument" do
+      e = assert_raise PError, fn -> run("(apply 1 '())") end
+      assert match?({:type_error, "apply", "procedure", _}, e.reason)
+    end
+
+    test "rejects an improper list as the trailing argument" do
+      e = assert_raise PError, fn -> run("(apply + '(1 2 . 3))") end
+      assert match?({:improper_list, "apply", _}, e.reason)
+    end
+  end
 end

--- a/test/schooner/primitives/case_lambda_test.exs
+++ b/test/schooner/primitives/case_lambda_test.exs
@@ -1,0 +1,163 @@
+defmodule Schooner.Primitives.CaseLambdaTest do
+  use ExUnit.Case, async: true
+
+  alias Schooner.Env
+  alias Schooner.Value
+
+  defp run(source), do: Schooner.run(source)
+
+  describe "clause shapes" do
+    test "empty fixed-arity formals" do
+      assert run("((case-lambda (() 'zero))) ") == Value.symbol("zero")
+    end
+
+    test "single fixed-arity clause" do
+      assert run("((case-lambda ((x) (* x 2))) 21)") == 42
+    end
+
+    test "multi-element fixed-arity clause" do
+      assert run("((case-lambda ((x y z) (+ x y z))) 1 2 3)") == 6
+    end
+
+    test "rest-only (variadic) formals bind the args list" do
+      assert run("((case-lambda (xs xs)) 1 2 3)") ==
+               Value.list([1, 2, 3])
+    end
+
+    test "rest-only formals also accept zero args" do
+      assert run("((case-lambda (xs xs)))") == :null
+    end
+
+    test "dotted-rest formals bind the head positionally and the tail as a list" do
+      assert run("((case-lambda ((a b . rest) (list a b rest))) 1 2 3 4)") ==
+               Value.list([1, 2, Value.list([3, 4])])
+    end
+
+    test "dotted-rest with empty tail still matches the at-least arity" do
+      assert run("((case-lambda ((a b . rest) (list a b rest))) 10 20)") ==
+               Value.list([10, 20, :null])
+    end
+  end
+
+  describe "arity selection" do
+    test "selects the matching fixed-arity clause" do
+      source = """
+      (define f
+        (case-lambda
+          (() 'zero)
+          ((x) (list 'one x))
+          ((x y) (list 'two x y))))
+      (list (f) (f 1) (f 1 2))
+      """
+
+      assert run(source) ==
+               Value.list([
+                 Value.symbol("zero"),
+                 Value.list([Value.symbol("one"), 1]),
+                 Value.list([Value.symbol("two"), 1, 2])
+               ])
+    end
+
+    test "first matching clause wins; later clauses with same arity are dead" do
+      source = """
+      (define f
+        (case-lambda
+          ((x) 'first)
+          ((x) 'second)))
+      (f 99)
+      """
+
+      assert run(source) == Value.symbol("first")
+    end
+
+    test "dotted-rest clause covers any arity at-or-above its fixed prefix" do
+      source = """
+      (define f
+        (case-lambda
+          (() 0)
+          ((a . rest) (+ a (length rest)))))
+      (list (f) (f 10) (f 10 'a 'b 'c))
+      """
+
+      assert run(source) == Value.list([0, 10, 13])
+    end
+  end
+
+  describe "no matching clause" do
+    test "raises a Scheme error tagged 'case-lambda: no matching clause'" do
+      source = """
+      (define f
+        (case-lambda
+          ((x) x)
+          ((x y) (+ x y))))
+      (f 1 2 3)
+      """
+
+      e = assert_raise Schooner.Error, fn -> run(source) end
+      assert {:error_obj, :user, {:string, msg}, [args]} = e.value
+      assert msg == "case-lambda: no matching clause"
+      assert args == Value.list([1, 2, 3])
+    end
+
+    test "(case-lambda) with zero clauses errors on every call" do
+      e = assert_raise Schooner.Error, fn -> run("((case-lambda) 1)") end
+      assert {:error_obj, :user, {:string, "case-lambda: no matching clause"}, _} = e.value
+    end
+  end
+
+  describe "nested case-lambda inside another lambda" do
+    test "closes over the outer lambda's parameter" do
+      source = """
+      (define mk
+        (lambda (base)
+          (case-lambda
+            (() base)
+            ((delta) (+ base delta))
+            ((lo hi) (+ base lo hi)))))
+      (define f (mk 100))
+      (list (f) (f 5) (f 10 20))
+      """
+
+      assert run(source) == Value.list([100, 105, 130])
+    end
+
+    test "case-lambda nested inside case-lambda" do
+      source = """
+      (define f
+        (case-lambda
+          ((tag) (case-lambda
+                   (() tag)
+                   ((x) (cons tag x))))))
+      (define inner (f 'outer))
+      (list (inner) (inner 'inner-arg))
+      """
+
+      assert run(source) ==
+               Value.list([
+                 Value.symbol("outer"),
+                 Value.pair(Value.symbol("outer"), Value.symbol("inner-arg"))
+               ])
+    end
+  end
+
+  describe "library surface" do
+    test "case-lambda is unavailable in strict eval/2 without the import" do
+      assert_raise Schooner.Eval.Error, fn ->
+        Schooner.eval(
+          "(define f (case-lambda ((x) x))) (f 1)",
+          Env.new()
+        )
+      end
+    end
+
+    test "case-lambda becomes available after explicit import in strict eval/2" do
+      source = """
+      (import (scheme base) (scheme case-lambda))
+      (define f (case-lambda ((x) (* x 3)) ((x y) (+ x y))))
+      (list (f 4) (f 4 5))
+      """
+
+      assert Schooner.eval(source, Env.new()) == Value.list([12, 9])
+    end
+  end
+end


### PR DESCRIPTION
Resolves #35.

## Summary
- Implement `(scheme case-lambda)` as a `syntax-rules` macro in `priv/scheme/case-lambda.scm`. Each clause lowers to a plain `lambda` wrapped in a rest-only outer lambda that selects the first matching clause by arity at call time. Pattern order — empty / proper-list / dotted-rest / bare-symbol — lets the existing syntax-rules matcher resolve clause shape without any new helper.
- Add `apply` as a `(scheme base)` primitive (r7rs §6.10). It was missing and is the natural prerequisite for the case-lambda lowering. The implementation tail-calls `Eval.apply_proc/2`, so `apply` in tail position preserves proper-tail-call behaviour.
- `(scheme case-lambda)` is added to the implicit-import list in `Schooner.run/1`, and its standard-library entry now exports the macro instead of an empty map.

## Test plan
- [x] `mix precommit` green (888 tests, 0 failures)
- [x] New `test/schooner/primitives/case_lambda_test.exs` covers every clause shape (fixed-arity, variadic, dotted-rest, empty), arity selection across multiple clauses, the "no matching clause" error, and case-lambda nested inside `lambda` and inside another `case-lambda`. Strict `eval/2` paths verify the macro is gated on `(import (scheme case-lambda))`.
- [x] `apply` tests in `test/schooner/primitives/base_pairs_test.exs` cover the bare-list, leading-args-plus-list, closure, non-procedure, and improper-tail cases.
- [x] `test/schooner/library/standard_test.exs` updated to assert the macro export now that the stub is gone.