### PR TITLE
Issue #49: newline and write-string primitives

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,4 +45,4 @@ each excluded upstream case annotated inline.
 | Primitive errors             | Type / arity / domain errors raised by primitives surface as `Schooner.Primitive.Error` on the Elixir side and are *not* catchable from Scheme `guard` / `with-exception-handler`. Only Scheme-level `(raise ...)` / `(error ...)` enter the handler chain. |
 | Libraries shipped            | `(scheme base)`, `(scheme cxr)`, `(scheme char)`, `(scheme inexact)`, `(scheme case-lambda)`, `(scheme lazy)`, `(scheme write)`, `(scheme read)`.        |
 | Libraries omitted            | `(scheme file)`, `(scheme load)`, `(scheme repl)`, `(scheme process-context)`, `(scheme time)`, `(scheme eval)`, `(scheme complex)`, `(scheme r5rs)`.    |
-| I/O                          | `display` only. No file ports, no string ports beyond what `(scheme read)` needs internally, no `newline` / `read-line` / `write-string`.                |
+| I/O                          | No file ports, no string ports beyond what `(scheme read)` needs internally, no `read-line`. `display` / `write` / `newline` / `write-string` are present in the string-port flavour: they return the rendered text instead of writing to a port. |

--- a/lib/schooner/library/standard.ex
+++ b/lib/schooner/library/standard.ex
@@ -6,10 +6,12 @@ defmodule Schooner.Library.Standard do
 
   `(scheme base)` is assembled from the union of `Primitives.Base`,
   `Primitives.Record`, `Primitives.Exceptions`,
-  `Primitives.Continuations`, plus the syntax-rules macros defined in
-  `priv/scheme/base.scm` (`when`, `unless`, `and`, `or`, `let`, `let*`,
-  `letrec`, `cond`, `case`, `do`). The other libraries map one-to-one
-  to a single primitive module:
+  `Primitives.Continuations`, plus the `newline` and `write-string`
+  output primitives in `Primitives.Write.base_io_specs/0`, plus the
+  syntax-rules macros defined in `priv/scheme/base.scm` (`when`,
+  `unless`, `and`, `or`, `let`, `let*`, `letrec`, `cond`, `case`,
+  `do`). The other libraries map one-to-one to a single primitive
+  module:
 
     * `(scheme cxr)` → `Primitives.Cxr`
     * `(scheme char)` → `Primitives.Char`
@@ -73,7 +75,8 @@ defmodule Schooner.Library.Standard do
             Primitives.Base.specs(),
             Primitives.Record.specs(),
             Primitives.Exceptions.specs(),
-            Primitives.Continuations.specs()
+            Primitives.Continuations.specs(),
+            Primitives.Write.base_io_specs()
           ]),
           macros_from_priv("base.scm")
         ),

--- a/lib/schooner/primitives/write.ex
+++ b/lib/schooner/primitives/write.ex
@@ -1,15 +1,18 @@
 defmodule Schooner.Primitives.Write do
   @moduledoc """
-  The `(scheme write)` library: `display`, `write`, `write-shared`,
-  `write-simple`.
+  The `(scheme write)` library — `display`, `write`, `write-shared`,
+  `write-simple` — plus the `(scheme base)` output primitives
+  `newline` and `write-string`.
 
   Schooner has no port abstraction (see PLAN.md — I/O is delegated to
   host functions), so these primitives deviate from r7rs in two ways:
 
-    1. They take exactly one argument — the value — with no port arg.
-       The host wires up I/O explicitly via injected functions.
+    1. They take only the value (no port arg). The host wires up I/O
+       explicitly via injected functions.
     2. They return the rendered text as a Scheme string instead of
-       writing to a port and returning unspecified.
+       writing to a port and returning unspecified. `(newline)`
+       returns the literal `"\\n"`; `(write-string str)` returns
+       `str` unchanged.
 
   This is the documented "string-port flavour" called out in the
   Phase 13 plan. `write-shared` and `write-simple` delegate to `write`
@@ -17,6 +20,7 @@ defmodule Schooner.Primitives.Write do
   no shared structures to label and no cycles to break.
   """
 
