### PR TITLE
Simplify PRs 51-54 follow-ups

### DIFF
--- a/lib/schooner/eval.ex
+++ b/lib/schooner/eval.ex
@@ -35,22 +35,17 @@ defmodule Schooner.Eval do
   alias Schooner.Value
 
   @doc """
-  Coerce a value reaching a single-value context. A bare value passes
-  through unchanged. A `{:values, {v}}` (single-arg `(values v)`)
-  unwraps to `v`. A `{:values, vtup}` with `tuple_size(vtup) != 1`
-  raises a `Schooner.Primitive.Error` with reason
-  `{:wrong_value_count, got, 1}`.
-
-  Used at every site that consumes one value: `eval_args`, the `if`
-  test, top-level of `Schooner.run/1` / `Schooner.eval/2`. The only
-  context that does *not* run through this is `call-with-values`'s
-  producer return path, which is the whole point of the marker.
+  Coerce a multi-value to a single value. Auto-unwraps a 1-element
+  `{:values, [v]}` to `v`; any other `{:values, vs}` raises
+  `{:wrong_value_count, got, 1}`. Bare values pass through. Called at
+  every single-value context — `call-with-values`'s producer return
+  path is the only deliberate exception.
   """
-  @spec single_value!(Value.t() | {:values, tuple()}) :: Value.t()
-  def single_value!({:values, {v}}), do: v
+  @spec single_value!(Value.t() | {:values, [Value.t()]}) :: Value.t()
+  def single_value!({:values, [v]}), do: v
 
-  def single_value!({:values, vtup}) when is_tuple(vtup) do
-    raise PError, reason: {:wrong_value_count, tuple_size(vtup), 1}
+  def single_value!({:values, vs}) when is_list(vs) do
+    raise PError, reason: {:wrong_value_count, length(vs), 1}
   end
 
   def single_value!(other), do: other
@@ -104,22 +99,16 @@ defmodule Schooner.Eval do
   # ---------------------------------------------------------------------------
 
   defp eval_if([test | [then_e | []]], env) do
-    if Value.truthy?(single_value!(eval(test, env))) do
-      eval(then_e, env)
-    else
-      :unspecified
-    end
+    if eval_test(test, env), do: eval(then_e, env), else: :unspecified
   end
 
   defp eval_if([test | [then_e | [else_e | []]]], env) do
-    if Value.truthy?(single_value!(eval(test, env))) do
-      eval(then_e, env)
-    else
-      eval(else_e, env)
-    end
+    if eval_test(test, env), do: eval(then_e, env), else: eval(else_e, env)
   end
 
   defp eval_if(_, _env), do: raise(Error, reason: {:bad_special_form, "if"})
+
+  defp eval_test(test, env), do: Value.truthy?(single_value!(eval(test, env)))
 
   # ---------------------------------------------------------------------------
   # lambda

--- a/lib/schooner/primitives/base.ex
+++ b/lib/schooner/primitives/base.ex
@@ -1217,17 +1217,12 @@ defmodule Schooner.Primitives.Base do
   # Multi-value returns
   # ---------------------------------------------------------------------------
   #
-  # `(values v ...)` produces a `{:values, vtup}` marker (vtup is a
-  # tuple of the produced values) that is destructured only by
-  # `call-with-values`. Anywhere else a multi-value reaches a
-  # single-value context (`eval_args`, `eval_if`'s test, the script's
-  # top-level), `Schooner.Eval.single_value!/1` either auto-unwraps
-  # the 1-element case to a bare value or raises
-  # `{:wrong_value_count, …}`. `{:values, vtup}` is therefore never
-  # observable by `write`, `display`, or any predicate — it is purely
-  # a transit marker between `values` and `call-with-values`. Using a
-  # tuple (not a list) keeps the marker shape distinct from any
-  # Scheme list value that might also flow through these paths.
+  # `(values v ...)` produces a `{:values, vs}` transit marker that
+  # only `call-with-values` destructures; everywhere else
+  # `Eval.single_value!/1` either unwraps the 1-element case or
+  # raises `{:wrong_value_count, …}`. The `:values` tag is unique to
+  # this marker — no Scheme value carries it — so the payload can be
+  # a plain list without shape-collision risk.
 
   defp multi_value_specs do
     [
@@ -1236,11 +1231,11 @@ defmodule Schooner.Primitives.Base do
     ]
   end
 
