### PR TITLE
Issue #36: support (include …) and (include-library-declarations …)

### DIFF
--- a/lib/schooner/library/loader.ex
+++ b/lib/schooner/library/loader.ex
@@ -17,14 +17,17 @@ defmodule Schooner.Library.Loader do
       based on the feature requirement clauses. Supported requirement
       forms: `feature-id` (a symbol), `(library NAME)`, `(and ...)`,
       `(or ...)`, `(not ...)`, and an `else` clause.
+    * `(include "path" ...)` — read each named file as a sequence of
+      body forms and splice them into the library's `(begin …)`. Paths
+      resolve relative to the file containing the `include` form.
+    * `(include-library-declarations "path" ...)` — read each named
+      file as a sequence of declarations and process them in place.
+      Paths resolve relative to the including file, so nested includes
+      thread the directory of the innermost file.
 
-  ## Deferred
-
-  `(include "path")` and `(include-library-declarations "path")` are
-  deferred to a later phase; the path-resolution logic is mostly
-  identical to `(include)` once the loader carries source-relative
-  context. Source-position threading for diagnostics is also a
-  follow-up.
+  Relative include paths that resolve outside the entry-point's
+  directory are rejected; absolute paths are likewise rejected unless
+  they fall inside the entry-point's directory.
   """
 
   alias Schooner.Env
@@ -38,21 +41,29 @@ defmodule Schooner.Library.Loader do
 
   @schooner_features [:r7rs]
 
+  @typedoc "Path-resolution context threaded through declaration processing."
+  @type ctx :: %{base_dir: binary() | nil, root_dir: binary() | nil}
+
   @doc """
   Compile a single `(define-library ...)` datum against `registry`.
   Returns a `%Schooner.Library{}` ready for `Library.register/2`.
+
+  `ctx` carries the directory used to resolve relative include paths.
   """
-  @spec compile(Value.t(), Library.registry()) :: Library.t()
+  @spec compile(Value.t(), Library.registry(), ctx()) :: Library.t()
+  def compile(datum, registry, ctx \\ %{base_dir: nil, root_dir: nil})
+
   def compile(
         {:pair, {:sym, "define-library"}, {:pair, name_datum, decls_list}},
-        registry
+        registry,
+        ctx
       ) do
     name = Library.canonicalise_name(name_datum)
     decls = Value.to_list(decls_list)
 
     parts =
       Enum.reduce(decls, %{imports: [], body: [], exports: [], features: []}, fn decl, acc ->
-        apply_decl(decl, acc, registry)
+        apply_decl(decl, acc, registry, ctx)
       end)
 
     binding_set = LibImport.resolve(parts.imports, registry)
@@ -75,7 +86,7 @@ defmodule Schooner.Library.Loader do
     )
   end
 
-  def compile(other, _registry) do
+  def compile(other, _registry, _ctx) do
     raise ArgumentError, "expected a (define-library ...) datum, got #{inspect(other)}"
   end
 
@@ -92,14 +103,30 @@ defmodule Schooner.Library.Loader do
   """
   @spec load_file(binary(), Library.registry()) :: Library.registry()
   def load_file(path, registry \\ Library.standard()) when is_binary(path) do
-    path
-    |> File.read!()
-    |> load_string(registry)
+    source = File.read!(path)
+    load_string(source, registry, base_dir: Path.dirname(Path.expand(path)))
   end
 
-  @doc "Compile and register every define-library form in `source`."
-  @spec load_string(binary(), Library.registry()) :: Library.registry()
-  def load_string(source, registry \\ Library.standard()) when is_binary(source) do
+  @doc """
+  Compile and register every define-library form in `source`.
+
+  Options:
+
+    * `:base_dir` — directory used to resolve relative `(include …)` and
+      `(include-library-declarations …)` paths. Defaults to `nil`,
+      which makes relative includes an error.
+  """
+  @spec load_string(binary(), Library.registry(), keyword()) :: Library.registry()
+  def load_string(source, registry \\ Library.standard(), opts \\ [])
+      when is_binary(source) and is_list(opts) do
+    base_dir =
+      case Keyword.get(opts, :base_dir) do
+        nil -> nil
+        dir when is_binary(dir) -> Path.expand(dir)
+      end
+
+    ctx = %{base_dir: base_dir, root_dir: base_dir}
+
     datums = Reader.read_string(source)
 
     libs =