+  alias Schooner.Primitive.Error
   alias Schooner.Value
 
   @doc """
@@ -34,6 +38,26 @@ defmodule Schooner.Primitives.Write do
     ]
   end
 
+  @doc """
+  Return the `(scheme base)` output primitives shipped here:
+  `newline` and `write-string`. Kept separate from `specs/0` so the
+  `(scheme write)` library entry stays purely r7rs `(scheme write)`.
+  """
+  @spec base_io_specs() :: [{binary(), non_neg_integer(), fun()}]
+  def base_io_specs do
+    [
+      {"newline", 0, &newline_/1},
+      {"write-string", 1, &write_string/1}
+    ]
+  end
+
   defp write_([value]), do: Value.string(Value.write(value))
   defp display_([value]), do: Value.string(Value.display(value))
+
+  defp newline_([]), do: Value.string("\n")
+
+  defp write_string([s]) when is_binary(s), do: s
+
+  defp write_string([other]),
+    do: raise(Error, reason: {:type_error, "write-string", "string", other})
 end

--- a/test/conformance/r7rs_section_4_test.exs
+++ b/test/conformance/r7rs_section_4_test.exs
@@ -12,7 +12,9 @@ defmodule Schooner.Conformance.R7rsSection4Test do
   #   - delayed evaluation (delay, force, make-promise): phase 13
   #   - dynamic bindings (parameterize, make-parameter): out of scope
   #   - exception handling (guard, raise): phase 11
-  #   - I/O (display, write, newline): host-injected; not in default env
+  #   - file ports / read-line: out of scope; `display`, `write`,
+  #     `newline`, `write-string` are present in the string-port flavour
+  #     (return rendered text instead of writing to a port)
   use ExUnit.Case, async: true
 
   alias Schooner.Value

--- a/test/schooner/primitives/write_test.exs
+++ b/test/schooner/primitives/write_test.exs
@@ -2,6 +2,7 @@ defmodule Schooner.Primitives.WriteTest do
   use ExUnit.Case, async: true
 
   alias Schooner.Eval.Error, as: EvalError
+  alias Schooner.Primitive.Error, as: PError
   alias Schooner.Value
 
   defp run(source), do: Schooner.run(source)
@@ -45,6 +46,28 @@ defmodule Schooner.Primitives.WriteTest do
     test "delegate to write for cycle-free immutable values" do
       assert run(~S|(write-shared "hi")|) == Value.string("\"hi\"")
       assert run("(write-simple '(1 2))") == Value.string("(1 2)")
+    end
+  end
+
+  describe "newline" do
+    test "returns the literal newline string" do
+      assert run("(newline)") == Value.string("\n")
+    end
+
+    test "errors when given an argument" do
+      assert_raise EvalError, fn -> run("(newline 'extra)") end
+    end
+  end
+
+  describe "write-string" do
+    test "returns the input string unchanged" do
+      assert run(~S|(write-string "hello")|) == Value.string("hello")
+      assert run(~S|(write-string "")|) == Value.string("")
+    end
+
+    test "rejects non-string input" do
+      e = assert_raise PError, fn -> run("(write-string 42)") end
+      assert match?({:type_error, "write-string", "string", _}, e.reason)
     end
   end
 


### PR DESCRIPTION
## Summary

Closes #49.

- Adds `(newline)` and `(write-string str)` to `(scheme base)`, in the same string-port flavour as `display`/`write`: `(newline)` returns `"\n"`, `(write-string str)` returns `str` unchanged.
- Implementation lives in `Primitives.Write` via a new `base_io_specs/0` so the `(scheme write)` `specs/0` stays purely r7rs `(scheme write)`. `Library.Standard.scheme_base` picks it up alongside the existing Base/Record/Exceptions/Continuations specs.
- README updated: I/O row now describes the string-port flavour explicitly, with file ports and `read-line` still listed as out of scope.

## Test plan

- [x] `(newline)` returns `"\n"`; arity error with extra args.
- [x] `(write-string "hi")` returns `"hi"`; `(write-string "")` returns `""`; non-string input raises `Schooner.Primitive.Error` with reason `{:type_error, "write-string", "string", _}`.
- [x] Existing write/display tests unaffected.
- [x] CI green.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EnQNbPMoBnXBEb9oHJctF7)_