### PR TITLE
Issue #50: multi-value returns (values, call-with-values, let-values, let*-values)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ each excluded upstream case annotated inline.
 | `define-syntax` placement    | Top-level only — a `define-syntax` inside a `(let () ...)` body is rejected.                                                                              |
 | `call/cc`                    | Escape-only. A captured continuation invoked after its dynamic extent has ended raises a Schooner error. Multi-shot continuations and `dynamic-wind` re-entry are deferred to v2.0. |
 | Letrec closure escape        | A closure created inside a `letrec` / `letrec*` / named `let` cannot recurse after escaping its frame; the rec frame does not survive. The mutation-free model rules out classical letrec via post-hoc assignment. |
-| Multi-value returns          | `values`, `call-with-values`, `define-values`, `let-values`, `let*-values` are not implemented.                                                           |
+| Multi-value returns          | `values`, `call-with-values`, `let-values`, `let*-values` are implemented; `define-values` is not (would need a non-mutating splice in the body desugarer). |
 | Parameter objects            | `make-parameter` and `parameterize` are not implemented.                                                                                                  |
 | Primitive errors             | Type / arity / domain errors raised by primitives surface as `Schooner.Primitive.Error` on the Elixir side and are *not* catchable from Scheme `guard` / `with-exception-handler`. Only Scheme-level `(raise ...)` / `(error ...)` enter the handler chain. |
 | Libraries shipped            | `(scheme base)`, `(scheme cxr)`, `(scheme char)`, `(scheme inexact)`, `(scheme case-lambda)`, `(scheme lazy)`, `(scheme write)`, `(scheme read)`.        |

--- a/lib/schooner.ex
+++ b/lib/schooner.ex
@@ -99,6 +99,7 @@ defmodule Schooner do
       body
       |> Expander.expand_program(syntax_env)
       |> Enum.reduce(:unspecified, fn form, _acc -> Eval.eval(form, env) end)
+      |> Eval.single_value!()
     after
       ExceptionState.restore(prev_handlers)
       ContinuationState.restore(prev_conts)

--- a/lib/schooner/eval.ex
+++ b/lib/schooner/eval.ex
@@ -31,7 +31,29 @@ defmodule Schooner.Eval do
   alias Schooner.Eval.Error
   alias Schooner.Eval.ExceptionState
   alias Schooner.Expander.SyntaxRules
+  alias Schooner.Primitive.Error, as: PError
   alias Schooner.Value
+
+  @doc """
+  Coerce a value reaching a single-value context. A bare value passes
+  through unchanged. A `{:values, {v}}` (single-arg `(values v)`)
+  unwraps to `v`. A `{:values, vtup}` with `tuple_size(vtup) != 1`
+  raises a `Schooner.Primitive.Error` with reason
+  `{:wrong_value_count, got, 1}`.
+
+  Used at every site that consumes one value: `eval_args`, the `if`
+  test, top-level of `Schooner.run/1` / `Schooner.eval/2`. The only
+  context that does *not* run through this is `call-with-values`'s
+  producer return path, which is the whole point of the marker.
+  """
+  @spec single_value!(Value.t() | {:values, tuple()}) :: Value.t()
+  def single_value!({:values, {v}}), do: v
+
+  def single_value!({:values, vtup}) when is_tuple(vtup) do
+    raise PError, reason: {:wrong_value_count, tuple_size(vtup), 1}
+  end
+
+  def single_value!(other), do: other
 
   @spec eval(Value.t(), Env.t()) :: Value.t()
 
@@ -82,7 +104,7 @@ defmodule Schooner.Eval do
   # ---------------------------------------------------------------------------
 
   defp eval_if([test | [then_e | []]], env) do
-    if Value.truthy?(eval(test, env)) do
+    if Value.truthy?(single_value!(eval(test, env))) do
       eval(then_e, env)
     else
       :unspecified
@@ -90,7 +112,7 @@ defmodule Schooner.Eval do
   end
 
   defp eval_if([test | [then_e | [else_e | []]]], env) do