@@ -108,52 +135,118 @@ defmodule Schooner.Library.Loader do
         other -> raise ArgumentError, "expected (define-library ...), got #{inspect(other)}"
       end)
 
-    ordered = topological_order!(libs)
+    ordered = topological_order!(libs, ctx)
 
-    Enum.reduce(ordered, registry, fn datum, reg -> Library.register(reg, compile(datum, reg)) end)
+    Enum.reduce(ordered, registry, fn datum, reg ->
+      Library.register(reg, compile(datum, reg, ctx))
+    end)
   end
 
   # ---------------------------------------------------------------------------
   # Declarations
   # ---------------------------------------------------------------------------
 
-  defp apply_decl({:pair, {:sym, "import"}, specs}, acc, _registry) do
+  defp apply_decl({:pair, {:sym, "import"}, specs}, acc, _registry, _ctx) do
     %{acc | imports: acc.imports ++ Value.to_list(specs)}
   end
 
-  defp apply_decl({:pair, {:sym, "begin"}, forms}, acc, _registry) do
+  defp apply_decl({:pair, {:sym, "begin"}, forms}, acc, _registry, _ctx) do
     %{acc | body: acc.body ++ Value.to_list(forms)}
   end
 
-  defp apply_decl({:pair, {:sym, "export"}, names}, acc, _registry) do
+  defp apply_decl({:pair, {:sym, "export"}, names}, acc, _registry, _ctx) do
     %{acc | exports: acc.exports ++ Value.to_list(names)}
   end
 
-  defp apply_decl({:pair, {:sym, "cond-expand"}, clauses}, acc, registry) do
+  defp apply_decl({:pair, {:sym, "cond-expand"}, clauses}, acc, registry, ctx) do
     case select_cond_expand(Value.to_list(clauses), registry) do
       {:ok, sub_decls} ->
-        Enum.reduce(sub_decls, acc, &apply_decl(&1, &2, registry))
+        Enum.reduce(sub_decls, acc, &apply_decl(&1, &2, registry, ctx))
 
       :no_match ->
         acc
     end
   end
 
-  defp apply_decl({:pair, {:sym, "include"}, _}, _acc, _registry) do
-    raise ArgumentError, "(include ...) is not yet supported in define-library bodies"
+  defp apply_decl({:pair, {:sym, "include"}, paths}, acc, _registry, ctx) do
+    forms =
+      paths
+      |> Value.to_list()
+      |> Enum.flat_map(fn path_datum ->
+        path = expect_string(path_datum, "include")
+        resolved = resolve_include_path(path, ctx)
+        read_datums(resolved, path)
+      end)
+
+    %{acc | body: acc.body ++ forms}
   end
 
   defp apply_decl(
-         {:pair, {:sym, "include-library-declarations"}, _},
-         _acc,
-         _registry
+         {:pair, {:sym, "include-library-declarations"}, paths},
+         acc,
+         registry,
+         ctx
        ) do
-    raise ArgumentError,
-          "(include-library-declarations ...) is not yet supported in define-library bodies"
+    paths
+    |> Value.to_list()
+    |> Enum.reduce(acc, fn path_datum, acc ->
+      path = expect_string(path_datum, "include-library-declarations")
+      resolved = resolve_include_path(path, ctx)
+      decls = read_datums(resolved, path)
+      inner_ctx = %{ctx | base_dir: Path.dirname(resolved)}
+      Enum.reduce(decls, acc, &apply_decl(&1, &2, registry, inner_ctx))
+    end)
   end
 
-  defp apply_decl(other, _acc, _registry) do
+  defp apply_decl(other, _acc, _registry, _ctx) do
     raise ArgumentError, "unsupported define-library declaration: #{inspect(other)}"
