### PR TITLE
Issues #11, #12, #13: pin sqrt/expt IEEE-754 boundary cases

### DIFF
--- a/lib/schooner/primitives/base.ex
+++ b/lib/schooner/primitives/base.ex
@@ -9,10 +9,25 @@ defmodule Schooner.Primitives.Base do
 
   Exactness rules follow r7rs: exact inputs (integers and rationals)
   produce exact results where possible; any inexact (float) operand
-  contaminates the whole expression. Operations that would step outside
-  the rational tower — complex numbers, irrationals — raise
-  `Schooner.Primitive.Error` rather than silently widening, since
-  Schooner ships only the integer/rational/real layers.
+  contaminates the whole expression. Real operations that produce a
+  complex result lift into the complex layer (`(sqrt -1)` ⟹ `+i`).
+
+  ## `sqrt` exact-vs-inexact split
+
+  `sqrt` keeps results exact whenever it can: a perfect-square integer
+  or rational yields an exact integer/rational; a non-square exact value
+  widens to a float. Negative real inputs lift into the imaginary axis
+  (`(sqrt -1)` ⟹ `0+i`, `(sqrt -1.0)` ⟹ `0+1.0i`). The non-finite floats
+  follow IEEE-754 directly: `(sqrt +inf.0)` ⟹ `+inf.0`, `(sqrt -inf.0)`
+  and `(sqrt +nan.0)` ⟹ `+nan.0`.
+
+  ## `expt` zero / unit-base short-circuits
+
+  `expt` follows the IEEE-754-2008 / C99 `pow` boundary rules ahead of
+  the usual NaN-propagation: anything raised to an exact `0` or signed
+  `±0.0` is `1.0` (including `(expt +nan.0 0)` and `(expt +inf.0 0)`);
+  `1` or `1.0` raised to anything is `1.0`; `±1` raised to `±inf.0` is
+  `1.0`. Outside those carve-outs, NaN propagates.
   """
 
   alias Schooner.Eval
@@ -408,8 +423,9 @@ defmodule Schooner.Primitives.Base do
 
   defp complex_int_pow(b, e), do: complex_mul(b, complex_int_pow(b, e - 1))
 
-  # IEEE-754 pow: anything^0 is 1.0 (even NaN, even infinities); 1^anything
-  # is 1.0; NaN otherwise propagates. inf^positive → inf, inf^negative → 0.0,
+  # IEEE-754 pow: anything^0 is 1.0 (even NaN, even infinities); ±1^±inf is
+  # 1.0 by the IEEE-754-2008 boundary carve-out; 1^anything is 1.0; NaN
+  # otherwise propagates. inf^positive → inf, inf^negative → 0.0,
   # |b|>1 ^ +inf → inf, |b|<1 ^ +inf → 0.0, mirrored for -inf exponents.
   defp special_expt(_, 0), do: 1.0
   defp special_expt(_, +0.0), do: 1.0
@@ -440,18 +456,18 @@ defmodule Schooner.Primitives.Base do
   defp special_expt(base, {:float_special, :pos_inf}) do
     cond do
       is_special(base) -> {:float_special, :pos_inf}
+      abs(to_float(base)) == 1.0 -> 1.0
       abs(to_float(base)) > 1.0 -> {:float_special, :pos_inf}
-      abs(to_float(base)) < 1.0 -> 0.0
-      true -> {:float_special, :nan}
+      true -> 0.0
     end
   end
 
   defp special_expt(base, {:float_special, :neg_inf}) do
     cond do
       is_special(base) -> 0.0
+      abs(to_float(base)) == 1.0 -> 1.0
       abs(to_float(base)) > 1.0 -> 0.0
-      abs(to_float(base)) < 1.0 -> {:float_special, :pos_inf}
-      true -> {:float_special, :nan}
+      true -> {:float_special, :pos_inf}
     end
   end
 

--- a/test/schooner/primitives/base_test.exs
+++ b/test/schooner/primitives/base_test.exs
@@ -645,15 +645,32 @@ defmodule Schooner.Primitives.BaseTest do
       assert run("(expt -inf.0 -3)") === 0.0
     end
 
-    test "expt — anything to the 0 is 1.0; 1 to anything is 1.0" do
+    test "expt — anything to the 0 is 1.0 (IEEE-754 anything^0 carve-out)" do
+      # IEEE-754-2008 / C99 pow: pow(NaN, 0) = pow(±inf, 0) = 1, ahead
+      # of NaN propagation. The exact-base sibling `(expt 0 0)` is exact 1.
       assert run("(expt +inf.0 0)") === 1.0
+      assert run("(expt -inf.0 0)") === 1.0
       assert run("(expt +nan.0 0)") === 1.0
+      assert run("(expt 0 0)") === 1
       assert run("(expt 1 +inf.0)") === 1.0
+    end
+
+    test "expt — anything to ±0.0 is 1.0 (signed-zero carve-out)" do
+      assert run("(expt +nan.0 0.0)") === 1.0
+      assert run("(expt +nan.0 (- 0.0))") === 1.0
+      assert run("(expt +inf.0 -0.0)") === 1.0
     end
 
     test "expt with NaN propagates (except the 0 / 1 short-circuits)" do
       assert run("(expt +nan.0 1)") == @nan
       assert run("(expt 2 +nan.0)") == @nan
+    end
+
+    test "sqrt of a negative inexact lifts into the imaginary axis (not NaN)" do
+      # `(sqrt -x)` returns `0 + sqrt(x)i` for any negative real, exact
+      # or inexact, since complex support landed.
+      assert run("(sqrt -1.0)") == {:complex, 0, 1.0}
+      assert run("(sqrt -4.0)") == {:complex, 0, 2.0}
     end
 
     test "exact->inexact is identity on specials" do
@@ -719,9 +736,20 @@ defmodule Schooner.Primitives.BaseTest do
       assert run("(expt -inf.0 +inf.0)") == @nan
     end
 
-    test "(expt -1.0 +inf.0) and (expt -1.0 -inf.0) — |base|==1 hits the NaN tail" do
-      assert run("(expt -1.0 +inf.0)") == @nan
-      assert run("(expt -1.0 -inf.0)") == @nan
+    test "(expt ±1 ±inf.0) — IEEE-754-2008 boundary: 1.0" do
+      # pow(±1, ±∞) = 1 is an explicit IEEE-754-2008 carve-out:
+      # |base| == 1 means every finite power is ±1, so the limit is well-defined.
+      assert run("(expt -1.0 +inf.0)") === 1.0
+      assert run("(expt -1.0 -inf.0)") === 1.0
+      assert run("(expt -1 +inf.0)") === 1.0
+      assert run("(expt -1 -inf.0)") === 1.0
+      assert run("(expt 1 -inf.0)") === 1.0
+      assert run("(expt 1.0 -inf.0)") === 1.0
+    end
+
+    test "(expt -1 +nan.0) propagates NaN — only ±1 raised to ±inf.0 is the carve-out" do
+      assert run("(expt -1 +nan.0)") == @nan
+      assert run("(expt -1.0 +nan.0)") == @nan
     end
 
     test "(expt -inf.0 odd-float) preserves the negative sign" do


### PR DESCRIPTION
## Summary

Aggregate fix for three IEEE-754 edge cases in `expt` and `sqrt`:

- **#12 (fix)** — `(expt -1 +inf.0)` and `(expt -1 -inf.0)` now return `1.0`, per the IEEE-754-2008 / C99 `pow` carve-out: `pow(±1, ±∞) = 1` regardless of NaN-propagation, since `|base| = 1` makes every finite power `±1` and the limit well-defined. Previously returned `+nan.0`.
- **#11 (audit)** — Pin the post-#56 behaviour that negative inexact reals (`(sqrt -1.0)`, `(sqrt -4.0)`) lift into the imaginary axis (`0+1.0i`, `0+2.0i`) rather than returning `+nan.0` or raising. The original NaN-vs-raise question was overtaken by complex support landing.
- **#13 (audit)** — Pin the IEEE-754 / C99 `pow` rule that `anything^0 = 1` short-circuits ahead of NaN-propagation: `(expt +nan.0 0)`, `(expt ±inf.0 0)`, `(expt +nan.0 ±0.0)` all return `1.0`; the exact sibling `(expt 0 0)` returns exact `1`.

Also updated the `Schooner.Primitives.Base` moduledoc with notes on `sqrt`'s exact-vs-inexact split and `expt`'s zero / unit-base short-circuits.

The only fix is for #12 (one `cond` clause in `special_expt` for each of the `:pos_inf` / `:neg_inf` exponent cases); #11 and #13 are pinned-by-test confirmations of existing behaviour.

## Test plan

- [x] `mix precommit` passes (compile --warnings-as-errors, deps.unlock --unused, format, credo --strict, test)
- [x] All 1234 existing tests still green
- [x] New tests cover `(expt ±1 ±inf.0) → 1.0`, `(expt -1 +nan.0) → +nan.0` (still NaN — only ±inf is carved out), `(expt anything 0) → 1.0`, `(expt 0 0) → exact 1`, `(sqrt -1.0) → 0+1.0i`
- [x] Existing `(expt -1.0 +inf.0)` test at `base_test.exs:722` updated to assert the new `1.0` behaviour

Closes #11
Closes #12
Closes #13