-    if Value.truthy?(eval(test, env)) do
+    if Value.truthy?(single_value!(eval(test, env))) do
       eval(then_e, env)
     else
       eval(else_e, env)
@@ -135,7 +157,7 @@ defmodule Schooner.Eval do
   # ---------------------------------------------------------------------------
 
   defp eval_define([{:sym, name} | [expr | []]], env) do
-    Env.define(env, name, eval(expr, env))
+    Env.define(env, name, single_value!(eval(expr, env)))
     :unspecified
   end
 
@@ -169,13 +191,17 @@ defmodule Schooner.Eval do
   # ---------------------------------------------------------------------------
 
   defp eval_apply(head_expr, args_form, env) do
-    proc = eval(head_expr, env)
+    proc = single_value!(eval(head_expr, env))
     args = eval_args(args_form, env, [])
     apply_proc(proc, args)
   end
 
   defp eval_args([], _env, acc), do: Enum.reverse(acc)
-  defp eval_args([h | t], env, acc), do: eval_args(t, env, [eval(h, env) | acc])
+
+  defp eval_args([h | t], env, acc) do
+    eval_args(t, env, [single_value!(eval(h, env)) | acc])
+  end
+
   defp eval_args(_, _env, _acc), do: raise(Error, reason: :improper_application)
 
   @spec apply_proc(Value.t(), [Value.t()]) :: Value.t()
@@ -243,7 +269,7 @@ defmodule Schooner.Eval do
       names
       |> Enum.zip(inits)
       |> Enum.each(fn {name, init} ->
-        Env.rec_set(rec_env, name, eval(init, rec_env))
+        Env.rec_set(rec_env, name, single_value!(eval(init, rec_env)))
       end)
 
       eval_body(body, rec_env)

--- a/lib/schooner/primitive/error.ex
+++ b/lib/schooner/primitive/error.ex
@@ -72,4 +72,8 @@ defmodule Schooner.Primitive.Error do
   defp format({:wrong_record_type, op, type_name}) do
     "`#{op}`: value is not a record of type `#{type_name}`"
   end
+
+  defp format({:wrong_value_count, got, expected}) do
+    "wrong number of values: expected #{expected}, got #{got}"
+  end
 end

--- a/lib/schooner/primitives/base.ex
+++ b/lib/schooner/primitives/base.ex
@@ -40,7 +40,8 @@ defmodule Schooner.Primitives.Base do
       vector_specs() ++
       bytevector_specs() ++
       string_specs() ++
-      symbol_specs()
+      symbol_specs() ++
+      multi_value_specs()
   end
 
   # ---------------------------------------------------------------------------
@@ -1211,6 +1212,38 @@ defmodule Schooner.Primitives.Base do
 
   defp string_to_symbol([other]),
     do: raise(Error, reason: {:type_error, "string->symbol", "string", other})
+
+  # ---------------------------------------------------------------------------
+  # Multi-value returns
+  # ---------------------------------------------------------------------------
+  #
+  # `(values v ...)` produces a `{:values, vtup}` marker (vtup is a
+  # tuple of the produced values) that is destructured only by
+  # `call-with-values`. Anywhere else a multi-value reaches a
+  # single-value context (`eval_args`, `eval_if`'s test, the script's
+  # top-level), `Schooner.Eval.single_value!/1` either auto-unwraps
+  # the 1-element case to a bare value or raises
+  # `{:wrong_value_count, …}`. `{:values, vtup}` is therefore never
+  # observable by `write`, `display`, or any predicate — it is purely
+  # a transit marker between `values` and `call-with-values`. Using a
+  # tuple (not a list) keeps the marker shape distinct from any
+  # Scheme list value that might also flow through these paths.
+
+  defp multi_value_specs do
+    [
+      {"values", {:at_least, 0}, &values_proc/1},
+      {"call-with-values", 2, &call_with_values_proc/1}
+    ]
+  end
+
+  defp values_proc(args), do: {:values, List.to_tuple(args)}
+
+  defp call_with_values_proc([producer, consumer]) do
+    case Eval.apply_proc(producer, []) do
+      {:values, vtup} -> Eval.apply_proc(consumer, Tuple.to_list(vtup))
+      single -> Eval.apply_proc(consumer, [single])
+    end
+  end
 
   # ---------------------------------------------------------------------------
   # Helpers