+  end
+
+  # ---------------------------------------------------------------------------
+  # Include path resolution
+  # ---------------------------------------------------------------------------
+
+  defp expect_string({:string, s}, _form), do: s
+
+  defp expect_string(other, form) do
+    raise ArgumentError, "(#{form} ...) expected string path, got #{inspect(other)}"
+  end
+
+  defp resolve_include_path(path, %{base_dir: base_dir, root_dir: root_dir}) do
+    cond do
+      Path.type(path) == :absolute ->
+        check_within_root(Path.expand(path), path, root_dir)
+
+      base_dir == nil ->
+        raise ArgumentError,
+              "cannot resolve relative include path #{inspect(path)} without a base directory; " <>
+                "load via Loader.load_file/2 or pass `:base_dir` to Loader.load_string/3"
+
+      true ->
+        check_within_root(Path.expand(path, base_dir), path, root_dir)
+    end
+  end
+
+  defp check_within_root(resolved, _original, nil), do: resolved
+
+  defp check_within_root(resolved, original, root_dir) do
+    if resolved == root_dir or String.starts_with?(resolved, root_dir <> "/") do
+      resolved
+    else
+      raise ArgumentError,
+            "include path #{inspect(original)} resolves outside the library root directory"
+    end
+  end
+
+  defp read_datums(resolved, original) do
+    case File.read(resolved) do
+      {:ok, source} ->
+        Reader.read_string(source)
+
+      {:error, reason} ->
+        raise ArgumentError,
+              "could not read include file #{inspect(original)}: #{:file.format_error(reason)}"
+    end
   end
 
   # ---------------------------------------------------------------------------
@@ -254,9 +347,9 @@ defmodule Schooner.Library.Loader do
   # Topological order over file-local libraries
   # ---------------------------------------------------------------------------
 
-  defp topological_order!(datums) do
+  defp topological_order!(datums, ctx) do
     by_name = Map.new(datums, fn d -> {extract_name(d), d} end)
