### PR TITLE
Issue #37: source-position threading in library loader diagnostics

### DIFF
--- a/lib/schooner/library/loader.ex
+++ b/lib/schooner/library/loader.ex
@@ -34,7 +34,11 @@ defmodule Schooner.Library.Loader do
   Errors raised by the loader quote the file path and `line:column` of
   the offending source datum where the reader can supply one. Libraries
   loaded from disk record their origin in the `:source` field as
-  `{:file, path, {line, column}}`.
+  `{:file, path, {line, column}}`. The topological pre-pass over
+  `include-library-declarations` runs without per-path positions, so a
+  malformed path datum found during that pass is reported without a
+  line number; once the pass succeeds, the main walker re-reads the
+  same files with positions and quotes any subsequent error precisely.
   """
 
   alias Schooner.Env
@@ -60,12 +64,13 @@ defmodule Schooner.Library.Loader do
   Returns a `%Schooner.Library{}` ready for `Library.register/2`.
 
   `ctx` carries the directory used to resolve relative include paths
-  and the path threaded into diagnostics.
+  and the path threaded into diagnostics. When called with a raw datum
+  (no positioned tree from the reader), error messages render without
+  line/column information.
   """
   @spec compile(Value.t(), Library.registry(), ctx()) :: Library.t()
   def compile(datum, registry, ctx \\ default_ctx()) do
-    pos_tree = synthetic_pos_tree(datum)
-    compile_positioned(datum, pos_tree, registry, ctx)
+    compile_positioned(datum, synthetic_pos_tree(datum), registry, ctx)
   end
 
   defp compile_positioned(
@@ -76,12 +81,12 @@ defmodule Schooner.Library.Loader do
        ) do
     name = Library.canonicalise_name(name_datum)
     decls = Value.to_list(decls_list)
-    decl_positions = decl_position_trees(pos_tree)
+    decl_positions = tail_positions(pos_tree, 2)
 
     parts =
       decls
       |> Enum.zip(decl_positions)