--- a/priv/scheme/base.scm
+++ b/priv/scheme/base.scm
@@ -135,3 +135,35 @@
   (syntax-rules ()
     ((_ var) var)
     ((_ var step) step)))
+
+;; -- multi-value binding ---------------------------------------------------
+;;
+;; Standard r7rs §4.2.2 reference implementation, using string literals
+;; ("bind" / "mktmp") as helper-rule keywords to drive the binding-walk.
+
+(define-syntax let-values
+  (syntax-rules ()
+    ((let-values (binding ...) body0 body1 ...)
+     (let-values "bind" (binding ...) () (begin body0 body1 ...)))
+    ((let-values "bind" () tmps body)
+     (let tmps body))
+    ((let-values "bind" ((b0 e0) binding ...) tmps body)
+     (let-values "mktmp" b0 e0 () (binding ...) tmps body))
+    ((let-values "mktmp" () e0 args bindings tmps body)
+     (call-with-values (lambda () e0)
+       (lambda args
+         (let-values "bind" bindings tmps body))))
+    ((let-values "mktmp" (a . b) e0 (arg ...) bindings (tmp ...) body)
+     (let-values "mktmp" b e0 (arg ... x) bindings (tmp ... (a x)) body))
+    ((let-values "mktmp" a e0 (arg ...) bindings (tmp ...) body)
+     (call-with-values (lambda () e0)
+       (lambda (arg ... . a)
+         (let-values "bind" bindings (tmp ...) body))))))
+
+(define-syntax let*-values
+  (syntax-rules ()
+    ((let*-values () body0 body1 ...)
+     (let () body0 body1 ...))
+    ((let*-values ((b0 e0) binding ...) body0 body1 ...)
+     (let-values ((b0 e0))
+       (let*-values (binding ...) body0 body1 ...)))))

--- a/test/conformance/r7rs_section_4_test.exs
+++ b/test/conformance/r7rs_section_4_test.exs
@@ -8,7 +8,8 @@ defmodule Schooner.Conformance.R7rsSection4Test do
   # back in once the dependencies land:
   #   - mutation (set!, vector-set!, string-set!): out of scope
   #   - internal define / body splicing: phase 8
-  #   - multi-value returns (let-values, let*-values): later
+  #   - `define-values`: not implemented (would need a non-mutating
+  #     splice in the body desugarer)
   #   - delayed evaluation (delay, force, make-promise): phase 13
   #   - dynamic bindings (parameterize, make-parameter): out of scope
   #   - exception handling (guard, raise): phase 11

--- a/test/conformance/scheme/4_2_derived_expressions.scm
+++ b/test/conformance/scheme/4_2_derived_expressions.scm
@@ -3,12 +3,13 @@
 ;;
 ;; Excluded from the upstream section, with reasons:
 ;;   - letrec* `means` test, exact-integer-sqrt cluster, and the
-;;     '(x y x y) shadowing case at lines 182-238: rely on (values),
-;;     (let*-values), exact-integer-sqrt and rationals — none of
-;;     which Schooner supports (no multi-value returns, no rational
-;;     tower, exact-integer-sqrt not in the shipped surface).
-;;   - `(let-values () 'ok)` and the `(let*-values () (define ...))`
-;;     scoping case at 240-246: let-values / let*-values not supported.
+;;     '(x y x y) shadowing case at lines 182-238: rely on
+;;     exact-integer-sqrt and rationals — neither shipped. (The
+;;     `values` / `let*-values` parts are now supported but the
+;;     other dependencies still gate these specific cases.)
+;;   - The `(let*-values () (define ...))` scoping case at 240-246:
+;;     uses an internal `define` after a `let*-values` body began,
+;;     which Schooner's body desugarer rejects.
 ;;   - `(set! x 5)` smoke at 248-251: mutation is out of scope (PLAN.md).
 ;;   - `(do ... (vector-set! vec i i))` at 253-256: vector-set! is a
 ;;     mutator. The pure `do` summing example at 258-261 is kept.