-    deps = Map.new(datums, fn d -> {extract_name(d), local_deps(d, by_name)} end)
+    deps = Map.new(datums, fn d -> {extract_name(d), local_deps(d, by_name, ctx)} end)
 
     {ordered, _done} =
       Enum.reduce(Map.keys(deps), {[], MapSet.new()}, fn name, {acc, done} ->
@@ -294,16 +387,31 @@ defmodule Schooner.Library.Loader do
     Library.canonicalise_name(name_datum)
   end
 
-  defp local_deps({:pair, {:sym, "define-library"}, {:pair, _, decls}}, by_name) do
+  defp local_deps({:pair, {:sym, "define-library"}, {:pair, _, decls}}, by_name, ctx) do
     decls
     |> Value.to_list()
-    |> Enum.flat_map(&decl_imports/1)
+    |> Enum.flat_map(&decl_imports(&1, ctx))
     |> Enum.map(&spec_to_canonical_dependency/1)
     |> Enum.filter(&Map.has_key?(by_name, &1))
   end
 
-  defp decl_imports({:pair, {:sym, "import"}, specs}), do: Value.to_list(specs)
-  defp decl_imports(_), do: []
+  defp decl_imports({:pair, {:sym, "import"}, specs}, _ctx), do: Value.to_list(specs)
+
+  defp decl_imports({:pair, {:sym, "include-library-declarations"}, paths}, ctx) do
+    paths
+    |> Value.to_list()
+    |> Enum.flat_map(fn path_datum ->
+      path = expect_string(path_datum, "include-library-declarations")
+      resolved = resolve_include_path(path, ctx)
+      inner_ctx = %{ctx | base_dir: Path.dirname(resolved)}
+
+      resolved
+      |> read_datums(path)
+      |> Enum.flat_map(&decl_imports(&1, inner_ctx))
+    end)
+  end
+
+  defp decl_imports(_other, _ctx), do: []
 
   # Reduce an import spec to the canonical name of the library it
   # ultimately points at, ignoring any wrapping modifiers.

--- a/test/schooner/library/loader_test.exs
+++ b/test/schooner/library/loader_test.exs
@@ -152,19 +152,6 @@ defmodule Schooner.Library.LoaderTest do
     end
   end
 
-  describe "deferred declarations" do
-    test "(include ...) raises a clear 'not yet supported' error" do
-      source = """
-      (define-library (with-include)
-        (include "missing.scm"))
-      """
-
-      assert_raise ArgumentError, ~r/include.*not yet supported/, fn ->
-        Loader.load_string(source, standard())
-      end
-    end
-  end
-
   describe "load_file/2" do
     @tag :tmp_dir
     test "loads define-library declarations from disk", %{tmp_dir: dir} do
@@ -180,6 +167,175 @@ defmodule Schooner.Library.LoaderTest do
       reg = Loader.load_file(path, standard())
       lib = Library.fetch!(reg, ["from-file"])
       assert {:var, 42} = Map.fetch!(lib.exports, "forty-two")
+    end
+  end
+
+  describe "(include ...)" do
+    @tag :tmp_dir
+    test "splices body forms from a file relative to the including file", %{tmp_dir: dir} do
+      File.write!(Path.join(dir, "body.scm"), """
+      (define (square x) (* x x))
+      (define forty-two 42)
+      """)
+
+      File.write!(Path.join(dir, "lib.scm"), """
+      (define-library (with-include)
+        (import (scheme base))
+        (export square forty-two)
+        (include "body.scm"))
+      """)
+
+      reg = Loader.load_file(Path.join(dir, "lib.scm"), standard())
+      lib = Library.fetch!(reg, ["with-include"])
+
+      assert {:var, {:closure, _, _, _, _}} = Map.fetch!(lib.exports, "square")
+      assert {:var, 42} = Map.fetch!(lib.exports, "forty-two")
+    end
+
+    @tag :tmp_dir
+    test "concatenates multiple paths in source order", %{tmp_dir: dir} do
+      File.write!(Path.join(dir, "a.scm"), "(define a 1)")
+      File.write!(Path.join(dir, "b.scm"), "(define b (+ a 1))")
+
+      File.write!(Path.join(dir, "lib.scm"), """
+      (define-library (multi-include)
+        (import (scheme base))
+        (export a b)
+        (include "a.scm" "b.scm"))
+      """)
+
+      reg = Loader.load_file(Path.join(dir, "lib.scm"), standard())
+      lib = Library.fetch!(reg, ["multi-include"])
+      assert {:var, 1} = Map.fetch!(lib.exports, "a")
+      assert {:var, 2} = Map.fetch!(lib.exports, "b")
+    end
+
+    @tag :tmp_dir
+    test "missing include file errors with the offending path quoted", %{tmp_dir: dir} do
+      File.write!(Path.join(dir, "lib.scm"), """
+      (define-library (with-include)
+        (include "no-such.scm"))
+      """)
+
+      assert_raise ArgumentError, ~r/no-such\.scm/, fn ->
+        Loader.load_file(Path.join(dir, "lib.scm"), standard())
+      end
+    end
+
+    @tag :tmp_dir
+    test "rejects relative paths that escape the entry-point directory", %{tmp_dir: dir} do
+      sub = Path.join(dir, "sub")
+      File.mkdir_p!(sub)
+      File.write!(Path.join(dir, "outside.scm"), "(define x 1)")
+
+      File.write!(Path.join(sub, "lib.scm"), """
+      (define-library (escaping)
+        (import (scheme base))
+        (export x)
+        (include "../outside.scm"))
+      """)
+
+      assert_raise ArgumentError, ~r/resolves outside/, fn ->
+        Loader.load_file(Path.join(sub, "lib.scm"), standard())
+      end
+    end
+
+    test "relative include without a base directory is an error" do
+      source = """
+      (define-library (no-base)
+        (include "anything.scm"))
+      """
+
+      assert_raise ArgumentError, ~r/without a base directory/, fn ->
+        Loader.load_string(source, standard())
+      end
+    end
+  end
+
+  describe "(include-library-declarations ...)" do
+    @tag :tmp_dir
+    test "splices declarations from an external file", %{tmp_dir: dir} do
+      File.write!(Path.join(dir, "decls.scm"), """
+      (import (scheme base))
+      (export answer)
+      (begin (define answer 42))
+      """)
+
+      File.write!(Path.join(dir, "lib.scm"), """
+      (define-library (with-decls)
+        (include-library-declarations "decls.scm"))
+      """)
+
+      reg = Loader.load_file(Path.join(dir, "lib.scm"), standard())
+      lib = Library.fetch!(reg, ["with-decls"])
+      assert {:var, 42} = Map.fetch!(lib.exports, "answer")
+    end
+
+    @tag :tmp_dir
+    test "nested includes resolve relative to the innermost file", %{tmp_dir: dir} do
+      sub = Path.join(dir, "sub")
+      File.mkdir_p!(sub)
+
+      File.write!(Path.join(sub, "body.scm"), "(define inner 7)")
+
+      File.write!(Path.join(sub, "decls.scm"), """
+      (import (scheme base))
+      (export inner)
+      (include "body.scm")
+      """)
+
+      File.write!(Path.join(dir, "lib.scm"), """
+      (define-library (nested)
+        (include-library-declarations "sub/decls.scm"))
+      """)
+
+      reg = Loader.load_file(Path.join(dir, "lib.scm"), standard())
+      lib = Library.fetch!(reg, ["nested"])
+      assert {:var, 7} = Map.fetch!(lib.exports, "inner")
+    end
+
+    @tag :tmp_dir
+    test "cond-expand inside an included declaration file works", %{tmp_dir: dir} do
+      File.write!(Path.join(dir, "decls.scm"), """
+      (cond-expand
+        (r7rs (import (scheme base))
+              (export who)
+              (begin (define who 'r7rs)))
+        (else (import (scheme base))
+              (export who)
+              (begin (define who 'other))))
+      """)
+
+      File.write!(Path.join(dir, "lib.scm"), """
+      (define-library (cx-included)
+        (include-library-declarations "decls.scm"))
+      """)
+
+      reg = Loader.load_file(Path.join(dir, "lib.scm"), standard())
+      lib = Library.fetch!(reg, ["cx-included"])
+      assert {:var, {:sym, "r7rs"}} = Map.fetch!(lib.exports, "who")
+    end
+
+    @tag :tmp_dir
+    test "import inside an included file is followed for topological order", %{tmp_dir: dir} do
+      File.write!(Path.join(dir, "decls.scm"), """
+      (import (helpers))
+      (export use-help)
+      (begin (define use-help (helper)))
+      """)
+
+      File.write!(Path.join(dir, "libs.scm"), """
+      (define-library (uses)
+        (include-library-declarations "decls.scm"))
+      (define-library (helpers)
+        (import (scheme base))
+        (export helper)
+        (begin (define (helper) 99)))
+      """)
+
+      reg = Loader.load_file(Path.join(dir, "libs.scm"), standard())
+      lib = Library.fetch!(reg, ["uses"])
+      assert {:var, 99} = Map.fetch!(lib.exports, "use-help")
     end
   end
 end


### PR DESCRIPTION
Closes #36.

## Summary
- Implements both `(include …)` and `(include-library-declarations …)` as `define-library` declaration heads per r7rs §5.6.1.
- Threads a `%{base_dir, root_dir}` context through `Loader.load_file/2 → load_string/3 (new \`:base_dir\` opt) → compile/3 (new arity)`, so nested includes resolve relative to the innermost including file.
- Rejects relative paths loaded from a string with no base directory, and rejects any include path that resolves outside the entry-point's directory.
- Topological dependency walking now follows `include-library-declarations` so a file-local library that imports through an included declaration file is ordered correctly.
- Removes the "Deferred" note from `Loader`'s moduledoc.

## Test plan
- [x] `mix precommit` (compile --warnings-as-errors, format, credo --strict, full test suite — 896 tests, 0 failures).
- [x] New tests in `test/schooner/library/loader_test.exs`:
  - `(include …)`: simple splice from disk, multi-path concatenation, missing-file error quoting the offending path, escape-the-root rejection, no-base-dir rejection.
  - `(include-library-declarations …)`: simple splice, nested includes resolving relative to the innermost file, `cond-expand` inside an included declaration file, topological order following imports inside an included file.