### PR TITLE
Lift test coverage from 90.91% to 95.43%

### DIFF
--- a/lib/schooner/primitives/inexact.ex
+++ b/lib/schooner/primitives/inexact.ex
@@ -109,7 +109,7 @@ defmodule Schooner.Primitives.Inexact do
 
   defp atan_([x]), do: atan_one(x, "atan")
   defp atan_([y, x]), do: atan_two(y, x, "atan")
-  defp atan_(_), do: raise(Error, reason: {:arity_error, "atan", 1, 2})
+  defp atan_(_), do: raise(Error, reason: {:type_error, "atan", "1 or 2 arguments", :too_many})
 
   defp atan_one({:float_special, :pos_inf}, _), do: :math.pi() / 2.0
   defp atan_one({:float_special, :neg_inf}, _), do: -:math.pi() / 2.0

--- a/test/schooner/env_test.exs
+++ b/test/schooner/env_test.exs
@@ -57,4 +57,21 @@ defmodule Schooner.EnvTest do
     assert Env.lookup(a, "k") == {:ok, 1}
     assert Env.lookup(b, "k") == :error
   end
+
+  test "pop/1 removes the topmost lexical frame" do
+    env =
+      Env.new()
+      |> Env.define("g", :global)
+      |> Env.extend([{"x", :outer}])
+      |> Env.extend([{"x", :inner}])
+
+    assert Env.lookup(env, "x") == {:ok, :inner}
+
+    after_one_pop = Env.pop(env)
+    assert Env.lookup(after_one_pop, "x") == {:ok, :outer}
+
+    after_two_pops = Env.pop(after_one_pop)
+    assert Env.lookup(after_two_pops, "x") == :error
+    assert Env.lookup(after_two_pops, "g") == {:ok, :global}
+  end
 end

--- a/test/schooner/error_test.exs
+++ b/test/schooner/error_test.exs
@@ -1,0 +1,42 @@
+defmodule Schooner.ErrorTest do
+  use ExUnit.Case, async: true
+
+  alias Schooner.Value
+
+  describe "irritants/1" do
+    test "returns the wrapped irritants for an error-object value" do
+      e = Schooner.Error.exception(value: Value.error_object(:user, "msg", [1, 2, 3]))
+      assert Schooner.Error.irritants(e) == [1, 2, 3]
+    end
+
+    test "returns [] for any non error-object value" do
+      e = Schooner.Error.exception(value: Value.symbol("oops"))
+      assert Schooner.Error.irritants(e) == []
+    end
+  end
+
+  describe "message formatting" do
+    test "error-object with no irritants formats without a colon-list" do
+      e = Schooner.Error.exception(value: Value.error_object(:user, "boom", []))
+      assert e.message == "uncaught Scheme error: boom"
+    end
+
+    test "error-object with irritants joins them after a colon" do
+      e = Schooner.Error.exception(value: Value.error_object(:user, "boom", [1, 2]))
+      assert e.message == "uncaught Scheme error: boom: 1 2"
+    end
+
+    test "non-string message renders via Value.write" do
+      # Per Value.error_object's docstring messages should be strings, but
+      # the formatter has to defend against malformed values built by hand.
+      malformed = {:error_obj, :user, Value.symbol("kaboom"), []}
+      e = Schooner.Error.exception(value: malformed)
+      assert e.message =~ "kaboom"
+    end
+
+    test "raised non-error-object value formats via Value.write" do
+      e = Schooner.Error.exception(value: Value.symbol("plain"))
+      assert e.message == "uncaught Scheme raise: plain"
+    end
+  end
+end

--- a/test/schooner/eval/continuation_state_test.exs
+++ b/test/schooner/eval/continuation_state_test.exs
@@ -1,0 +1,56 @@
+defmodule Schooner.Eval.ContinuationStateTest do
+  use ExUnit.Case, async: false
+
+  alias Schooner.Eval.ContinuationState
+
+  setup do
+    on_exit(fn -> ContinuationState.reset() end)
+    ContinuationState.reset()
+    :ok
+  end
+
+  test "register / live? / deregister round-trip" do
+    tag = make_ref()
+
+    refute ContinuationState.live?(tag)
+    ContinuationState.register(tag)
+    assert ContinuationState.live?(tag)
+    ContinuationState.deregister(tag)
+    refute ContinuationState.live?(tag)
+  end
+
+  test "snapshot and restore preserve the live-tag set" do
+    a = make_ref()
+    b = make_ref()
+    ContinuationState.register(a)
+    ContinuationState.register(b)
+
+    snapshot = ContinuationState.snapshot()
+    assert MapSet.size(snapshot) == 2
+
+    ContinuationState.reset()
+    refute ContinuationState.live?(a)
+    refute ContinuationState.live?(b)
+
+    ContinuationState.restore(snapshot)
+    assert ContinuationState.live?(a)
+    assert ContinuationState.live?(b)
+  end
+
+  test "restore of an empty snapshot clears the slot" do
+    ContinuationState.register(make_ref())
+    ContinuationState.restore(MapSet.new())
+    assert ContinuationState.snapshot() == MapSet.new()
+  end
+
+  test "deregister of the last tag clears the slot" do
+    tag = make_ref()
+    ContinuationState.register(tag)
+    ContinuationState.deregister(tag)
+
+    # The set is now empty — confirmed by re-checking via snapshot, which
+    # surfaces an empty MapSet whether the slot is gone or holds an empty
+    # set (the implementation chooses the former).
+    assert ContinuationState.snapshot() == MapSet.new()
+  end
+end