--- a/test/schooner/primitives/base_test.exs
+++ b/test/schooner/primitives/base_test.exs
@@ -1023,4 +1023,58 @@ defmodule Schooner.Primitives.BaseTest do
       assert match?({:codepoint_out_of_range, "char", _}, e.reason)
     end
   end
+
+  describe "multi-value returns" do
+    test "(values v) in single-value context returns v unchanged" do
+      assert run("(values 42)") == 42
+      assert run("(+ (values 5) 10)") == 15
+    end
+
+    test "(values) in single-value context errors with wrong-value-count" do
+      e = assert_raise PError, fn -> run("(values)") end
+      assert match?({:wrong_value_count, 0, 1}, e.reason)
+    end
+
+    test "(values v1 v2 ...) in single-value context errors with wrong-value-count" do
+      e = assert_raise PError, fn -> run("(values 1 2)") end
+      assert match?({:wrong_value_count, 2, 1}, e.reason)
+    end
+
+    test "call-with-values routes a single-value producer to a 1-arg consumer" do
+      assert run("(call-with-values (lambda () 5) (lambda (x) (* x 2)))") == 10
+    end
+
+    test "call-with-values routes a multi-value producer to a multi-arg consumer" do
+      assert run("(call-with-values (lambda () (values 1 2 3)) +)") == 6
+      assert run("(call-with-values (lambda () (values 4 5)) -)") == -1
+    end
+
+    test "call-with-values routes a zero-value producer to a zero-arg consumer" do
+      assert run("(call-with-values (lambda () (values)) (lambda () 'ok))") == Value.symbol("ok")
+    end
+
+    test "let-values binds multiple values from a single producer" do
+      assert run("(let-values (((a b) (values 1 2))) (+ a b))") == 3
+    end
+
+    test "let-values with rest formals binds all values to a list" do
+      assert run("(let-values ((all (values 1 2 3))) all)") == Value.list([1, 2, 3])
+    end
+
+    test "let-values with multiple bindings independently destructures each producer" do
+      assert run("""
+             (let-values (((a b) (values 1 2))
+                          ((c d) (values 3 4)))
+               (list a b c d))
+             """) == Value.list([1, 2, 3, 4])
+    end
+
+    test "let*-values lets later bindings see earlier ones" do
+      assert run("""
+             (let*-values (((a b) (values 1 2))
+                           ((c) (values (+ a b))))
+               c)
+             """) == 3
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Closes #50.

- Adds `values` and `call-with-values` primitives in `Primitives.Base`. `values` returns `{:values, vtup}` (an Elixir tuple, not a list, so the marker shape can never be confused with a Scheme list).
- Adds `Eval.single_value!/1`: auto-unwraps `{:values, {v}}` → `v`, raises `{:wrong_value_count, got, 1}` otherwise, identity for everything else.
- Wraps every consumer site that expects exactly one value: `eval_args`, `eval_if` test, `eval_apply` head, `eval_define`, `eval_letrec_star` init, and the top-level `Schooner.run/1` / `Schooner.eval/2` boundary.
- Adds `let-values` and `let*-values` to `priv/scheme/base.scm` using the standard r7rs §4.2.2 reference macro.
- `define-values` is **not** in this PR — would need a non-mutating splice in the body desugarer; called out in README.

## Test plan

- [x] `(values 42)` returns 42 in single-value context.
- [x] `(values)` and `(values 1 2)` raise `{:wrong_value_count, got, 1}` when reaching a single-value context.
- [x] `call-with-values` routes single-value, multi-value, and zero-value producers to consumers correctly.
- [x] `let-values` with `((a b) (values 1 2))` binds correctly; rest formals bind everything to a list; multi-binding case works.
- [x] `let*-values` lets later bindings see earlier ones.
- [x] Existing tests should be unaffected — `single_value!` is identity for non-`{:values, …}` values.
- [x] CI green.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EnQNbPMoBnXBEb9oHJctF7)_