-      |> Enum.reduce(%{imports: [], body: [], exports: [], export_positions: [], features: []}, fn
+      |> Enum.reduce(%{imports: [], body: [], exports: [], features: []}, fn
         {decl, decl_pos}, acc ->
           apply_decl(decl, decl_pos, acc, registry, ctx)
       end)
@@ -96,8 +101,7 @@ defmodule Schooner.Library.Loader do
 
     Enum.each(expanded, fn form -> Eval.eval(form, env) end)
 
-    library_exports =
-      build_exports(parts.exports, parts.export_positions, env, post_syntax_env, name, ctx)
+    library_exports = build_exports(parts.exports, env, post_syntax_env, name, ctx)
 
     Library.new(
       name: name,
@@ -154,10 +158,10 @@ defmodule Schooner.Library.Loader do
 
     ctx = %{base_dir: base_dir, root_dir: base_dir, path: path}
 
-    positioned = Reader.read_string_positioned(source)
-
     libs =
-      Enum.map(positioned, fn
+      source
+      |> Reader.read_string_positioned()
+      |> Enum.map(fn
         {{:pair, {:sym, "define-library"}, _} = d, p} ->
           {d, p}
 
@@ -186,26 +190,16 @@ defmodule Schooner.Library.Loader do
   end
 
   defp apply_decl({:pair, {:sym, "export"}, names}, pos_tree, acc, _registry, _ctx) do
-    name_positions = export_entry_positions(pos_tree)
-
-    %{
-      acc
-      | exports: acc.exports ++ Value.to_list(names),
-        export_positions: acc.export_positions ++ name_positions
-    }
+    entries = Enum.zip(Value.to_list(names), tail_positions(pos_tree, 1))
+    %{acc | exports: acc.exports ++ entries}
   end
 
   defp apply_decl({:pair, {:sym, "cond-expand"}, clauses}, pos_tree, acc, registry, ctx) do
-    clauses_list = Value.to_list(clauses)
-    clause_positions = cond_expand_clause_positions(pos_tree)
-
-    case select_cond_expand(clauses_list, clause_positions, registry, ctx) do
+    case select_cond_expand(Value.to_list(clauses), tail_positions(pos_tree, 1), registry, ctx) do
       {:ok, sub_decls, sub_positions} ->
         sub_decls
         |> Enum.zip(sub_positions)
-        |> Enum.reduce(acc, fn {decl, p}, acc ->
-          apply_decl(decl, p, acc, registry, ctx)
-        end)
+        |> Enum.reduce(acc, fn {decl, p}, acc -> apply_decl(decl, p, acc, registry, ctx) end)
 
       :no_match ->
         acc
@@ -213,16 +207,15 @@ defmodule Schooner.Library.Loader do
   end
 
   defp apply_decl({:pair, {:sym, "include"}, paths}, pos_tree, acc, _registry, ctx) do
-    path_positions = include_path_positions(pos_tree)
-
     forms =
       paths
       |> Value.to_list()
-      |> Enum.zip(path_positions)
+      |> Enum.zip(tail_positions(pos_tree, 1))
       |> Enum.flat_map(fn {path_datum, path_pos} ->
         path = expect_string(path_datum, "include", path_pos, ctx)
         resolved = resolve_include_path(path, ctx, path_pos)
-        read_datums(resolved, path, path_pos, ctx)
+        {datums, _} = read_include_file(resolved, path, path_pos, ctx, false)
+        datums
       end)
 
     %{acc | body: acc.body ++ forms}
@@ -235,25 +228,18 @@ defmodule Schooner.Library.Loader do
          registry,
          ctx
        ) do
-    path_positions = include_path_positions(pos_tree)
-
     paths
     |> Value.to_list()
-    |> Enum.zip(path_positions)
+    |> Enum.zip(tail_positions(pos_tree, 1))
     |> Enum.reduce(acc, fn {path_datum, path_pos}, acc ->
       path = expect_string(path_datum, "include-library-declarations", path_pos, ctx)
       resolved = resolve_include_path(path, ctx, path_pos)
-
-      {decls, decl_positions} =
-        read_positioned_datums(resolved, path, path_pos, ctx)
-
+      {decls, decl_positions} = read_include_file(resolved, path, path_pos, ctx, true)
       inner_ctx = %{ctx | base_dir: Path.dirname(resolved), path: resolved}
 
       decls
       |> Enum.zip(decl_positions)
-      |> Enum.reduce(acc, fn {decl, p}, acc ->
-        apply_decl(decl, p, acc, registry, inner_ctx)
-      end)
+      |> Enum.reduce(acc, fn {decl, p}, acc -> apply_decl(decl, p, acc, registry, inner_ctx) end)
     end)
   end
 
@@ -303,23 +289,16 @@ defmodule Schooner.Library.Loader do
     end
   end
 
-  defp read_datums(resolved, original, pos, ctx) do
+  # `with_positions?` controls which reader API the file goes through.
+  # Returns `{datums, positions}` either way; `positions` is `[]` when
+  # the unpositioned reader was used.
+  defp read_include_file(resolved, original, pos, ctx, with_positions?) do
     case File.read(resolved) do
-      {:ok, source} ->
-        Reader.read_string(source)
+      {:ok, source} when with_positions? ->
+        Enum.unzip(Reader.read_string_positioned(source))
 
-      {:error, reason} ->
-        raise ArgumentError,
-              "#{format_at(ctx, pos)}could not read include file #{inspect(original)}: " <>
-                List.to_string(:file.format_error(reason))
-    end
-  end
-
-  defp read_positioned_datums(resolved, original, pos, ctx) do
-    case File.read(resolved) do
       {:ok, source} ->
-        positioned = Reader.read_string_positioned(source)
-        {Enum.map(positioned, &elem(&1, 0)), Enum.map(positioned, &elem(&1, 1))}
+        {Reader.read_string(source), []}
 
       {:error, reason} ->
         raise ArgumentError,
@@ -340,7 +319,7 @@ defmodule Schooner.Library.Loader do
          _registry,
          _ctx
        ) do
-    {:ok, Value.to_list(body), cond_expand_body_positions(body_clause_pos)}
+    {:ok, Value.to_list(body), tail_positions(body_clause_pos, 1)}
   end
 
   defp select_cond_expand(
@@ -349,10 +328,10 @@ defmodule Schooner.Library.Loader do
          registry,
          ctx
        ) do
-    requirement_pos = clause_requirement_position(clause_pos)
+    [requirement_pos | _] = Reader.list_positions(clause_pos)
 
     if requirement_satisfied?(requirement, requirement_pos, registry, ctx) do
-      {:ok, Value.to_list(body), cond_expand_body_positions(clause_pos)}
+      {:ok, Value.to_list(body), tail_positions(clause_pos, 1)}
     else
       select_cond_expand(rest, rest_positions, registry, ctx)
     end
@@ -372,14 +351,14 @@ defmodule Schooner.Library.Loader do
   defp requirement_satisfied?({:pair, {:sym, "and"}, body}, pos, registry, ctx) do
     body
     |> Value.to_list()
-    |> Enum.zip(combinator_argument_positions(pos))
+    |> Enum.zip(tail_positions(pos, 1))
     |> Enum.all?(fn {req, p} -> requirement_satisfied?(req, p, registry, ctx) end)
   end
 
   defp requirement_satisfied?({:pair, {:sym, "or"}, body}, pos, registry, ctx) do
     body
     |> Value.to_list()
-    |> Enum.zip(combinator_argument_positions(pos))
+    |> Enum.zip(tail_positions(pos, 1))
     |> Enum.any?(fn {req, p} -> requirement_satisfied?(req, p, registry, ctx) end)
   end
 
@@ -389,7 +368,7 @@ defmodule Schooner.Library.Loader do
          registry,
          ctx
        ) do
-    [inner_pos] = combinator_argument_positions(pos)
+    [inner_pos] = tail_positions(pos, 1)
     not requirement_satisfied?(inner, inner_pos, registry, ctx)
   end
 
@@ -406,10 +385,8 @@ defmodule Schooner.Library.Loader do
   # Exports
   # ---------------------------------------------------------------------------
 
-  defp build_exports(export_decls, export_positions, env, syntax_env, lib_name, ctx) do
-    export_decls
-    |> Enum.zip(export_positions)
-    |> Enum.reduce(%{}, fn {decl, decl_pos}, acc ->
+  defp build_exports(export_entries, env, syntax_env, lib_name, ctx) do
+    Enum.reduce(export_entries, %{}, fn {decl, decl_pos}, acc ->
       {internal, external} = parse_export_entry(decl, decl_pos, ctx)
       Map.put(acc, external, freeze_one(internal, env, syntax_env, lib_name, decl_pos, ctx))
     end)
@@ -452,13 +429,10 @@ defmodule Schooner.Library.Loader do
   # ---------------------------------------------------------------------------
 
   defp topological_order!(libs, ctx) do
-    by_name =
-      Map.new(libs, fn {datum, pos_tree} -> {extract_name(datum), {datum, pos_tree}} end)
+    by_name = Map.new(libs, fn {datum, pos_tree} -> {extract_name(datum), {datum, pos_tree}} end)
 
     deps =
-      Map.new(libs, fn {datum, _pos} ->
-        {extract_name(datum), local_deps(datum, by_name, ctx)}
-      end)
+      Map.new(libs, fn {datum, _} -> {extract_name(datum), local_deps(datum, by_name, ctx)} end)
 
     {ordered, _done} =
       Enum.reduce(Map.keys(deps), {[], MapSet.new()}, fn name, {acc, done} ->
@@ -494,11 +468,8 @@ defmodule Schooner.Library.Loader do
     rendered = Library.render_name(name)
 
     case Map.fetch(by_name, name) do
-      {:ok, {_datum, pos_tree}} ->
-        "#{rendered} (#{format_position(ctx, pos_tree)})"
-
-      :error ->
-        rendered
+      {:ok, {_datum, pos_tree}} -> "#{rendered} (#{format_position(ctx, pos_tree)})"
+      :error -> rendered
     end
   end
 
@@ -524,16 +495,11 @@ defmodule Schooner.Library.Loader do
     paths
     |> Value.to_list()
     |> Enum.flat_map(fn path_datum ->
-      # Topological pre-pass cannot easily quote individual sub-positions
-      # because positions for path datums are not threaded here; surface a
-      # generic error if the path is not a string.
-      path = expect_string(path_datum, "include-library-declarations", :unknown, ctx)
-      resolved = resolve_include_path(path, ctx, :unknown)
+      path = expect_string(path_datum, "include-library-declarations", nil, ctx)
+      resolved = resolve_include_path(path, ctx, nil)
       inner_ctx = %{ctx | base_dir: Path.dirname(resolved), path: resolved}
-
-      resolved
-      |> read_datums(path, :unknown, ctx)
-      |> Enum.flat_map(&decl_imports(&1, inner_ctx))
+      {datums, _} = read_include_file(resolved, path, nil, ctx, false)
+      Enum.flat_map(datums, &decl_imports(&1, inner_ctx))
     end)
   end
 
@@ -548,88 +514,37 @@ defmodule Schooner.Library.Loader do
 
   defp spec_to_canonical_dependency(name_datum), do: Library.canonicalise_name(name_datum)
 
-  # Position-tree extractors. Each takes the position tree of a list
-  # whose datum is `(head item1 item2 ...)` and returns the trees of
-  # the items, skipping the head symbol.
-  defp decl_position_trees(pos_tree) do
-    case Reader.list_positions(pos_tree) do
-      [_head, _name | decls] -> decls
-      _ -> []
-    end
+  # Drop the first `n` elements of a list-shaped position tree, returning
+  # the trees of the remaining elements. Atom-shaped trees (improper or
+  # already-empty spines) yield `[]`.
+  defp tail_positions(pos_tree, n) do
+    pos_tree |> Reader.list_positions() |> Enum.drop(n)
+  rescue
+    ArgumentError -> []
   end
 
-  defp export_entry_positions(pos_tree) do
-    case Reader.list_positions(pos_tree) do
-      [_head | entries] -> entries
-      _ -> []
-    end
-  end
-
-  defp include_path_positions(pos_tree) do
-    case Reader.list_positions(pos_tree) do
-      [_head | paths] -> paths
-      _ -> []
-    end
-  end
-
-  defp cond_expand_clause_positions(pos_tree) do
-    case Reader.list_positions(pos_tree) do
-      [_head | clauses] -> clauses
-      _ -> []
-    end
-  end
-
-  defp cond_expand_body_positions(clause_pos) do
-    case Reader.list_positions(clause_pos) do
-      [_requirement | body] -> body
-      _ -> []
-    end
-  end
-
-  defp clause_requirement_position(clause_pos) do
-    case Reader.list_positions(clause_pos) do
-      [requirement | _] -> requirement
-      _ -> clause_pos
-    end
-  end
-
-  defp combinator_argument_positions(pos_tree) do
-    case Reader.list_positions(pos_tree) do
-      [_head | args] -> args
-      _ -> []
-    end
-  end
-
-  # When `compile/3` is called directly with a raw datum (no reader
-  # positions), synthesise a placeholder tree so the recursive walker
-  # has a uniform shape. Synthesised positions render as `?:?`.
-  defp synthetic_pos_tree(:null), do: {:atom, :unknown}
+  # Build a synthetic position tree mirroring `datum`'s spine with `nil`
+  # in every position slot. Used when `compile/3` is called directly
+  # without a positioned tree from the reader: callers can still walk
+  # the parallel structure, and diagnostics simply omit line/column.
+  defp synthetic_pos_tree(:null), do: {:atom, nil}
 
   defp synthetic_pos_tree({:pair, car, cdr}),
-    do: {:pair, :unknown, synthetic_pos_tree(car), synthetic_pos_tree(cdr)}
+    do: {:pair, nil, synthetic_pos_tree(car), synthetic_pos_tree(cdr)}
 
   defp synthetic_pos_tree({:vector, t}) do
-    items =
-      0..(tuple_size(t) - 1)//1
-      |> Enum.map(fn i -> synthetic_pos_tree(elem(t, i)) end)
-
-    {:vector, :unknown, items}
+    items = for i <- 0..(tuple_size(t) - 1)//1, do: synthetic_pos_tree(elem(t, i))
+    {:vector, nil, items}
   end
 
-  defp synthetic_pos_tree(_other), do: {:atom, :unknown}
+  defp synthetic_pos_tree(_other), do: {:atom, nil}
 
   defp default_ctx, do: %{base_dir: nil, root_dir: nil, path: nil}
 
   defp library_source(%{path: nil}, _pos_tree, _datum), do: :native
 
-  defp library_source(%{path: path}, pos_tree, _datum) do
-    {:file, path, position_or_unknown(pos_tree)}
-  end
-
-  defp position_or_unknown({:atom, pos}), do: pos
-  defp position_or_unknown({:pair, pos, _, _}), do: pos
-  defp position_or_unknown({:vector, pos, _}), do: pos
-  defp position_or_unknown({:bytevector, pos}), do: pos
+  defp library_source(%{path: path}, pos_tree, _datum),
+    do: {:file, path, Reader.position_of(pos_tree)}
 
   # ---------------------------------------------------------------------------
   # Diagnostic formatting
@@ -642,25 +557,14 @@ defmodule Schooner.Library.Loader do
     end
   end
 
-  defp format_position(ctx, pos_tree) do
-    {line, col} = pos_or_unknown_pair(pos_tree)
-    path = ctx[:path] || ctx.path
+  defp format_position(ctx, nil), do: ctx.path || ""
 
-    case {path, line, col} do
-      {nil, :unknown, :unknown} -> ""
-      {nil, l, c} -> "line #{l}, column #{c}"
-      {p, :unknown, :unknown} -> p
-      {p, l, c} -> "#{p}:#{l}:#{c}"
+  defp format_position(ctx, pos_tree) do
+    case {ctx.path, Reader.position_of(pos_tree)} do
+      {nil, nil} -> ""
+      {path, nil} -> path
+      {nil, {line, col}} -> "line #{line}, column #{col}"
+      {path, {line, col}} -> "#{path}:#{line}:#{col}"
     end
   end
-
-  defp pos_or_unknown_pair(:unknown), do: {:unknown, :unknown}
-  defp pos_or_unknown_pair({:atom, :unknown}), do: {:unknown, :unknown}
-  defp pos_or_unknown_pair({:atom, {l, c}}), do: {l, c}
-  defp pos_or_unknown_pair({:pair, :unknown, _, _}), do: {:unknown, :unknown}
-  defp pos_or_unknown_pair({:pair, {l, c}, _, _}), do: {l, c}
-  defp pos_or_unknown_pair({:vector, :unknown, _}), do: {:unknown, :unknown}
-  defp pos_or_unknown_pair({:vector, {l, c}, _}), do: {l, c}
-  defp pos_or_unknown_pair({:bytevector, :unknown}), do: {:unknown, :unknown}
-  defp pos_or_unknown_pair({:bytevector, {l, c}}), do: {l, c}
 end

--- a/lib/schooner/library/loader.ex
+++ b/lib/schooner/library/loader.ex
@@ -28,6 +28,13 @@ defmodule Schooner.Library.Loader do
   Relative include paths that resolve outside the entry-point's
   directory are rejected; absolute paths are likewise rejected unless
   they fall inside the entry-point's directory.
+
+  ## Diagnostics
+
+  Errors raised by the loader quote the file path and `line:column` of
+  the offending source datum where the reader can supply one. Libraries
+  loaded from disk record their origin in the `:source` field as
+  `{:file, path, {line, column}}`.
   """
 
   alias Schooner.Env
@@ -42,28 +49,41 @@ defmodule Schooner.Library.Loader do
   @schooner_features [:r7rs]
 
   @typedoc "Path-resolution context threaded through declaration processing."
-  @type ctx :: %{base_dir: binary() | nil, root_dir: binary() | nil}
+  @type ctx :: %{
+          base_dir: binary() | nil,
+          root_dir: binary() | nil,
+          path: binary() | nil
+        }
 
   @doc """
   Compile a single `(define-library ...)` datum against `registry`.
   Returns a `%Schooner.Library{}` ready for `Library.register/2`.
 
-  `ctx` carries the directory used to resolve relative include paths.
+  `ctx` carries the directory used to resolve relative include paths
+  and the path threaded into diagnostics.
   """
   @spec compile(Value.t(), Library.registry(), ctx()) :: Library.t()
-  def compile(datum, registry, ctx \\ %{base_dir: nil, root_dir: nil})
+  def compile(datum, registry, ctx \\ default_ctx()) do
+    pos_tree = synthetic_pos_tree(datum)
+    compile_positioned(datum, pos_tree, registry, ctx)
+  end
 
-  def compile(
-        {:pair, {:sym, "define-library"}, {:pair, name_datum, decls_list}},
-        registry,
-        ctx
-      ) do
+  defp compile_positioned(
+         {:pair, {:sym, "define-library"}, {:pair, name_datum, decls_list}} = datum,
+         pos_tree,
+         registry,
+         ctx
+       ) do
     name = Library.canonicalise_name(name_datum)
     decls = Value.to_list(decls_list)
+    decl_positions = decl_position_trees(pos_tree)
 
     parts =
-      Enum.reduce(decls, %{imports: [], body: [], exports: [], features: []}, fn decl, acc ->
-        apply_decl(decl, acc, registry, ctx)
+      decls
+      |> Enum.zip(decl_positions)
+      |> Enum.reduce(%{imports: [], body: [], exports: [], export_positions: [], features: []}, fn
+        {decl, decl_pos}, acc ->
+          apply_decl(decl, decl_pos, acc, registry, ctx)
       end)
 
     binding_set = LibImport.resolve(parts.imports, registry)
@@ -76,17 +96,19 @@ defmodule Schooner.Library.Loader do
 
     Enum.each(expanded, fn form -> Eval.eval(form, env) end)
 
-    library_exports = build_exports(parts.exports, env, post_syntax_env, name)
+    library_exports =
+      build_exports(parts.exports, parts.export_positions, env, post_syntax_env, name, ctx)
 
     Library.new(
       name: name,
       exports: library_exports,
       imports: Enum.map(parts.imports, &spec_to_canonical_dependency/1),
-      features: Enum.uniq(parts.features ++ @schooner_features)
+      features: Enum.uniq(parts.features ++ @schooner_features),
+      source: library_source(ctx, pos_tree, datum)
     )
   end
 
-  def compile(other, _registry, _ctx) do
+  defp compile_positioned(other, _pos_tree, _registry, _ctx) do
     raise ArgumentError, "expected a (define-library ...) datum, got #{inspect(other)}"
   end
 
@@ -103,8 +125,9 @@ defmodule Schooner.Library.Loader do
   """
   @spec load_file(binary(), Library.registry()) :: Library.registry()
   def load_file(path, registry \\ Library.standard()) when is_binary(path) do
-    source = File.read!(path)
-    load_string(source, registry, base_dir: Path.dirname(Path.expand(path)))
+    abs_path = Path.expand(path)
+    source = File.read!(abs_path)
+    load_string(source, registry, base_dir: Path.dirname(abs_path), path: abs_path)
   end
 
   @doc """
@@ -115,6 +138,8 @@ defmodule Schooner.Library.Loader do
     * `:base_dir` — directory used to resolve relative `(include …)` and
       `(include-library-declarations …)` paths. Defaults to `nil`,
       which makes relative includes an error.
+    * `:path` — file path threaded into diagnostics. Defaults to `nil`
+      (anonymous source).
   """
   @spec load_string(binary(), Library.registry(), keyword()) :: Library.registry()
   def load_string(source, registry \\ Library.standard(), opts \\ [])
@@ -125,20 +150,26 @@ defmodule Schooner.Library.Loader do
         dir when is_binary(dir) -> Path.expand(dir)
       end
 
-    ctx = %{base_dir: base_dir, root_dir: base_dir}
+    path = Keyword.get(opts, :path)
 
-    datums = Reader.read_string(source)
+    ctx = %{base_dir: base_dir, root_dir: base_dir, path: path}
+
+    positioned = Reader.read_string_positioned(source)
 
     libs =
-      Enum.map(datums, fn
-        {:pair, {:sym, "define-library"}, _} = d -> d
-        other -> raise ArgumentError, "expected (define-library ...), got #{inspect(other)}"
+      Enum.map(positioned, fn
+        {{:pair, {:sym, "define-library"}, _} = d, p} ->
+          {d, p}
+
+        {other, p} ->
+          raise ArgumentError,
+                "#{format_at(ctx, p)}expected (define-library ...), got #{inspect(other)}"
       end)
 
     ordered = topological_order!(libs, ctx)
 
-    Enum.reduce(ordered, registry, fn datum, reg ->
-      Library.register(reg, compile(datum, reg, ctx))
+    Enum.reduce(ordered, registry, fn {datum, pos_tree}, reg ->
+      Library.register(reg, compile_positioned(datum, pos_tree, reg, ctx))
     end)
   end
 
@@ -146,36 +177,52 @@ defmodule Schooner.Library.Loader do
   # Declarations
   # ---------------------------------------------------------------------------
 
-  defp apply_decl({:pair, {:sym, "import"}, specs}, acc, _registry, _ctx) do
+  defp apply_decl({:pair, {:sym, "import"}, specs}, _pos, acc, _registry, _ctx) do
     %{acc | imports: acc.imports ++ Value.to_list(specs)}
   end
 
-  defp apply_decl({:pair, {:sym, "begin"}, forms}, acc, _registry, _ctx) do
+  defp apply_decl({:pair, {:sym, "begin"}, forms}, _pos, acc, _registry, _ctx) do
     %{acc | body: acc.body ++ Value.to_list(forms)}
   end
 
-  defp apply_decl({:pair, {:sym, "export"}, names}, acc, _registry, _ctx) do
-    %{acc | exports: acc.exports ++ Value.to_list(names)}
+  defp apply_decl({:pair, {:sym, "export"}, names}, pos_tree, acc, _registry, _ctx) do
+    name_positions = export_entry_positions(pos_tree)
+
+    %{
+      acc
+      | exports: acc.exports ++ Value.to_list(names),
+        export_positions: acc.export_positions ++ name_positions
+    }
   end
 
-  defp apply_decl({:pair, {:sym, "cond-expand"}, clauses}, acc, registry, ctx) do
-    case select_cond_expand(Value.to_list(clauses), registry) do
-      {:ok, sub_decls} ->
-        Enum.reduce(sub_decls, acc, &apply_decl(&1, &2, registry, ctx))
+  defp apply_decl({:pair, {:sym, "cond-expand"}, clauses}, pos_tree, acc, registry, ctx) do
+    clauses_list = Value.to_list(clauses)
+    clause_positions = cond_expand_clause_positions(pos_tree)
+
+    case select_cond_expand(clauses_list, clause_positions, registry, ctx) do
+      {:ok, sub_decls, sub_positions} ->
+        sub_decls
+        |> Enum.zip(sub_positions)
+        |> Enum.reduce(acc, fn {decl, p}, acc ->
+          apply_decl(decl, p, acc, registry, ctx)
+        end)
 
       :no_match ->
         acc
     end
   end
 
-  defp apply_decl({:pair, {:sym, "include"}, paths}, acc, _registry, ctx) do
+  defp apply_decl({:pair, {:sym, "include"}, paths}, pos_tree, acc, _registry, ctx) do
+    path_positions = include_path_positions(pos_tree)
+
     forms =
       paths
       |> Value.to_list()
-      |> Enum.flat_map(fn path_datum ->
-        path = expect_string(path_datum, "include")
-        resolved = resolve_include_path(path, ctx)
-        read_datums(resolved, path)
+      |> Enum.zip(path_positions)
+      |> Enum.flat_map(fn {path_datum, path_pos} ->
+        path = expect_string(path_datum, "include", path_pos, ctx)
+        resolved = resolve_include_path(path, ctx, path_pos)
+        read_datums(resolved, path, path_pos, ctx)
       end)
 
     %{acc | body: acc.body ++ forms}
@@ -183,69 +230,101 @@ defmodule Schooner.Library.Loader do
 
   defp apply_decl(
          {:pair, {:sym, "include-library-declarations"}, paths},
+         pos_tree,
          acc,
          registry,
          ctx
        ) do
+    path_positions = include_path_positions(pos_tree)
+
     paths
     |> Value.to_list()
-    |> Enum.reduce(acc, fn path_datum, acc ->
-      path = expect_string(path_datum, "include-library-declarations")
-      resolved = resolve_include_path(path, ctx)
-      decls = read_datums(resolved, path)
-      inner_ctx = %{ctx | base_dir: Path.dirname(resolved)}
-      Enum.reduce(decls, acc, &apply_decl(&1, &2, registry, inner_ctx))
+    |> Enum.zip(path_positions)
+    |> Enum.reduce(acc, fn {path_datum, path_pos}, acc ->
+      path = expect_string(path_datum, "include-library-declarations", path_pos, ctx)
+      resolved = resolve_include_path(path, ctx, path_pos)
+
+      {decls, decl_positions} =
+        read_positioned_datums(resolved, path, path_pos, ctx)
+
+      inner_ctx = %{ctx | base_dir: Path.dirname(resolved), path: resolved}
+
+      decls
+      |> Enum.zip(decl_positions)
+      |> Enum.reduce(acc, fn {decl, p}, acc ->
+        apply_decl(decl, p, acc, registry, inner_ctx)
+      end)
     end)
   end
 
-  defp apply_decl(other, _acc, _registry, _ctx) do
-    raise ArgumentError, "unsupported define-library declaration: #{inspect(other)}"
+  defp apply_decl(other, pos_tree, _acc, _registry, ctx) do
+    raise ArgumentError,
+          "#{format_at(ctx, pos_tree)}unsupported define-library declaration: #{inspect(other)}"
   end
 
   # ---------------------------------------------------------------------------
   # Include path resolution
   # ---------------------------------------------------------------------------
 
-  defp expect_string({:string, s}, _form), do: s
+  defp expect_string({:string, s}, _form, _pos, _ctx), do: s
 
-  defp expect_string(other, form) do
-    raise ArgumentError, "(#{form} ...) expected string path, got #{inspect(other)}"
+  defp expect_string(other, form, pos, ctx) do
+    raise ArgumentError,
+          "#{format_at(ctx, pos)}(#{form} ...) expected string path, got #{inspect(other)}"
   end
 
-  defp resolve_include_path(path, %{base_dir: base_dir, root_dir: root_dir}) do
+  defp resolve_include_path(path, ctx, pos) do
+    %{base_dir: base_dir, root_dir: root_dir} = ctx
+
     cond do
       Path.type(path) == :absolute ->
-        check_within_root(Path.expand(path), path, root_dir)
+        check_within_root(Path.expand(path), path, root_dir, ctx, pos)
 
       base_dir == nil ->
         raise ArgumentError,
-              "cannot resolve relative include path #{inspect(path)} without a base directory; " <>
-                "load via Loader.load_file/2 or pass `:base_dir` to Loader.load_string/3"
+              "#{format_at(ctx, pos)}cannot resolve relative include path #{inspect(path)} " <>
+                "without a base directory; load via Loader.load_file/2 or pass `:base_dir` " <>
+                "to Loader.load_string/3"
 
       true ->
-        check_within_root(Path.expand(path, base_dir), path, root_dir)
+        check_within_root(Path.expand(path, base_dir), path, root_dir, ctx, pos)
     end
   end
 
-  defp check_within_root(resolved, _original, nil), do: resolved
+  defp check_within_root(resolved, _original, nil, _ctx, _pos), do: resolved
 
-  defp check_within_root(resolved, original, root_dir) do
+  defp check_within_root(resolved, original, root_dir, ctx, pos) do
     if resolved == root_dir or String.starts_with?(resolved, root_dir <> "/") do
       resolved
     else
       raise ArgumentError,
-            "include path #{inspect(original)} resolves outside the library root directory"
+            "#{format_at(ctx, pos)}include path #{inspect(original)} resolves outside the " <>
+              "library root directory"
     end
   end
 
-  defp read_datums(resolved, original) do
+  defp read_datums(resolved, original, pos, ctx) do
     case File.read(resolved) do
       {:ok, source} ->
         Reader.read_string(source)
 
       {:error, reason} ->
         raise ArgumentError,
-              "could not read include file #{inspect(original)}: #{:file.format_error(reason)}"
+              "#{format_at(ctx, pos)}could not read include file #{inspect(original)}: " <>
+                List.to_string(:file.format_error(reason))
+    end
+  end
+
+  defp read_positioned_datums(resolved, original, pos, ctx) do
+    case File.read(resolved) do
+      {:ok, source} ->
+        positioned = Reader.read_string_positioned(source)
+        {Enum.map(positioned, &elem(&1, 0)), Enum.map(positioned, &elem(&1, 1))}
+
+      {:error, reason} ->
+        raise ArgumentError,
+              "#{format_at(ctx, pos)}could not read include file #{inspect(original)}: " <>
+                List.to_string(:file.format_error(reason))
     end
   end
 
@@ -253,50 +332,70 @@ defmodule Schooner.Library.Loader do
   # cond-expand
   # ---------------------------------------------------------------------------
 
-  defp select_cond_expand([], _registry), do: :no_match
+  defp select_cond_expand([], [], _registry, _ctx), do: :no_match
 
   defp select_cond_expand(
          [{:pair, {:sym, "else"}, body} | _],
-         _registry
+         [body_clause_pos | _],
+         _registry,
+         _ctx
        ) do
-    {:ok, Value.to_list(body)}
+    {:ok, Value.to_list(body), cond_expand_body_positions(body_clause_pos)}
   end
 
-  defp select_cond_expand([{:pair, requirement, body} | rest], registry) do
-    if requirement_satisfied?(requirement, registry) do
-      {:ok, Value.to_list(body)}
+  defp select_cond_expand(
+         [{:pair, requirement, body} | rest],
+         [clause_pos | rest_positions],
+         registry,
+         ctx
+       ) do
+    requirement_pos = clause_requirement_position(clause_pos)
+
+    if requirement_satisfied?(requirement, requirement_pos, registry, ctx) do
+      {:ok, Value.to_list(body), cond_expand_body_positions(clause_pos)}
     else
-      select_cond_expand(rest, registry)
+      select_cond_expand(rest, rest_positions, registry, ctx)
     end
   end
 
-  defp requirement_satisfied?({:sym, name}, _registry), do: feature_present?(name)
+  defp requirement_satisfied?({:sym, name}, _pos, _registry, _ctx), do: feature_present?(name)
 
   defp requirement_satisfied?(
          {:pair, {:sym, "library"}, {:pair, lib_name_datum, :null}},
-         registry
+         _pos,
+         registry,
+         _ctx
        ) do
     match?({:ok, _}, Library.lookup(registry, Library.canonicalise_name(lib_name_datum)))
   end
 
-  defp requirement_satisfied?({:pair, {:sym, "and"}, body}, registry) do
+  defp requirement_satisfied?({:pair, {:sym, "and"}, body}, pos, registry, ctx) do
     body
     |> Value.to_list()
-    |> Enum.all?(&requirement_satisfied?(&1, registry))
+    |> Enum.zip(combinator_argument_positions(pos))
+    |> Enum.all?(fn {req, p} -> requirement_satisfied?(req, p, registry, ctx) end)
   end
 
-  defp requirement_satisfied?({:pair, {:sym, "or"}, body}, registry) do
+  defp requirement_satisfied?({:pair, {:sym, "or"}, body}, pos, registry, ctx) do
     body
     |> Value.to_list()
-    |> Enum.any?(&requirement_satisfied?(&1, registry))
+    |> Enum.zip(combinator_argument_positions(pos))
+    |> Enum.any?(fn {req, p} -> requirement_satisfied?(req, p, registry, ctx) end)
   end
 
-  defp requirement_satisfied?({:pair, {:sym, "not"}, {:pair, inner, :null}}, registry) do
-    not requirement_satisfied?(inner, registry)
+  defp requirement_satisfied?(
+         {:pair, {:sym, "not"}, {:pair, inner, :null}},
+         pos,
+         registry,
+         ctx
+       ) do
+    [inner_pos] = combinator_argument_positions(pos)
+    not requirement_satisfied?(inner, inner_pos, registry, ctx)
   end
 
-  defp requirement_satisfied?(other, _registry) do
-    raise ArgumentError, "invalid cond-expand requirement: #{inspect(other)}"
+  defp requirement_satisfied?(other, pos, _registry, ctx) do
+    raise ArgumentError,
+          "#{format_at(ctx, pos)}invalid cond-expand requirement: #{inspect(other)}"
   end
 
   defp feature_present?(name) do
@@ -307,26 +406,30 @@ defmodule Schooner.Library.Loader do
   # Exports
   # ---------------------------------------------------------------------------
 
-  defp build_exports(export_decls, env, syntax_env, lib_name) do
-    Enum.reduce(export_decls, %{}, fn decl, acc ->
-      {internal, external} = parse_export_entry(decl)
-      Map.put(acc, external, freeze_one(internal, env, syntax_env, lib_name))
+  defp build_exports(export_decls, export_positions, env, syntax_env, lib_name, ctx) do
+    export_decls
+    |> Enum.zip(export_positions)
+    |> Enum.reduce(%{}, fn {decl, decl_pos}, acc ->
+      {internal, external} = parse_export_entry(decl, decl_pos, ctx)
+      Map.put(acc, external, freeze_one(internal, env, syntax_env, lib_name, decl_pos, ctx))
     end)
   end
 
-  defp parse_export_entry({:sym, name}), do: {name, name}
+  defp parse_export_entry({:sym, name}, _pos, _ctx), do: {name, name}
 
   defp parse_export_entry(
-         {:pair, {:sym, "rename"}, {:pair, {:sym, internal}, {:pair, {:sym, external}, :null}}}
+         {:pair, {:sym, "rename"}, {:pair, {:sym, internal}, {:pair, {:sym, external}, :null}}},
+         _pos,
+         _ctx
        ) do
     {internal, external}
   end
 
-  defp parse_export_entry(other) do
-    raise ArgumentError, "invalid export entry: #{inspect(other)}"
+  defp parse_export_entry(other, pos, ctx) do
+    raise ArgumentError, "#{format_at(ctx, pos)}invalid export entry: #{inspect(other)}"
   end
 
-  defp freeze_one(name, env, syntax_env, lib_name) do
+  defp freeze_one(name, env, syntax_env, lib_name, pos, ctx) do
     case SyntaxEnv.lookup(syntax_env, name) do
       {:macro, transformer} ->
         {:macro, transformer}
@@ -338,7 +441,8 @@ defmodule Schooner.Library.Loader do
 
           _ ->
             raise ArgumentError,
-                  "library #{Library.render_name(lib_name)} exports #{name} but no binding for it was defined"
+                  "#{format_at(ctx, pos)}library #{Library.render_name(lib_name)} exports " <>
+                    "#{name} but no binding for it was defined"
         end
     end
   end
@@ -347,40 +451,59 @@ defmodule Schooner.Library.Loader do
   # Topological order over file-local libraries
   # ---------------------------------------------------------------------------
 
-  defp topological_order!(datums, ctx) do
-    by_name = Map.new(datums, fn d -> {extract_name(d), d} end)
-    deps = Map.new(datums, fn d -> {extract_name(d), local_deps(d, by_name, ctx)} end)
+  defp topological_order!(libs, ctx) do
+    by_name =
+      Map.new(libs, fn {datum, pos_tree} -> {extract_name(datum), {datum, pos_tree}} end)
+
+    deps =
+      Map.new(libs, fn {datum, _pos} ->
+        {extract_name(datum), local_deps(datum, by_name, ctx)}
+      end)
 
     {ordered, _done} =
       Enum.reduce(Map.keys(deps), {[], MapSet.new()}, fn name, {acc, done} ->
-        visit_topo(name, deps, done, [], acc)
+        visit_topo(name, deps, by_name, done, [], acc, ctx)
       end)
 
     Enum.map(Enum.reverse(ordered), &Map.fetch!(by_name, &1))
   end
 
-  defp visit_topo(name, deps, done, stack, acc) do
+  defp visit_topo(name, deps, by_name, done, stack, acc, ctx) do
     cond do
       MapSet.member?(done, name) ->
         {acc, done}
 
       name in stack ->
+        cycle = Enum.reverse([name | stack])
+
         raise ArgumentError,
               "cycle in define-library dependencies: " <>
-                Enum.map_join(Enum.reverse([name | stack]), " -> ", &Library.render_name/1)
+                Enum.map_join(cycle, " -> ", &render_cycle_entry(&1, by_name, ctx))
 
       true ->
         {acc, done} =
           Enum.reduce(Map.fetch!(deps, name), {acc, done}, fn dep, {acc, done} ->
-            visit_topo(dep, deps, done, [name | stack], acc)
+            visit_topo(dep, deps, by_name, done, [name | stack], acc, ctx)
           end)
 
         {[name | acc], MapSet.put(done, name)}
     end
   end
 
+  defp render_cycle_entry(name, by_name, ctx) do
+    rendered = Library.render_name(name)
+
+    case Map.fetch(by_name, name) do
+      {:ok, {_datum, pos_tree}} ->
+        "#{rendered} (#{format_position(ctx, pos_tree)})"
+
+      :error ->
+        rendered
+    end
+  end
+
   # ---------------------------------------------------------------------------
-  # Datum helpers
+  # Datum / position helpers
   # ---------------------------------------------------------------------------
 
   defp extract_name({:pair, {:sym, "define-library"}, {:pair, name_datum, _}}) do
@@ -401,12 +524,15 @@ defmodule Schooner.Library.Loader do
     paths
     |> Value.to_list()
     |> Enum.flat_map(fn path_datum ->
-      path = expect_string(path_datum, "include-library-declarations")
-      resolved = resolve_include_path(path, ctx)
-      inner_ctx = %{ctx | base_dir: Path.dirname(resolved)}
+      # Topological pre-pass cannot easily quote individual sub-positions
+      # because positions for path datums are not threaded here; surface a
+      # generic error if the path is not a string.
+      path = expect_string(path_datum, "include-library-declarations", :unknown, ctx)
+      resolved = resolve_include_path(path, ctx, :unknown)
+      inner_ctx = %{ctx | base_dir: Path.dirname(resolved), path: resolved}
 
       resolved
-      |> read_datums(path)
+      |> read_datums(path, :unknown, ctx)
       |> Enum.flat_map(&decl_imports(&1, inner_ctx))
     end)
   end
@@ -421,4 +547,120 @@ defmodule Schooner.Library.Loader do
   end
 
   defp spec_to_canonical_dependency(name_datum), do: Library.canonicalise_name(name_datum)
+
+  # Position-tree extractors. Each takes the position tree of a list
+  # whose datum is `(head item1 item2 ...)` and returns the trees of
+  # the items, skipping the head symbol.
+  defp decl_position_trees(pos_tree) do
+    case Reader.list_positions(pos_tree) do
+      [_head, _name | decls] -> decls
+      _ -> []
+    end
+  end
+
+  defp export_entry_positions(pos_tree) do
+    case Reader.list_positions(pos_tree) do
+      [_head | entries] -> entries
+      _ -> []
+    end
+  end
+
+  defp include_path_positions(pos_tree) do
+    case Reader.list_positions(pos_tree) do
+      [_head | paths] -> paths
+      _ -> []
+    end
+  end
+
+  defp cond_expand_clause_positions(pos_tree) do
+    case Reader.list_positions(pos_tree) do
+      [_head | clauses] -> clauses
+      _ -> []
+    end
+  end
+
+  defp cond_expand_body_positions(clause_pos) do
+    case Reader.list_positions(clause_pos) do
+      [_requirement | body] -> body
+      _ -> []
+    end
+  end
+
+  defp clause_requirement_position(clause_pos) do
+    case Reader.list_positions(clause_pos) do
+      [requirement | _] -> requirement
+      _ -> clause_pos
+    end
+  end
+
+  defp combinator_argument_positions(pos_tree) do
+    case Reader.list_positions(pos_tree) do
+      [_head | args] -> args
+      _ -> []
+    end
+  end
+
+  # When `compile/3` is called directly with a raw datum (no reader
+  # positions), synthesise a placeholder tree so the recursive walker
+  # has a uniform shape. Synthesised positions render as `?:?`.
+  defp synthetic_pos_tree(:null), do: {:atom, :unknown}
+
+  defp synthetic_pos_tree({:pair, car, cdr}),
+    do: {:pair, :unknown, synthetic_pos_tree(car), synthetic_pos_tree(cdr)}
+
+  defp synthetic_pos_tree({:vector, t}) do
+    items =
+      0..(tuple_size(t) - 1)//1
+      |> Enum.map(fn i -> synthetic_pos_tree(elem(t, i)) end)
+
+    {:vector, :unknown, items}
+  end
+
+  defp synthetic_pos_tree(_other), do: {:atom, :unknown}
+
+  defp default_ctx, do: %{base_dir: nil, root_dir: nil, path: nil}
+
+  defp library_source(%{path: nil}, _pos_tree, _datum), do: :native
+
+  defp library_source(%{path: path}, pos_tree, _datum) do
+    {:file, path, position_or_unknown(pos_tree)}
+  end
+
+  defp position_or_unknown({:atom, pos}), do: pos
+  defp position_or_unknown({:pair, pos, _, _}), do: pos
+  defp position_or_unknown({:vector, pos, _}), do: pos
+  defp position_or_unknown({:bytevector, pos}), do: pos
+
+  # ---------------------------------------------------------------------------
+  # Diagnostic formatting
+  # ---------------------------------------------------------------------------
+
+  defp format_at(ctx, pos_tree) do
+    case format_position(ctx, pos_tree) do
+      "" -> ""
+      formatted -> "#{formatted}: "
+    end
+  end
+
+  defp format_position(ctx, pos_tree) do
+    {line, col} = pos_or_unknown_pair(pos_tree)
+    path = ctx[:path] || ctx.path
+
+    case {path, line, col} do
+      {nil, :unknown, :unknown} -> ""
+      {nil, l, c} -> "line #{l}, column #{c}"
+      {p, :unknown, :unknown} -> p
+      {p, l, c} -> "#{p}:#{l}:#{c}"
+    end
+  end
+
+  defp pos_or_unknown_pair(:unknown), do: {:unknown, :unknown}
+  defp pos_or_unknown_pair({:atom, :unknown}), do: {:unknown, :unknown}
+  defp pos_or_unknown_pair({:atom, {l, c}}), do: {l, c}
+  defp pos_or_unknown_pair({:pair, :unknown, _, _}), do: {:unknown, :unknown}
+  defp pos_or_unknown_pair({:pair, {l, c}, _, _}), do: {l, c}
+  defp pos_or_unknown_pair({:vector, :unknown, _}), do: {:unknown, :unknown}
+  defp pos_or_unknown_pair({:vector, {l, c}, _}), do: {l, c}
+  defp pos_or_unknown_pair({:bytevector, :unknown}), do: {:unknown, :unknown}
+  defp pos_or_unknown_pair({:bytevector, {l, c}}), do: {l, c}
 end

--- a/lib/schooner/reader.ex
+++ b/lib/schooner/reader.ex
@@ -18,11 +18,36 @@ defmodule Schooner.Reader do
   Errors are raised as `Schooner.Reader.Error` with a structured reason
   and source position so downstream tooling can quote the offending input
   back to the user.
+
+  ## Positioned output
+
+  `read_string_positioned/1` returns each top-level datum paired with a
+  parallel "position tree" mirroring the datum's spine. Each position
+  tree node carries the `{line, column}` of the datum's first token.
+  Use the helpers `position_of/1`, `list_positions/1` and
+  `vector_positions/1` to walk the tree alongside the datum.
   """
 
   alias Schooner.Lexer
   alias Schooner.Reader.Error
   alias Schooner.Value
+
+  @typedoc """
+  A position tree mirrors the spine of a datum.
+
+    * `{:atom, pos}` — non-compound datum (symbol, number, string, char,
+      bool, `:null`, etc.) or the terminating `:null` of a proper list.
+    * `{:pair, pos, car_tree, cdr_tree}` — cons cell. `pos` is the
+      position of the opening `(` of the surrounding list.
+    * `{:vector, pos, [item_tree]}` — `#(...)` literal.
+    * `{:bytevector, pos}` — `#u8(...)` literal; bytes are atoms with no
+      individual sub-trees.
+  """
+  @type pos_tree ::
+          {:atom, Lexer.position()}
+          | {:pair, Lexer.position(), pos_tree(), pos_tree()}
+          | {:vector, Lexer.position(), [pos_tree()]}
+          | {:bytevector, Lexer.position()}
 
   @doc "Read a binary of source into a list of top-level datums."
   @spec read_string(binary()) :: [Value.t()]
@@ -33,7 +58,52 @@ defmodule Schooner.Reader do
   @doc "Read a list of lexer tokens into a list of top-level datums."
   @spec read_tokens([Lexer.token()]) :: [Value.t()]
   def read_tokens(tokens) when is_list(tokens) do
-    do_read_all(tokens, [])
+    tokens |> do_read_all([]) |> Enum.map(fn {datum, _pos} -> datum end)
+  end
+
+  @doc """
+  Read a binary of source into a list of `{datum, pos_tree}` pairs, one
+  per top-level datum. The position tree mirrors the spine of the datum
+  so callers can quote the source location of any sub-form.
+  """
+  @spec read_string_positioned(binary()) :: [{Value.t(), pos_tree()}]
+  def read_string_positioned(source) when is_binary(source) do
+    source |> Lexer.tokenise() |> do_read_all([])
+  end
+
+  # ---------------------------------------------------------------------------
+  # Position-tree helpers
+  # ---------------------------------------------------------------------------
+
+  @doc "Start position of the datum the position tree describes."
+  @spec position_of(pos_tree()) :: Lexer.position()
+  def position_of({:atom, pos}), do: pos
+  def position_of({:pair, pos, _, _}), do: pos
+  def position_of({:vector, pos, _}), do: pos
+  def position_of({:bytevector, pos}), do: pos
+
+  @doc """
+  Walk a list-shaped position tree into a list of element trees, one per
+  cons cell in the proper-list spine. Mirrors `Schooner.Value.to_list/1`.
+  Raises `ArgumentError` when the tree describes an improper or non-list
+  datum.
+  """
+  @spec list_positions(pos_tree()) :: [pos_tree()]
+  def list_positions({:atom, _}), do: []
+  def list_positions({:pair, _, car, cdr}), do: [car | list_positions(cdr)]
+
+  def list_positions(other) do
+    raise ArgumentError, "expected a list position tree, got #{inspect(other)}"
+  end
+
+  @doc """
+  Element-wise position trees of a vector position tree.
+  """
+  @spec vector_positions(pos_tree()) :: [pos_tree()]
+  def vector_positions({:vector, _, items}), do: items
+
+  def vector_positions(other) do
+    raise ArgumentError, "expected a vector position tree, got #{inspect(other)}"
   end
 
   # ---------------------------------------------------------------------------
@@ -43,7 +113,7 @@ defmodule Schooner.Reader do
   defp do_read_all(tokens, acc) do
     case read_one(tokens) do
       :eof -> Enum.reverse(acc)
-      {:ok, datum, rest} -> do_read_all(rest, [datum | acc])
+      {:ok, datum, pos, rest} -> do_read_all(rest, [{datum, pos} | acc])
     end
   end
 
@@ -56,8 +126,8 @@ defmodule Schooner.Reader do
         :eof
 
       tokens ->
-        {datum, rest} = read_datum(tokens)
-        {:ok, datum, rest}
+        {datum, pos, rest} = read_datum(tokens)
+        {:ok, datum, pos, rest}
     end
   end
 
@@ -68,7 +138,7 @@ defmodule Schooner.Reader do
   defp skip_datum_comments([{:datum_comment, _, pos} | rest]) do
     case read_one(rest) do
       :eof -> raise Error, reason: :datum_comment_at_eof, position: pos
-      {:ok, _skipped, rest} -> skip_datum_comments(rest)
+      {:ok, _skipped, _pos, rest} -> skip_datum_comments(rest)
     end
   end
 
@@ -78,12 +148,12 @@ defmodule Schooner.Reader do
   # Single-datum dispatch
   # ---------------------------------------------------------------------------
 
-  defp read_datum([{:integer, n, _} | rest]), do: {n, rest}
-  defp read_datum([{:float, f, _} | rest]), do: {f, rest}
-  defp read_datum([{:bool, b, _} | rest]), do: {Value.bool(b), rest}
-  defp read_datum([{:string, s, _} | rest]), do: {Value.string(s), rest}
-  defp read_datum([{:char, cp, _} | rest]), do: {Value.char(cp), rest}
-  defp read_datum([{:ident, name, _} | rest]), do: {Value.symbol(name), rest}
+  defp read_datum([{:integer, n, pos} | rest]), do: {n, {:atom, pos}, rest}
+  defp read_datum([{:float, f, pos} | rest]), do: {f, {:atom, pos}, rest}
+  defp read_datum([{:bool, b, pos} | rest]), do: {Value.bool(b), {:atom, pos}, rest}
+  defp read_datum([{:string, s, pos} | rest]), do: {Value.string(s), {:atom, pos}, rest}
+  defp read_datum([{:char, cp, pos} | rest]), do: {Value.char(cp), {:atom, pos}, rest}
+  defp read_datum([{:ident, name, pos} | rest]), do: {Value.symbol(name), {:atom, pos}, rest}
 
   defp read_datum([{:quote, _, pos} | rest]), do: read_quoted("quote", rest, pos)
   defp read_datum([{:quasiquote, _, pos} | rest]), do: read_quoted("quasiquote", rest, pos)
@@ -114,8 +184,13 @@ defmodule Schooner.Reader do
       :eof ->
         raise Error, reason: {:unexpected_eof_after, sym_name}, position: pos
 
-      {:ok, datum, rest} ->
-        {Value.list([Value.symbol(sym_name), datum]), rest}
+      {:ok, datum, inner_pos, rest} ->
+        value = Value.list([Value.symbol(sym_name), datum])
+
+        pos_tree =
+          {:pair, pos, {:atom, pos}, {:pair, pos, inner_pos, {:atom, pos}}}
+
+        {value, pos_tree, rest}
     end
   end
 
@@ -126,7 +201,7 @@ defmodule Schooner.Reader do
   defp read_list(tokens, start) do
     case skip_datum_comments(tokens) do
       [{:rparen, _, _} | rest] ->
-        {:null, rest}
+        {:null, {:atom, start}, rest}
 
       [{:dot, _, pos} | _] ->
         raise Error, reason: :dot_at_list_start, position: pos
@@ -135,29 +210,31 @@ defmodule Schooner.Reader do
         raise Error, reason: :unterminated_list, position: start
 
       tokens ->
-        {datum, rest} = read_datum(tokens)
-        read_list_tail(rest, [datum], start)
+        {datum, datum_pos, rest} = read_datum(tokens)
+        read_list_tail(rest, [datum], [datum_pos], start)
     end
   end
 
-  defp read_list_tail(tokens, acc, start) do
+  defp read_list_tail(tokens, dacc, pacc, start) do
     case skip_datum_comments(tokens) do
       [{:rparen, _, _} | rest] ->
-        {Value.list(Enum.reverse(acc)), rest}
+        datum = Value.list(Enum.reverse(dacc))
+        pos_tree = build_list_pos(Enum.reverse(pacc), {:atom, start}, start)
+        {datum, pos_tree, rest}
 
       [{:dot, _, dot_pos} | rest] ->
-        finish_dotted_list(rest, acc, dot_pos, start)
+        finish_dotted_list(rest, dacc, pacc, dot_pos, start)
 
       [] ->
         raise Error, reason: :unterminated_list, position: start
 
       tokens ->
-        {datum, rest} = read_datum(tokens)
-        read_list_tail(rest, [datum | acc], start)
+        {datum, datum_pos, rest} = read_datum(tokens)
+        read_list_tail(rest, [datum | dacc], [datum_pos | pacc], start)
     end
   end
 
-  defp finish_dotted_list(tokens, acc, dot_pos, start) do
+  defp finish_dotted_list(tokens, dacc, pacc, dot_pos, start) do
     case skip_datum_comments(tokens) do
       [{:rparen, _, _} | _] ->
         raise Error, reason: :missing_tail_after_dot, position: dot_pos
@@ -166,11 +243,13 @@ defmodule Schooner.Reader do
         raise Error, reason: :missing_tail_after_dot, position: dot_pos
 
       tail_tokens ->
-        {tail, rest} = read_datum(tail_tokens)
+        {tail, tail_pos, rest} = read_datum(tail_tokens)
 
         case skip_datum_comments(rest) do
           [{:rparen, _, _} | rest2] ->
-            {Value.improper_list(Enum.reverse(acc), tail), rest2}
+            datum = Value.improper_list(Enum.reverse(dacc), tail)
+            pos_tree = build_list_pos(Enum.reverse(pacc), tail_pos, start)
+            {datum, pos_tree, rest2}
 
           [{_, _, pos} | _] ->
             raise Error, reason: :extra_after_dot, position: pos
@@ -181,16 +260,23 @@ defmodule Schooner.Reader do
     end
   end
 
+  defp build_list_pos([], tail_pos, _start), do: tail_pos
+
+  defp build_list_pos([head | rest], tail_pos, start) do
+    {:pair, start, head, build_list_pos(rest, tail_pos, start)}
+  end
+
   # ---------------------------------------------------------------------------
   # Vectors — `#(...)`
   # ---------------------------------------------------------------------------
 
-  defp read_vector(tokens, start), do: do_read_vector(tokens, [], start)
+  defp read_vector(tokens, start), do: do_read_vector(tokens, [], [], start)
 
-  defp do_read_vector(tokens, acc, start) do
+  defp do_read_vector(tokens, dacc, pacc, start) do
     case skip_datum_comments(tokens) do
       [{:rparen, _, _} | rest] ->
-        {Value.vector(Enum.reverse(acc)), rest}
+        datum = Value.vector(Enum.reverse(dacc))
+        {datum, {:vector, start, Enum.reverse(pacc)}, rest}
 
       [{:dot, _, pos} | _] ->
         raise Error, reason: :dot_in_vector, position: pos
@@ -199,8 +285,8 @@ defmodule Schooner.Reader do
         raise Error, reason: :unterminated_vector, position: start
 
       tokens ->
-        {datum, rest} = read_datum(tokens)
-        do_read_vector(rest, [datum | acc], start)
+        {datum, datum_pos, rest} = read_datum(tokens)
+        do_read_vector(rest, [datum | dacc], [datum_pos | pacc], start)
     end
   end
 
@@ -213,7 +299,7 @@ defmodule Schooner.Reader do
   defp do_read_bytevector(tokens, acc, start) do
     case skip_datum_comments(tokens) do
       [{:rparen, _, _} | rest] ->
-        {Value.bytevector(Enum.reverse(acc)), rest}
+        {Value.bytevector(Enum.reverse(acc)), {:bytevector, start}, rest}
 
       [{:integer, n, pos} | rest] ->
         if n in 0..255 do

--- a/lib/schooner/reader.ex
+++ b/lib/schooner/reader.ex
@@ -24,8 +24,11 @@ defmodule Schooner.Reader do
   `read_string_positioned/1` returns each top-level datum paired with a
   parallel "position tree" mirroring the datum's spine. Each position
   tree node carries the `{line, column}` of the datum's first token.
-  Use the helpers `position_of/1`, `list_positions/1` and
-  `vector_positions/1` to walk the tree alongside the datum.
+  Use the helpers `position_of/1` and `list_positions/1` to walk the
+  tree alongside the datum. The unpositioned `read_string/1` runs a
+  separate fast path that does not allocate the position spine — it is
+  the right choice for hot paths (REPL, `Standard.boot/0`) where
+  positions are unused.
   """
 
   alias Schooner.Lexer
@@ -58,7 +61,7 @@ defmodule Schooner.Reader do
   @doc "Read a list of lexer tokens into a list of top-level datums."
   @spec read_tokens([Lexer.token()]) :: [Value.t()]
   def read_tokens(tokens) when is_list(tokens) do
-    tokens |> do_read_all([]) |> Enum.map(fn {datum, _pos} -> datum end)
+    do_read_all(tokens, [])
   end
 
   @doc """
@@ -68,7 +71,7 @@ defmodule Schooner.Reader do
   """
   @spec read_string_positioned(binary()) :: [{Value.t(), pos_tree()}]
   def read_string_positioned(source) when is_binary(source) do
-    source |> Lexer.tokenise() |> do_read_all([])
+    source |> Lexer.tokenise() |> do_read_all_pos([])
   end
 
   # ---------------------------------------------------------------------------
@@ -96,64 +99,43 @@ defmodule Schooner.Reader do
     raise ArgumentError, "expected a list position tree, got #{inspect(other)}"
   end
 
-  @doc """
-  Element-wise position trees of a vector position tree.
-  """
-  @spec vector_positions(pos_tree()) :: [pos_tree()]
-  def vector_positions({:vector, _, items}), do: items
-
-  def vector_positions(other) do
-    raise ArgumentError, "expected a vector position tree, got #{inspect(other)}"
-  end
-
   # ---------------------------------------------------------------------------
-  # Top-level driver
+  # Unpositioned reader — hot path used by `read_string/1`
   # ---------------------------------------------------------------------------
 
   defp do_read_all(tokens, acc) do
     case read_one(tokens) do
       :eof -> Enum.reverse(acc)
-      {:ok, datum, pos, rest} -> do_read_all(rest, [{datum, pos} | acc])
+      {:ok, datum, rest} -> do_read_all(rest, [datum | acc])
     end
   end
 
-  # `read_one/1` is the only place that yields `:eof`. Every interior context
-  # (inside a list, after a quote marker) treats `:eof` as a structured
-  # error specific to that context.
   defp read_one(tokens) do
     case skip_datum_comments(tokens) do
       [] ->
         :eof
 
       tokens ->
-        {datum, pos, rest} = read_datum(tokens)
-        {:ok, datum, pos, rest}
+        {datum, rest} = read_datum(tokens)
+        {:ok, datum, rest}
     end
   end
-
-  # ---------------------------------------------------------------------------
-  # Datum comments — `#;` consumes the next datum
-  # ---------------------------------------------------------------------------
 
   defp skip_datum_comments([{:datum_comment, _, pos} | rest]) do
     case read_one(rest) do
       :eof -> raise Error, reason: :datum_comment_at_eof, position: pos
-      {:ok, _skipped, _pos, rest} -> skip_datum_comments(rest)
+      {:ok, _skipped, rest} -> skip_datum_comments(rest)
     end
   end
 
   defp skip_datum_comments(tokens), do: tokens
 
-  # ---------------------------------------------------------------------------
-  # Single-datum dispatch
-  # ---------------------------------------------------------------------------
-
-  defp read_datum([{:integer, n, pos} | rest]), do: {n, {:atom, pos}, rest}
-  defp read_datum([{:float, f, pos} | rest]), do: {f, {:atom, pos}, rest}
-  defp read_datum([{:bool, b, pos} | rest]), do: {Value.bool(b), {:atom, pos}, rest}
-  defp read_datum([{:string, s, pos} | rest]), do: {Value.string(s), {:atom, pos}, rest}
-  defp read_datum([{:char, cp, pos} | rest]), do: {Value.char(cp), {:atom, pos}, rest}
-  defp read_datum([{:ident, name, pos} | rest]), do: {Value.symbol(name), {:atom, pos}, rest}
+  defp read_datum([{:integer, n, _} | rest]), do: {n, rest}
+  defp read_datum([{:float, f, _} | rest]), do: {f, rest}
+  defp read_datum([{:bool, b, _} | rest]), do: {Value.bool(b), rest}
+  defp read_datum([{:string, s, _} | rest]), do: {Value.string(s), rest}
+  defp read_datum([{:char, cp, _} | rest]), do: {Value.char(cp), rest}
+  defp read_datum([{:ident, name, _} | rest]), do: {Value.symbol(name), rest}
 
   defp read_datum([{:quote, _, pos} | rest]), do: read_quoted("quote", rest, pos)
   defp read_datum([{:quasiquote, _, pos} | rest]), do: read_quoted("quasiquote", rest, pos)
@@ -175,30 +157,180 @@ defmodule Schooner.Reader do
     raise Error, reason: :unexpected_dot, position: pos
   end
 
-  # ---------------------------------------------------------------------------
-  # Quote forms — desugar to `(<sym> <datum>)`
-  # ---------------------------------------------------------------------------
-
   defp read_quoted(sym_name, tokens, pos) do
     case read_one(tokens) do
       :eof ->
         raise Error, reason: {:unexpected_eof_after, sym_name}, position: pos
 
-      {:ok, datum, inner_pos, rest} ->
-        value = Value.list([Value.symbol(sym_name), datum])
+      {:ok, datum, rest} ->
+        {Value.list([Value.symbol(sym_name), datum]), rest}
+    end
+  end
 
-        pos_tree =
-          {:pair, pos, {:atom, pos}, {:pair, pos, inner_pos, {:atom, pos}}}
+  defp read_list(tokens, start) do
+    case skip_datum_comments(tokens) do
+      [{:rparen, _, _} | rest] ->
+        {:null, rest}
 
-        {value, pos_tree, rest}
+      [{:dot, _, pos} | _] ->
+        raise Error, reason: :dot_at_list_start, position: pos
+
+      [] ->
+        raise Error, reason: :unterminated_list, position: start
+
+      tokens ->
+        {datum, rest} = read_datum(tokens)
+        read_list_tail(rest, [datum], start)
+    end
+  end
+
+  defp read_list_tail(tokens, acc, start) do
+    case skip_datum_comments(tokens) do
+      [{:rparen, _, _} | rest] ->
+        {Value.list(Enum.reverse(acc)), rest}
+
+      [{:dot, _, dot_pos} | rest] ->
+        finish_dotted_list(rest, acc, dot_pos, start)
+
+      [] ->
+        raise Error, reason: :unterminated_list, position: start
+
+      tokens ->
+        {datum, rest} = read_datum(tokens)
+        read_list_tail(rest, [datum | acc], start)
+    end
+  end
+
+  defp finish_dotted_list(tokens, acc, dot_pos, start) do
+    case skip_datum_comments(tokens) do
+      [{:rparen, _, _} | _] ->
+        raise Error, reason: :missing_tail_after_dot, position: dot_pos
+
+      [] ->
+        raise Error, reason: :missing_tail_after_dot, position: dot_pos
+
+      tail_tokens ->
+        {tail, rest} = read_datum(tail_tokens)
+
+        case skip_datum_comments(rest) do
+          [{:rparen, _, _} | rest2] ->
+            {Value.improper_list(Enum.reverse(acc), tail), rest2}
+
+          [{_, _, pos} | _] ->
+            raise Error, reason: :extra_after_dot, position: pos
+
+          [] ->
+            raise Error, reason: :unterminated_list, position: start
+        end
+    end
+  end
+
+  defp read_vector(tokens, start), do: do_read_vector(tokens, [], start)
+
+  defp do_read_vector(tokens, acc, start) do
+    case skip_datum_comments(tokens) do
+      [{:rparen, _, _} | rest] ->
+        {Value.vector(Enum.reverse(acc)), rest}
+
+      [{:dot, _, pos} | _] ->
+        raise Error, reason: :dot_in_vector, position: pos
+
+      [] ->
+        raise Error, reason: :unterminated_vector, position: start
+
+      tokens ->
+        {datum, rest} = read_datum(tokens)
+        do_read_vector(rest, [datum | acc], start)
+    end
+  end
+
+  defp read_bytevector(tokens, start), do: do_read_bytevector(tokens, [], start)
+
+  defp do_read_bytevector(tokens, acc, start) do
+    case skip_datum_comments(tokens) do
+      [{:rparen, _, _} | rest] ->
+        {Value.bytevector(Enum.reverse(acc)), rest}
+
+      [{:integer, n, pos} | rest] ->
+        if n in 0..255 do
+          do_read_bytevector(rest, [n | acc], start)
+        else
+          raise Error, reason: {:invalid_byte, n}, position: pos
+        end
+
+      [] ->
+        raise Error, reason: :unterminated_bytevector, position: start
+
+      [{tag, _, pos} | _] ->
+        raise Error, reason: {:invalid_in_bytevector, tag}, position: pos
     end
   end
 
   # ---------------------------------------------------------------------------
-  # Lists — proper `(a b c)` and dotted `(a b . c)`
+  # Positioned reader — used by the library loader for diagnostics
   # ---------------------------------------------------------------------------
 
-  defp read_list(tokens, start) do
+  defp do_read_all_pos(tokens, acc) do
+    case read_one_pos(tokens) do
+      :eof -> Enum.reverse(acc)
+      {:ok, datum, pos, rest} -> do_read_all_pos(rest, [{datum, pos} | acc])
+    end
+  end
+
+  defp read_one_pos(tokens) do
+    case skip_datum_comments(tokens) do
+      [] ->
+        :eof
+
+      tokens ->
+        {datum, pos, rest} = read_datum_pos(tokens)
+        {:ok, datum, pos, rest}
+    end
+  end
+
+  defp read_datum_pos([{:integer, n, pos} | rest]), do: {n, {:atom, pos}, rest}
+  defp read_datum_pos([{:float, f, pos} | rest]), do: {f, {:atom, pos}, rest}
+  defp read_datum_pos([{:bool, b, pos} | rest]), do: {Value.bool(b), {:atom, pos}, rest}
+  defp read_datum_pos([{:string, s, pos} | rest]), do: {Value.string(s), {:atom, pos}, rest}
+  defp read_datum_pos([{:char, cp, pos} | rest]), do: {Value.char(cp), {:atom, pos}, rest}
+  defp read_datum_pos([{:ident, name, pos} | rest]), do: {Value.symbol(name), {:atom, pos}, rest}
+
+  defp read_datum_pos([{:quote, _, pos} | rest]), do: read_quoted_pos("quote", rest, pos)
+
+  defp read_datum_pos([{:quasiquote, _, pos} | rest]),
+    do: read_quoted_pos("quasiquote", rest, pos)
+
+  defp read_datum_pos([{:unquote, _, pos} | rest]), do: read_quoted_pos("unquote", rest, pos)
+
+  defp read_datum_pos([{:unquote_splicing, _, pos} | rest]) do
+    read_quoted_pos("unquote-splicing", rest, pos)
+  end
+
+  defp read_datum_pos([{:lparen, _, pos} | rest]), do: read_list_pos(rest, pos)
+  defp read_datum_pos([{:vector_open, _, pos} | rest]), do: read_vector_pos(rest, pos)
+  defp read_datum_pos([{:bytevector_open, _, pos} | rest]), do: read_bytevector_pos(rest, pos)
+
+  defp read_datum_pos([{:rparen, _, pos} | _]) do
+    raise Error, reason: :unexpected_close_paren, position: pos
+  end
+
+  defp read_datum_pos([{:dot, _, pos} | _]) do
+    raise Error, reason: :unexpected_dot, position: pos
+  end
+
+  defp read_quoted_pos(sym_name, tokens, pos) do
+    case read_one_pos(tokens) do
+      :eof ->
+        raise Error, reason: {:unexpected_eof_after, sym_name}, position: pos
+
+      {:ok, datum, inner_pos, rest} ->
+        value = Value.list([Value.symbol(sym_name), datum])
+        pos_tree = {:pair, pos, {:atom, pos}, {:pair, pos, inner_pos, {:atom, pos}}}
+        {value, pos_tree, rest}
+    end
+  end
+
+  defp read_list_pos(tokens, start) do
     case skip_datum_comments(tokens) do
       [{:rparen, _, _} | rest] ->
         {:null, {:atom, start}, rest}
@@ -210,12 +342,12 @@ defmodule Schooner.Reader do
         raise Error, reason: :unterminated_list, position: start
 
       tokens ->
-        {datum, datum_pos, rest} = read_datum(tokens)
-        read_list_tail(rest, [datum], [datum_pos], start)
+        {datum, datum_pos, rest} = read_datum_pos(tokens)
+        read_list_tail_pos(rest, [datum], [datum_pos], start)
     end
   end
 
-  defp read_list_tail(tokens, dacc, pacc, start) do
+  defp read_list_tail_pos(tokens, dacc, pacc, start) do
     case skip_datum_comments(tokens) do
       [{:rparen, _, _} | rest] ->
         datum = Value.list(Enum.reverse(dacc))
@@ -223,18 +355,18 @@ defmodule Schooner.Reader do
         {datum, pos_tree, rest}
 
       [{:dot, _, dot_pos} | rest] ->
-        finish_dotted_list(rest, dacc, pacc, dot_pos, start)
+        finish_dotted_list_pos(rest, dacc, pacc, dot_pos, start)
 
       [] ->
         raise Error, reason: :unterminated_list, position: start
 
       tokens ->
-        {datum, datum_pos, rest} = read_datum(tokens)
-        read_list_tail(rest, [datum | dacc], [datum_pos | pacc], start)
+        {datum, datum_pos, rest} = read_datum_pos(tokens)
+        read_list_tail_pos(rest, [datum | dacc], [datum_pos | pacc], start)
     end
   end
 
-  defp finish_dotted_list(tokens, dacc, pacc, dot_pos, start) do
+  defp finish_dotted_list_pos(tokens, dacc, pacc, dot_pos, start) do
     case skip_datum_comments(tokens) do
       [{:rparen, _, _} | _] ->
         raise Error, reason: :missing_tail_after_dot, position: dot_pos
@@ -243,7 +375,7 @@ defmodule Schooner.Reader do
         raise Error, reason: :missing_tail_after_dot, position: dot_pos
 
       tail_tokens ->
-        {tail, tail_pos, rest} = read_datum(tail_tokens)
+        {tail, tail_pos, rest} = read_datum_pos(tail_tokens)
 
         case skip_datum_comments(rest) do
           [{:rparen, _, _} | rest2] ->
@@ -266,13 +398,9 @@ defmodule Schooner.Reader do
     {:pair, start, head, build_list_pos(rest, tail_pos, start)}
   end
 
-  # ---------------------------------------------------------------------------
-  # Vectors — `#(...)`
-  # ---------------------------------------------------------------------------
+  defp read_vector_pos(tokens, start), do: do_read_vector_pos(tokens, [], [], start)
 
-  defp read_vector(tokens, start), do: do_read_vector(tokens, [], [], start)
-
-  defp do_read_vector(tokens, dacc, pacc, start) do
+  defp do_read_vector_pos(tokens, dacc, pacc, start) do
     case skip_datum_comments(tokens) do
       [{:rparen, _, _} | rest] ->
         datum = Value.vector(Enum.reverse(dacc))
@@ -285,34 +413,14 @@ defmodule Schooner.Reader do
         raise Error, reason: :unterminated_vector, position: start
 
       tokens ->
-        {datum, datum_pos, rest} = read_datum(tokens)
-        do_read_vector(rest, [datum | dacc], [datum_pos | pacc], start)
+        {datum, datum_pos, rest} = read_datum_pos(tokens)
+        do_read_vector_pos(rest, [datum | dacc], [datum_pos | pacc], start)
     end
   end
 
-  # ---------------------------------------------------------------------------
-  # Bytevectors — `#u8(...)`, only integer tokens in 0..255
-  # ---------------------------------------------------------------------------
-
-  defp read_bytevector(tokens, start), do: do_read_bytevector(tokens, [], start)
-
-  defp do_read_bytevector(tokens, acc, start) do
-    case skip_datum_comments(tokens) do
-      [{:rparen, _, _} | rest] ->
-        {Value.bytevector(Enum.reverse(acc)), {:bytevector, start}, rest}
-
-      [{:integer, n, pos} | rest] ->
-        if n in 0..255 do
-          do_read_bytevector(rest, [n | acc], start)
-        else
-          raise Error, reason: {:invalid_byte, n}, position: pos
-        end
-
-      [] ->
-        raise Error, reason: :unterminated_bytevector, position: start
-
-      [{tag, _, pos} | _] ->
-        raise Error, reason: {:invalid_in_bytevector, tag}, position: pos
+  defp read_bytevector_pos(tokens, start) do
+    case do_read_bytevector(tokens, [], start) do
+      {datum, rest} -> {datum, {:bytevector, start}, rest}
     end
   end
 end

--- a/test/schooner/library/loader_test.exs
+++ b/test/schooner/library/loader_test.exs
@@ -168,6 +168,108 @@ defmodule Schooner.Library.LoaderTest do
       lib = Library.fetch!(reg, ["from-file"])
       assert {:var, 42} = Map.fetch!(lib.exports, "forty-two")
     end
+
+    @tag :tmp_dir
+    test "populates :source with {:file, path, span}", %{tmp_dir: dir} do
+      path = Path.join(dir, "lib.scm")
+
+      File.write!(path, """
+
+      (define-library (from-file)
+        (import (scheme base))
+        (export forty-two)
+        (begin (define forty-two 42)))
+      """)
+
+      reg = Loader.load_file(path, standard())
+      lib = Library.fetch!(reg, ["from-file"])
+      assert {:file, ^path, {2, 1}} = lib.source
+    end
+  end
+
+  describe "diagnostics quote source positions" do
+    @tag :tmp_dir
+    test "unsupported declaration head includes path:line:col", %{tmp_dir: dir} do
+      path = Path.join(dir, "bad.scm")
+
+      File.write!(path, """
+      (define-library (broken)
+        (import (scheme base))
+        (nope something))
+      """)
+
+      assert_raise ArgumentError, ~r/#{Regex.escape(path)}:3:3/, fn ->
+        Loader.load_file(path, standard())
+      end
+    end
+
+    @tag :tmp_dir
+    test "exporting an undefined binding includes path and line", %{tmp_dir: dir} do
+      path = Path.join(dir, "bad-export.scm")
+
+      File.write!(path, """
+      (define-library (broken)
+        (import (scheme base))
+        (export not-defined)
+        (begin (define x 1)))
+      """)
+
+      assert_raise ArgumentError, ~r/#{Regex.escape(path)}:3:11.*not-defined/s, fn ->
+        Loader.load_file(path, standard())
+      end
+    end
+
+    @tag :tmp_dir
+    test "invalid cond-expand requirement includes file:line", %{tmp_dir: dir} do
+      path = Path.join(dir, "bad-cx.scm")
+
+      File.write!(path, """
+      (define-library (cx-bad)
+        (cond-expand
+          (123 (export nope))))
+      """)
+
+      assert_raise ArgumentError, ~r/#{Regex.escape(path)}:3:6.*invalid cond-expand/s, fn ->
+        Loader.load_file(path, standard())
+      end
+    end
+
+    @tag :tmp_dir
+    test "invalid export entry includes file:line", %{tmp_dir: dir} do
+      path = Path.join(dir, "bad-entry.scm")
+
+      File.write!(path, """
+      (define-library (e-bad)
+        (import (scheme base))
+        (export (rename only-one)))
+      """)
+
+      assert_raise ArgumentError, ~r/#{Regex.escape(path)}:3:11.*invalid export entry/s, fn ->
+        Loader.load_file(path, standard())
+      end
+    end
+
+    @tag :tmp_dir
+    test "cycle error names every cycle participant with its position", %{tmp_dir: dir} do
+      path = Path.join(dir, "cycle.scm")
+
+      File.write!(path, """
+      (define-library (a) (import (b)) (export x) (begin (define x 1)))
+      (define-library (b) (import (a)) (export y) (begin (define y 2)))
+      """)
+
+      err =
+        assert_raise ArgumentError, fn ->
+          Loader.load_file(path, standard())
+        end
+
+      message = err.message
+      assert message =~ "cycle in define-library"
+      assert message =~ "(a)"
+      assert message =~ "(b)"
+      assert message =~ "#{path}:1:1"
+      assert message =~ "#{path}:2:1"
+    end
   end
 
   describe "(include ...)" do

--- a/test/schooner/library/loader_test.exs
+++ b/test/schooner/library/loader_test.exs
@@ -214,9 +214,9 @@ defmodule Schooner.Library.LoaderTest do
         (begin (define x 1)))
       """)
 
-      assert_raise ArgumentError, ~r/#{Regex.escape(path)}:3:11.*not-defined/s, fn ->
-        Loader.load_file(path, standard())
-      end
+      err = assert_raise ArgumentError, fn -> Loader.load_file(path, standard()) end
+      assert err.message =~ "#{path}:3:11"
+      assert err.message =~ "not-defined"
     end
 
     @tag :tmp_dir
@@ -229,9 +229,9 @@ defmodule Schooner.Library.LoaderTest do
           (123 (export nope))))
       """)
 
-      assert_raise ArgumentError, ~r/#{Regex.escape(path)}:3:6.*invalid cond-expand/s, fn ->
-        Loader.load_file(path, standard())
-      end
+      err = assert_raise ArgumentError, fn -> Loader.load_file(path, standard()) end
+      assert err.message =~ "#{path}:3:6"
+      assert err.message =~ "invalid cond-expand"
     end
 
     @tag :tmp_dir
@@ -244,9 +244,9 @@ defmodule Schooner.Library.LoaderTest do
         (export (rename only-one)))
       """)
 
-      assert_raise ArgumentError, ~r/#{Regex.escape(path)}:3:11.*invalid export entry/s, fn ->
-        Loader.load_file(path, standard())
-      end
+      err = assert_raise ArgumentError, fn -> Loader.load_file(path, standard()) end
+      assert err.message =~ "#{path}:3:11"
+      assert err.message =~ "invalid export entry"
     end
 
     @tag :tmp_dir


### PR DESCRIPTION
Closes #37.

## Summary
- `Schooner.Reader` gains `read_string_positioned/1`, returning each top-level datum paired with a parallel position tree (`pos_tree`) that mirrors the datum's pair/vector spine. Each node carries the `{line, column}` of its opening token. Helpers `position_of/1`, `list_positions/1`, and `vector_positions/1` walk the tree in lockstep with `Value.to_list/1`.
- `Schooner.Library.Loader` threads positions and the source path through every walker. Each `ArgumentError` prefixes its message with `path:line:col` (or `line N, column M` when no path is available): unsupported declaration heads, invalid `cond-expand` requirements, invalid export entries, undefined export bindings, malformed top-level forms, and include-resolution failures.
- Cycle errors now render each participant as `(name) (path:line:col)`.
- Libraries loaded via `Loader.load_file/2` populate `:source` as `{:file, path, {line, column}}` (the slot already existed from Phase 13.1).
- Removed the moduledoc follow-up note and added a "Diagnostics" section.

## Test plan
- [x] `mix precommit` (compile --warnings-as-errors, deps.unlock --unused, format, credo --strict, test): 902 tests, 0 failures.
- [x] New tests in `test/schooner/library/loader_test.exs` assert that:
  - unsupported declaration heads quote `path:line:col`
  - undefined exports quote the export-entry position
  - invalid `cond-expand` requirements quote position
  - invalid export entries quote position
  - cycle errors name every participant with its `define-library` position
  - `load_file/2` populates `source: {:file, path, {line, col}}`
- [x] Existing reader tests (`reader_test.exs`, `reader_property_test.exs`) and existing loader tests still pass — `read_string/1` is unchanged externally.