--- a/test/schooner/eval_test.exs
+++ b/test/schooner/eval_test.exs
@@ -286,4 +286,21 @@ defmodule Schooner.EvalTest do
 
     Schooner.eval(source, env)
   end
+
+  describe "primitive arity_mismatch surfaces on under-supply to {:at_least, n}" do
+    test "string=? requires at least 2 args" do
+      e = assert_raise Error, fn -> run(~S|(string=? "x")|) end
+      assert match?({:arity_mismatch, "string=?", {:at_least, 2}, 1}, e.reason)
+    end
+  end
+
+  describe "guard clause whose test evaluates to literal #f" do
+    test "false-test clause is skipped, next clause matches" do
+      assert run("""
+             (guard (e ((eq? e 'never) 1)
+                       ((eq? e 'matched) 2))
+               (raise 'matched))
+             """) == 2
+    end
+  end
 end

--- a/test/schooner/expander/derived_test.exs
+++ b/test/schooner/expander/derived_test.exs
@@ -1,0 +1,17 @@
+defmodule Schooner.Expander.DerivedTest do
+  use ExUnit.Case, async: true
+
+  alias Schooner.Expander.Derived
+
+  test "priv_files/0 lists base.scm and lazy.scm in load order" do
+    assert Derived.priv_files() == ["base.scm", "lazy.scm"]
+  end
+
+  test "source/0 concatenates the priv files with a newline separator" do
+    src = Derived.source()
+    assert is_binary(src)
+    # Both files contribute identifiable content; check at least the
+    # prelude commentary tokens exist.
+    assert src =~ "define-syntax"
+  end
+end