-  defp values_proc(args), do: {:values, List.to_tuple(args)}
+  defp values_proc(args), do: {:values, args}
 
   defp call_with_values_proc([producer, consumer]) do
     case Eval.apply_proc(producer, []) do
-      {:values, vtup} -> Eval.apply_proc(consumer, Tuple.to_list(vtup))
+      {:values, vs} -> Eval.apply_proc(consumer, vs)
       single -> Eval.apply_proc(consumer, [single])
     end
   end

--- a/lib/schooner/primitives/char.ex
+++ b/lib/schooner/primitives/char.ex
@@ -153,7 +153,7 @@ defmodule Schooner.Primitives.Char do
 
   defp char_numeric_p([{:char, cp}]) when cp in ?0..?9, do: Value.bool(true)
   defp char_numeric_p([{:char, cp}]) when cp < 128, do: Value.bool(false)
-  defp char_numeric_p([{:char, cp}]), do: Value.bool(Regex.match?(@numeric_re, <<cp::utf8>>))
+  defp char_numeric_p([{:char, cp}]), do: Value.bool(nd?(cp))
   defp char_numeric_p([other]), do: raise_char("char-numeric?", other)
 
   defp char_whitespace_p([{:char, cp}]) when cp in [?\s, ?\t, ?\n, ?\r, ?\v, ?\f],
@@ -192,27 +192,19 @@ defmodule Schooner.Primitives.Char do
   defp digit_value([{:char, cp}]) when cp < 128, do: Value.bool(false)
 
   defp digit_value([{:char, cp}]) do
-    if Regex.match?(@numeric_re, <<cp::utf8>>) do
-      nd_block_offset(cp, 0)
-    else
-      Value.bool(false)
-    end
+    if nd?(cp), do: nd_block_offset(cp, 0), else: Value.bool(false)
   end
 
-  defp digit_value([other]),
-    do: raise(Error, reason: {:type_error, "digit-value", "char", other})
+  defp digit_value([other]), do: raise_char("digit-value", other)
 
   defp nd_block_offset(_cp, 9), do: 9
 
   defp nd_block_offset(cp, n) do
     prev = cp - 1
-
-    if prev >= 0 and Regex.match?(@numeric_re, <<prev::utf8>>) do
-      nd_block_offset(prev, n + 1)
-    else
-      n
-    end
+    if nd?(prev), do: nd_block_offset(prev, n + 1), else: n
   end
+
+  defp nd?(cp), do: Regex.match?(@numeric_re, <<cp::utf8>>)
 
   # ---------------------------------------------------------------------------
   # Helpers


### PR DESCRIPTION
## Summary

Cleanup pass over the four PRs merged on 2026-04-29 (#51 digit-value + exact/inexact aliases, #52 syntax-rules hygiene fixes, #53 newline/write-string, #54 multi-value returns). Three small, independent simplifications:

- **`lib/schooner/primitives/char.ex`** — extract `nd?/1` helper now shared by `char_numeric_p`, `digit_value`, and `nd_block_offset` (was three inline copies of `Regex.match?(@numeric_re, <<cp::utf8>>)`). `digit_value`'s type-error now goes through the existing `raise_char/2` helper, matching every other category predicate. Dropped a redundant `prev >= 0` guard — `cp >= 128` in that clause.
- **`lib/schooner/eval.ex`** — extracted `eval_test/2` so both `eval_if/2` clauses collapse to one-liners. Trimmed `single_value!/1`'s docstring (the per-call-site enumeration would go stale on every new caller).
- **`lib/schooner/primitives/base.ex`** — dropped the `List.to_tuple`/`Tuple.to_list` round-trip in `values`/`call-with-values`; the `:values` tag is the discriminator, so the payload can be a plain list without shape-collision risk against Scheme list values. Trimmed the WHAT-narrating comment block above `multi_value_specs`.

Net diff: +27/-51 across three files.

## Test plan
- [x] `mix precommit` clean (compile, format, credo --strict, 1045 tests)