--- a/test/schooner/expander_test.exs
+++ b/test/schooner/expander_test.exs
@@ -359,4 +359,80 @@ defmodule Schooner.ExpanderTest do
              """) == 314
     end
   end
+
+  describe "Expander.Error message formatting" do
+    alias Schooner.Expander.Error, as: EE
+
+    test ":no_matching_rule names the keyword" do
+      err = EE.exception(reason: {:no_matching_rule, "bin"})
+      assert err.message =~ "no matching"
+      assert err.message =~ "bin"
+    end
+
+    test ":ellipsis_count_mismatch names the offending variable" do
+      err = EE.exception(reason: {:ellipsis_count_mismatch, "x"})
+      assert err.message =~ "ellipsis"
+      assert err.message =~ "x"
+    end
+
+    test ":ellipsis_no_pattern_var names the location" do
+      err = EE.exception(reason: {:ellipsis_no_pattern_var, "template"})
+      assert err.message =~ "no pattern variable"
+      assert err.message =~ "template"
+    end
+
+    test ":syntax_rules_arity reports the form count" do
+      err = EE.exception(reason: {:syntax_rules_arity, 0})
+      assert err.message =~ "literals list and at least one rule"
+      assert err.message =~ "0"
+    end
+
+    test ":nested_define_syntax_unsupported is rendered as a fixed message" do
+      err = EE.exception(reason: :nested_define_syntax_unsupported)
+      assert err.message == "`define-syntax` is currently only supported at top level"
+    end
+  end
+
+  describe "top-level (begin (define-syntax ...) ...) splices through expand_top_begin" do
+    test "macro defined inside top-level begin is usable afterwards" do
+      assert run("""
+             (begin
+               (define-syntax twice
+                 (syntax-rules () ((_ x) (* x 2)))))
+             (twice 7)
+             """) == 14
+    end
+  end
+
+  describe "let-syntax body wrapping" do
+    test "multi-form body wraps in (begin ...) via wrap_body_as_form" do
+      # When the body is a single form, wrap_body_as_form returns it bare;
+      # with two-or-more forms it must wrap them in (begin ...).
+      assert run("""
+             (let-syntax ((m (syntax-rules () ((_ x) x))))
+               (m 1)
+               (m 2)
+               (m 3))
+             """) == 3
+    end
+  end
+
+  describe "nested quasiquote / unquote-splicing" do
+    test "unquote-splicing at level > 1 keeps the form symbolic and recurses" do
+      # ``(a ,@,b) — outer ` lifts level to 1, inner ` to 2; ,@,b sees
+      # level 2 so unquote-splicing's level > 1 branch fires, then the
+      # inner unquote-splicing goes deeper.
+      assert run("(define x 1) ``(a ,@,x)") ==
+               Value.list([
+                 Value.symbol("quasiquote"),
+                 Value.list([
+                   Value.symbol("a"),
+                   Value.list([
+                     Value.symbol("unquote-splicing"),
+                     Value.list([Value.symbol("unquote"), Value.symbol("x")])
+                   ])
+                 ])
+               ])
+    end
+  end
 end

--- a/test/schooner/lexer_test.exs
+++ b/test/schooner/lexer_test.exs
@@ -369,5 +369,23 @@ defmodule Schooner.LexerTest do
       err = assert_raise Error, fn -> Lexer.tokenise(".+@") end
       assert match?({:invalid_token, _}, err.reason)
     end
+
+    test "Lexer.Error message describes :rationals_unsupported" do
+      err = Error.exception(reason: :rationals_unsupported, position: {7, 3})
+      assert err.message == "rationals are not supported at line 7, column 3"
+    end
+
+    test "Lexer.Error message describes :empty_atom" do
+      err = Error.exception(reason: :empty_atom, position: {1, 1})
+      assert err.message == "empty token at line 1, column 1"
+    end
+
+    test "Lexer.Error message describes {:invalid_identifier, raw}" do
+      err =
+        Error.exception(reason: {:invalid_identifier, "x@y"}, position: {1, 1})
+
+      assert err.message =~ "invalid identifier"
+      assert err.message =~ "x@y"
+    end
   end
 end

--- a/test/schooner/library/import_test.exs
+++ b/test/schooner/library/import_test.exs
@@ -169,4 +169,51 @@ defmodule Schooner.Library.ImportTest do
       end
     end
   end
+
+  describe "resolve/2 — malformed specs" do
+    test "non-list spec is rejected with a clear ArgumentError" do
+      err =
+        assert_raise ArgumentError, fn ->
+          LibImport.resolve([42], test_registry())
+        end
+
+      assert err.message =~ "invalid import spec"
+    end
+
+    test "rename modifier silently ignores names that aren't in the inner exports" do
+      bindings =
+        LibImport.resolve(
+          [datum("(rename (only (scheme base) car) (cadr nope))")],
+          test_registry()
+        )
+
+      # `cadr` was never present (we only kept `car`), so the rename is
+      # ignored — `car` survives unchanged.
+      assert Map.keys(bindings) == ["car"]
+    end
+
+    test "rename clause that isn't (old new) is rejected" do
+      err =
+        assert_raise ArgumentError, fn ->
+          LibImport.resolve(
+            [datum("(rename (only (scheme base) car) (car))")],
+            test_registry()
+          )
+        end
+
+      assert err.message =~ "invalid rename clause"
+    end
+
+    test "non-symbol name in `only` modifier is rejected" do
+      err =
+        assert_raise ArgumentError, fn ->
+          LibImport.resolve(
+            [datum(~s|(only (scheme base) "not-a-sym")|)],
+            test_registry()
+          )
+        end
+
+      assert err.message =~ "must be a symbol"
+    end
+  end
 end

--- a/test/schooner/library/loader_test.exs
+++ b/test/schooner/library/loader_test.exs
@@ -4,6 +4,7 @@ defmodule Schooner.Library.LoaderTest do
   alias Schooner.Library
   alias Schooner.Library.Loader
   alias Schooner.Library.Standard
+  alias Schooner.Reader
 
   defp standard, do: Standard.build_registry()
 
@@ -438,6 +439,215 @@ defmodule Schooner.Library.LoaderTest do
       reg = Loader.load_file(Path.join(dir, "libs.scm"), standard())
       lib = Library.fetch!(reg, ["uses"])
       assert {:var, 99} = Map.fetch!(lib.exports, "use-help")
+    end
+  end
+
+  describe "compile/2,3 directly (no positioned tree)" do
+    test "compile/2 builds a library against a registry" do
+      [datum] =
+        Reader.read_string("""
+        (define-library (direct)
+          (import (scheme base))
+          (export double)
+          (begin (define (double x) (* x 2))))
+        """)
+
+      lib = Loader.compile(datum, standard())
+      assert lib.name == ["direct"]
+      assert {:var, {:closure, _, _, _, _}} = Map.fetch!(lib.exports, "double")
+      assert lib.source == :native
+    end
+
+    test "compile/2 on a non-define-library datum raises ArgumentError" do
+      [datum] = Reader.read_string("(begin 1 2)")
+
+      assert_raise ArgumentError, ~r/expected a \(define-library/, fn ->
+        Loader.compile(datum, standard())
+      end
+    end
+
+    test "compile/2 still walks vector and atom subtrees in synthetic_pos_tree" do
+      # exercises synthetic_pos_tree's :vector and :atom branches via a
+      # body that contains a vector literal and a bare integer literal.
+      [datum] =
+        Reader.read_string("""
+        (define-library (vec-direct)
+          (import (scheme base))
+          (export v)
+          (begin (define v (vector 1 2 3))))
+        """)
+
+      lib = Loader.compile(datum, standard())
+      assert {:var, {:vector, _}} = Map.fetch!(lib.exports, "v")
+    end
+
+    test "diagnostic without a positioned tree omits line/column" do
+      [datum] =
+        Reader.read_string("""
+        (define-library (no-pos)
+          (import (scheme base))
+          (export missing)
+          (begin (define x 1)))
+        """)
+
+      err = assert_raise ArgumentError, fn -> Loader.compile(datum, standard()) end
+      assert err.message =~ "missing"
+      refute err.message =~ ~r/line \d+/
+      refute err.message =~ ~r/:\d+:\d+/
+    end
+  end
+
+  describe "default registry" do
+    test "load_string/1 uses Library.standard() when no registry is given" do
+      source = """
+      (define-library (default-reg)
+        (import (scheme base))
+        (export who)
+        (begin (define who 'default)))
+      """
+
+      reg = Loader.load_string(source)
+      assert match?({:ok, _}, Library.lookup(reg, ["default-reg"]))
+      # Confirm scheme base is still there (i.e. we got the standard registry).
+      assert match?({:ok, _}, Library.lookup(reg, ["scheme", "base"]))
+    end
+
+    @tag :tmp_dir
+    test "load_file/1 uses Library.standard() when no registry is given", %{tmp_dir: dir} do
+      path = Path.join(dir, "lib.scm")
+
+      File.write!(path, """
+      (define-library (default-reg-file)
+        (import (scheme base))
+        (export n)
+        (begin (define n 7)))
+      """)
+
+      reg = Loader.load_file(path)
+      assert match?({:ok, _}, Library.lookup(reg, ["default-reg-file"]))
+    end
+  end
+
+  describe "cond-expand `or` and `not` requirement combinators" do
+    test "or selects the first satisfied requirement" do
+      source = """
+      (define-library (cx-or)
+        (cond-expand
+          ((or (library (scheme nope)) r7rs)
+            (import (scheme base))
+            (export ok)
+            (begin (define ok 'yes)))
+          (else
+            (import (scheme base))
+            (export ok)
+            (begin (define ok 'no)))))
+      """
+
+      reg = Loader.load_string(source, standard())
+      lib = Library.fetch!(reg, ["cx-or"])
+      assert {:var, {:sym, "yes"}} = Map.fetch!(lib.exports, "ok")
+    end
+
+    test "later cond-expand requirement is evaluated when earlier ones fail" do
+      source = """
+      (define-library (cx-rest)
+        (cond-expand
+          ((library (scheme nope))
+            (import (scheme base))
+            (export ok)
+            (begin (define ok 'never)))
+          (r7rs
+            (import (scheme base))
+            (export ok)
+            (begin (define ok 'second)))))
+      """
+
+      reg = Loader.load_string(source, standard())
+      lib = Library.fetch!(reg, ["cx-rest"])
+      assert {:var, {:sym, "second"}} = Map.fetch!(lib.exports, "ok")
+    end
+  end
+
+  describe "exporting a macro" do
+    test "macro bindings flow through library exports" do
+      source = """
+      (define-library (macro-export)
+        (import (scheme base))
+        (export my-when)
+        (begin
+          (define-syntax my-when
+            (syntax-rules ()
+              ((_ test body ...) (if test (begin body ...) #f))))))
+      """
+
+      reg = Loader.load_string(source, standard())
+      lib = Library.fetch!(reg, ["macro-export"])
+      assert {:macro, _} = Map.fetch!(lib.exports, "my-when")
+    end
+  end
+
+  describe "include path types" do
+    @tag :tmp_dir
+    test "absolute include path inside the entry-point directory is allowed", %{tmp_dir: dir} do
+      body_path = Path.join(dir, "abs_body.scm")
+      File.write!(body_path, "(define eight 8)")
+
+      lib_path = Path.join(dir, "lib.scm")
+
+      File.write!(lib_path, """
+      (define-library (abs-include)
+        (import (scheme base))
+        (export eight)
+        (include "#{body_path}"))
+      """)
+
+      reg = Loader.load_file(lib_path, standard())
+      lib = Library.fetch!(reg, ["abs-include"])
+      assert {:var, 8} = Map.fetch!(lib.exports, "eight")
+    end
+
+    @tag :tmp_dir
+    test "absolute include path outside the entry-point directory is rejected", %{tmp_dir: dir} do
+      sub = Path.join(dir, "sub")
+      File.mkdir_p!(sub)
+
+      outside_path = Path.join(dir, "outside.scm")
+      File.write!(outside_path, "(define x 1)")
+
+      lib_path = Path.join(sub, "lib.scm")
+
+      File.write!(lib_path, """
+      (define-library (abs-escape)
+        (import (scheme base))
+        (export x)
+        (include "#{outside_path}"))
+      """)
+
+      assert_raise ArgumentError, ~r/resolves outside/, fn ->
+        Loader.load_file(lib_path, standard())
+      end
+    end
+
+    test "non-string include path raises a clear error" do
+      source = """
+      (define-library (bad-path)
+        (import (scheme base))
+        (include 42))
+      """
+
+      err = assert_raise ArgumentError, fn -> Loader.load_string(source, standard()) end
+      assert err.message =~ "expected string path"
+    end
+  end
+
+  describe "load_string error messages with no path/no position" do
+    test "non-define-library top-level form names the offender (no path)" do
+      source = "(begin 1)"
+
+      err = assert_raise ArgumentError, fn -> Loader.load_string(source, standard()) end
+      assert err.message =~ "expected (define-library"
+      # No path was given, so we get a position-only prefix.
+      assert err.message =~ ~r/line \d+, column \d+/
     end
   end
 end

--- a/test/schooner/library_test.exs
+++ b/test/schooner/library_test.exs
@@ -212,4 +212,34 @@ defmodule Schooner.LibraryTest do
       assert idx.(["r"]) < idx.(["top"])
     end
   end
+
+  describe "canonicalise_name/1" do
+    alias Schooner.Reader
+
+    test "symbol segments become binaries" do
+      [datum] = Reader.read_string("(scheme base)")
+      assert Library.canonicalise_name(datum) == ["scheme", "base"]
+    end
+
+    test "non-negative integer segments pass through" do
+      [datum] = Reader.read_string("(srfi 1)")
+      assert Library.canonicalise_name(datum) == ["srfi", 1]
+    end
+
+    test "negative integer segment is rejected" do
+      [datum] = Reader.read_string("(srfi -1)")
+
+      assert_raise ArgumentError, ~r/symbols or non-negative integers/, fn ->
+        Library.canonicalise_name(datum)
+      end
+    end
+
+    test "non-symbol non-integer segment is rejected" do
+      [datum] = Reader.read_string(~s|(scheme "base")|)
+
+      assert_raise ArgumentError, ~r/symbols or non-negative integers/, fn ->
+        Library.canonicalise_name(datum)
+      end
+    end
+  end
 end

--- a/test/schooner/primitives/base_test.exs
+++ b/test/schooner/primitives/base_test.exs
@@ -917,4 +917,93 @@ defmodule Schooner.Primitives.BaseTest do
       assert match?({:index_out_of_range, "string->list", _, _}, e.reason)
     end
   end
+
+  # ---------------------------------------------------------------------------
+  # Variadic copy/conversion primitives reject 4+ args distinctly so the
+  # error names "1 to 3 arguments" rather than landing in the underlying
+  # range function with garbage extras.
+  # ---------------------------------------------------------------------------
+
+  describe "1-to-3-argument primitives reject too many args" do
+    test "vector-copy with 4 args" do
+      e = assert_raise PError, fn -> run("(vector-copy #(1 2 3) 0 3 99)") end
+      assert e.reason == {:type_error, "vector-copy", "1 to 3 arguments", :too_many}
+    end
+
+    test "bytevector-copy with 4 args" do
+      e = assert_raise PError, fn -> run("(bytevector-copy #u8(1 2 3) 0 3 99)") end
+      assert e.reason == {:type_error, "bytevector-copy", "1 to 3 arguments", :too_many}
+    end
+
+    test "utf8->string with 4 args" do
+      e = assert_raise PError, fn -> run("(utf8->string #u8(97 98 99) 0 3 99)") end
+      assert e.reason == {:type_error, "utf8->string", "1 to 3 arguments", :too_many}
+    end
+
+    test "string->utf8 with 4 args" do
+      e = assert_raise PError, fn -> run(~S|(string->utf8 "abc" 0 3 99)|) end
+      assert e.reason == {:type_error, "string->utf8", "1 to 3 arguments", :too_many}
+    end
+  end
+
+  describe "utf8->string / string->utf8 with start-only and start+end" do
+    test "utf8->string with explicit start and end" do
+      assert run("(utf8->string #u8(97 98 99 100) 1 3)") == Value.string("bc")
+    end
+
+    test "string->utf8 with explicit start and end" do
+      assert run(~S|(string->utf8 "abcd" 1 3)|) == Value.bytevector(<<?b, ?c>>)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # signed-zero, expt -1^even, and -0/-0 = NaN exercise the remaining
+  # arithmetic edge cases.
+  # ---------------------------------------------------------------------------
+
+  describe "signed-zero arithmetic edges" do
+    test "(-1) raised to an even integer is exactly 1" do
+      assert run("(expt -1 4)") === 1
+    end
+
+    test "(-1) raised to an odd integer is exactly -1" do
+      assert run("(expt -1 3)") === -1
+    end
+
+    test "+inf.0 multiplied by -0.0 is NaN (sign_finite hits its -0.0 clause)" do
+      assert run("(* +inf.0 -0.0)") == {:float_special, :nan}
+    end
+
+    test "(-0.0) divided by (-0.0) is NaN" do
+      assert run("(/ -0.0 -0.0)") == {:float_special, :nan}
+    end
+
+    test "+inf.0 + +inf.0 stays +inf.0 (special_add same-key clause)" do
+      assert run("(+ +inf.0 +inf.0)") == {:float_special, :pos_inf}
+      assert run("(+ -inf.0 -inf.0)") == {:float_special, :neg_inf}
+    end
+  end
+
+  describe "char codepoint validation" do
+    alias Schooner.Value, as: V
+
+    defp string_primitive do
+      {_, _, fun} = Enum.find(Schooner.Primitives.Base.specs(), fn {n, _, _} -> n == "string" end)
+      fun
+    end
+
+    test "(string c) raises when the char carries a codepoint past 0x10FFFF" do
+      bad = V.char(0x110000)
+
+      e = assert_raise PError, fn -> string_primitive().([bad]) end
+      assert match?({:codepoint_out_of_range, "char", _}, e.reason)
+    end
+
+    test "(string c) raises when the char carries a surrogate codepoint" do
+      surrogate = V.char(0xD800)
+
+      e = assert_raise PError, fn -> string_primitive().([surrogate]) end
+      assert match?({:codepoint_out_of_range, "char", _}, e.reason)
+    end
+  end
 end

--- a/test/schooner/primitives/exceptions_test.exs
+++ b/test/schooner/primitives/exceptions_test.exs
@@ -141,6 +141,22 @@ defmodule Schooner.Primitives.ExceptionsTest do
                    (+ (raise-continuable 3)
                       (raise-continuable 4))))|) == 14
     end
+
+    test "raise-continuable with no handler installed escapes to the host" do
+      e = assert_raise Schooner.Error, fn -> run("(raise-continuable 'oops)") end
+      assert e.value == Value.symbol("oops")
+    end
+  end
+
+  describe "error-object-irritants type-check" do
+    test "raises a type error when called with a non-error-object" do
+      e = assert_raise Schooner.Primitive.Error, fn -> run("(error-object-irritants 1)") end
+
+      assert match?(
+               {:type_error, "error-object-irritants", "error object", _},
+               e.reason
+             )
+    end
   end
 
   describe "guard" do

--- a/test/schooner/primitives/inexact_test.exs
+++ b/test/schooner/primitives/inexact_test.exs
@@ -43,9 +43,38 @@ defmodule Schooner.Primitives.InexactTest do
       assert run("(log 0)") == {:float_special, :neg_inf}
     end
 
+    test "log of positive zero floats = -inf.0" do
+      assert run("(log 0.0)") == {:float_special, :neg_inf}
+      assert run("(log -0.0)") == {:float_special, :neg_inf}
+    end
+
+    test "log on positive float = :math.log" do
+      assert_in_delta run("(log 2.5)"), :math.log(2.5), 1.0e-12
+    end
+
+    test "log of NaN = NaN; log of +inf = +inf" do
+      assert run("(log +nan.0)") == {:float_special, :nan}
+      assert run("(log +inf.0)") == {:float_special, :pos_inf}
+    end
+
+    test "log of -inf raises (would be complex)" do
+      e = assert_raise PError, fn -> run("(log -inf.0)") end
+      assert match?({:irrational, "log", _}, e.reason)
+    end
+
     test "log of negative integer raises" do
       e = assert_raise PError, fn -> run("(log -1)") end
       assert match?({:irrational, "log", _}, e.reason)
+    end
+
+    test "log of negative float raises" do
+      e = assert_raise PError, fn -> run("(log -1.5)") end
+      assert match?({:irrational, "log", _}, e.reason)
+    end
+
+    test "log on non-number raises type error" do
+      e = assert_raise PError, fn -> run(~s{(log "hi")}) end
+      assert match?({:type_error, "log", "number", _}, e.reason)
     end
 
     test "log with base — log base 10 of 1000 ≈ 3.0" do
@@ -67,12 +96,33 @@ defmodule Schooner.Primitives.InexactTest do
     test "cos +nan.0 = +nan.0" do
       assert run("(cos +nan.0)") == {:float_special, :nan}
     end
+
+    test "trig functions raise on non-number arg" do
+      e = assert_raise PError, fn -> run(~s{(sin "x")}) end
+      assert match?({:type_error, "sin", "number", _}, e.reason)
+
+      e = assert_raise PError, fn -> run(~s{(cos "x")}) end
+      assert match?({:type_error, "cos", "number", _}, e.reason)
+
+      e = assert_raise PError, fn -> run(~s{(tan "x")}) end
+      assert match?({:type_error, "tan", "number", _}, e.reason)
+    end
   end
 
   describe "asin / acos" do
     test "asin 0 = 0; acos 1 = 0" do
       assert run("(asin 0)") == 0.0
       assert run("(acos 1)") == 0.0
+    end
+
+    test "asin/acos on float in range" do
+      assert_in_delta run("(asin 0.5)"), :math.asin(0.5), 1.0e-12
+      assert_in_delta run("(acos 0.5)"), :math.acos(0.5), 1.0e-12
+    end
+
+    test "asin/acos on +nan.0 = +nan.0" do
+      assert run("(asin +nan.0)") == {:float_special, :nan}
+      assert run("(acos +inf.0)") == {:float_special, :nan}
     end
 
     test "asin out of [-1,1] raises" do
@@ -84,6 +134,14 @@ defmodule Schooner.Primitives.InexactTest do
       e = assert_raise PError, fn -> run("(acos -2.5)") end
       assert match?({:irrational, "acos", _}, e.reason)
     end
+
+    test "asin/acos on non-number raises type error" do
+      e = assert_raise PError, fn -> run(~s{(asin "hi")}) end
+      assert match?({:type_error, "asin", "number", _}, e.reason)
+
+      e = assert_raise PError, fn -> run(~s{(acos "hi")}) end
+      assert match?({:type_error, "acos", "number", _}, e.reason)
+    end
   end
 
   describe "atan" do
@@ -91,14 +149,45 @@ defmodule Schooner.Primitives.InexactTest do
       assert_in_delta run("(atan 1)"), :math.pi() / 4.0, 1.0e-12
     end
 
+    test "atan on float = :math.atan" do
+      assert_in_delta run("(atan 0.5)"), :math.atan(0.5), 1.0e-12
+    end
+
     test "atan +inf.0 = pi/2; atan -inf.0 = -pi/2" do
       assert_in_delta run("(atan +inf.0)"), :math.pi() / 2.0, 1.0e-12
       assert_in_delta run("(atan -inf.0)"), -:math.pi() / 2.0, 1.0e-12
     end
 
+    test "atan +nan.0 = +nan.0" do
+      assert run("(atan +nan.0)") == {:float_special, :nan}
+    end
+
+    test "atan on non-number raises type error" do
+      e = assert_raise PError, fn -> run(~s{(atan "hi")}) end
+      assert match?({:type_error, "atan", "number", _}, e.reason)
+    end
+
     test "two-arg atan = atan2(y, x)" do
       assert_in_delta run("(atan 1 1)"), :math.pi() / 4.0, 1.0e-12
       assert_in_delta run("(atan 0 -1)"), :math.pi(), 1.0e-12
+    end
+
+    test "two-arg atan with +nan.0 in either slot = +nan.0" do
+      assert run("(atan +nan.0 1)") == {:float_special, :nan}
+      assert run("(atan 1 +nan.0)") == {:float_special, :nan}
+    end
+
+    test "two-arg atan with non-number raises pointing at the offender" do
+      e = assert_raise PError, fn -> run(~s{(atan 1 "x")}) end
+      assert match?({:type_error, "atan", "number", _}, e.reason)
+
+      e = assert_raise PError, fn -> run(~s{(atan "x" 1)}) end
+      assert match?({:type_error, "atan", "number", _}, e.reason)
+    end
+
+    test "atan with too many arguments raises an arity-shaped type error" do
+      e = assert_raise PError, fn -> run("(atan 1 2 3)") end
+      assert e.reason == {:type_error, "atan", "1 or 2 arguments", :too_many}
     end
   end
 
@@ -127,6 +216,18 @@ defmodule Schooner.Primitives.InexactTest do
     test "predicates raise on non-number arg" do
       e = assert_raise PError, fn -> run("(finite? \"hi\")") end
       assert match?({:type_error, "finite?", "number", _}, e.reason)
+
+      e = assert_raise PError, fn -> run(~s{(infinite? "hi")}) end
+      assert match?({:type_error, "infinite?", "number", _}, e.reason)
+
+      e = assert_raise PError, fn -> run(~s{(nan? "hi")}) end
+      assert match?({:type_error, "nan?", "number", _}, e.reason)
+    end
+  end
+
+  describe "exp on floats" do
+    test "exp on float input = :math.exp" do
+      assert_in_delta run("(exp 1.5)"), :math.exp(1.5), 1.0e-12
     end
   end
 end

--- a/test/schooner/reader_test.exs
+++ b/test/schooner/reader_test.exs
@@ -325,4 +325,156 @@ defmodule Schooner.ReaderTest do
       assert err.reason == {:invalid_in_bytevector, :ident}
     end
   end
+
+  describe "read_string_positioned/1" do
+    test "atom carries {:atom, position}" do
+      assert [{42, {:atom, {1, 1}}}] = Reader.read_string_positioned("42")
+      assert [{1.5, {:atom, {1, 4}}}] = Reader.read_string_positioned("   1.5")
+    end
+
+    test "every primitive token kind threads through position_of" do
+      datums = Reader.read_string_positioned(~s|#t "hi" #\\a foo|)
+
+      assert Enum.map(datums, fn {_d, p} -> Reader.position_of(p) end) ==
+               [{1, 1}, {1, 4}, {1, 9}, {1, 13}]
+    end
+
+    test "list pos tree is a chain of :pair nodes pointing at the opener" do
+      [{datum, pos_tree}] = Reader.read_string_positioned("  (a b c)")
+
+      assert datum == Value.list([Value.symbol("a"), Value.symbol("b"), Value.symbol("c")])
+      assert Reader.position_of(pos_tree) == {1, 3}
+
+      [a_pos, b_pos, c_pos] = Reader.list_positions(pos_tree)
+      assert Reader.position_of(a_pos) == {1, 4}
+      assert Reader.position_of(b_pos) == {1, 6}
+      assert Reader.position_of(c_pos) == {1, 8}
+    end
+
+    test "empty list reads as :null with an :atom-shaped position tree" do
+      [{datum, pos_tree}] = Reader.read_string_positioned(" ()")
+      assert datum == []
+      assert pos_tree == {:atom, {1, 2}}
+    end
+
+    test "dotted-pair position tree records the tail's position in place of [] sentinel" do
+      [{datum, pos_tree}] = Reader.read_string_positioned("(1 . 2)")
+      assert datum == Value.pair(1, 2)
+
+      assert {:pair, {1, 1}, {:atom, {1, 2}}, {:atom, {1, 6}}} = pos_tree
+    end
+
+    test "vector pos tree carries the start and an item-tree per element" do
+      [{datum, pos_tree}] = Reader.read_string_positioned("#(1 2)")
+      assert datum == Value.vector([1, 2])
+
+      assert {:vector, {1, 1}, [item1, item2]} = pos_tree
+      assert item1 == {:atom, {1, 3}}
+      assert item2 == {:atom, {1, 5}}
+    end
+
+    test "bytevector pos tree carries only the start position" do
+      [{datum, pos_tree}] = Reader.read_string_positioned("#u8(1 2)")
+      assert datum == Value.bytevector([1, 2])
+      assert pos_tree == {:bytevector, {1, 1}}
+    end
+
+    test "quote forms desugar with position trees pointing at the prefix" do
+      [{datum, pos_tree}] = Reader.read_string_positioned(" 'foo")
+
+      assert datum == Value.list([Value.symbol("quote"), Value.symbol("foo")])
+
+      [quote_sym_pos, foo_pos] = Reader.list_positions(pos_tree)
+      assert Reader.position_of(quote_sym_pos) == {1, 2}
+      assert Reader.position_of(foo_pos) == {1, 3}
+    end
+
+    test "quasiquote, unquote, unquote-splicing all tracked" do
+      [{_, p1}] = Reader.read_string_positioned("`x")
+      [{_, p2}] = Reader.read_string_positioned(",x")
+      [{_, p3}] = Reader.read_string_positioned(",@x")
+
+      assert Reader.position_of(p1) == {1, 1}
+      assert Reader.position_of(p2) == {1, 1}
+      assert Reader.position_of(p3) == {1, 1}
+    end
+
+    test "datum comments are skipped while preserving positions of survivors" do
+      [{datum, pos_tree}] = Reader.read_string_positioned("#; foo bar")
+      assert datum == Value.symbol("bar")
+      assert Reader.position_of(pos_tree) == {1, 8}
+    end
+
+    test "improper list — vector item carries its sub-tree" do
+      [{datum, pos_tree}] = Reader.read_string_positioned("(#(1 2) . 3)")
+      assert datum == Value.pair(Value.vector([1, 2]), 3)
+
+      assert {:pair, _, vec_pos, tail_pos} = pos_tree
+      assert {:vector, _, [_, _]} = vec_pos
+      assert tail_pos == {:atom, {1, 11}}
+    end
+
+    test "errors during positioned read still raise with reader.error" do
+      err = assert_raise Error, fn -> Reader.read_string_positioned("(") end
+      assert err.reason == :unterminated_list
+      assert err.position == {1, 1}
+    end
+
+    test "positioned reader rejects unmatched close-paren" do
+      err = assert_raise Error, fn -> Reader.read_string_positioned(" )") end
+      assert err.reason == :unexpected_close_paren
+      assert err.position == {1, 2}
+    end
+
+    test "positioned reader rejects bare dot" do
+      err = assert_raise Error, fn -> Reader.read_string_positioned(" . ") end
+      assert err.reason == :unexpected_dot
+    end
+
+    test "positioned reader rejects dot at list start" do
+      err = assert_raise Error, fn -> Reader.read_string_positioned("(. 1)") end
+      assert err.reason == :dot_at_list_start
+    end
+
+    test "positioned reader rejects extra after dot" do
+      err = assert_raise Error, fn -> Reader.read_string_positioned("(1 . 2 3)") end
+      assert err.reason == :extra_after_dot
+    end
+
+    test "positioned reader rejects missing tail after dot" do
+      err = assert_raise Error, fn -> Reader.read_string_positioned("(1 . )") end
+      assert err.reason == :missing_tail_after_dot
+
+      err = assert_raise Error, fn -> Reader.read_string_positioned("(1 . ") end
+      assert err.reason == :missing_tail_after_dot
+    end
+
+    test "positioned reader rejects unterminated dotted-list (eof after tail)" do
+      err = assert_raise Error, fn -> Reader.read_string_positioned("(1 . 2") end
+      assert err.reason == :unterminated_list
+    end
+
+    test "positioned reader rejects unterminated vector" do
+      err = assert_raise Error, fn -> Reader.read_string_positioned("#(1 2") end
+      assert err.reason == :unterminated_vector
+    end
+
+    test "positioned reader rejects dot in vector" do
+      err = assert_raise Error, fn -> Reader.read_string_positioned("#(1 . 2)") end
+      assert err.reason == :dot_in_vector
+    end
+
+    test "positioned reader rejects quote with no following datum" do
+      err = assert_raise Error, fn -> Reader.read_string_positioned("'") end
+      assert err.reason == {:unexpected_eof_after, "quote"}
+    end
+  end
+
+  describe "list_positions/1" do
+    test "raises ArgumentError for a non-list-shaped tree (vector)" do
+      [{_, pos_tree}] = Reader.read_string_positioned("#(1 2)")
+
+      assert_raise ArgumentError, fn -> Reader.list_positions(pos_tree) end
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- Adds focused tests for the lowest-coverage modules — positioned reader output, transcendental primitives, library loader entry points, error-message formatters, and exception/continuation state round-trips.
- 21 of 36 modules now hit 100% (was 11). Total coverage rises from 90.91% to 95.43%.
- Fixes a latent bug in `atan_/1`: the 4+ argument catch-all raised `{:arity_error, ...}`, a reason `Schooner.Primitive.Error.format/1` has no clause for, so `(atan 1 2 3)` blew up with `FunctionClauseError`. Aligned with the existing `{:type_error, op, "N or M arguments", :too_many}` shape used by `vector-copy` and friends.

## Test plan
- [x] `mix precommit` (compile --warnings-as-errors, deps.unlock --unused, format, credo --strict, test) — 1003 tests, 0 failures, no credo issues
- [x] `mix test --cover` — 95.43% total, 21 modules at 100%

## Coverage highlights

| Module | Before | After |
| --- | --- | --- |
| `Schooner.Primitives.Inexact` | 63.93% | **100%** |
| `Schooner.Expander.Derived` | 50% | **100%** |
| `Schooner.Expander.Error` | 58.33% | **100%** |
| `Schooner.Reader` | 70.07% | 95.62% |
| `Schooner.Library.Loader` | 83.33% | 94.23% |
| `Schooner.Library.Import` | 85.19% | **100%** |
| `Schooner.Lexer.Error` | 86.96% | **100%** |
| `Schooner.Error` | 84.62% | **100%** |
| `Schooner.Eval.ContinuationState` | 91.67% | **100%** |
| `Schooner.Eval.ExceptionState` | 94.44% | **100%** |
| `Schooner.Library` | 96.72% | **100%** |
| `Schooner.Env` | 96.67% | **100%** |

Remaining gaps (Eval 90.51%, Expander 93.79%, Expander.SyntaxRules 81.33%) are mostly defensive `bad_special_form` raise clauses guarded by the expander's own validation — only reachable by handcrafting malformed AST and bypassing the expander.