### PR TITLE
Lift Primitives.Complex and Primitives.Inexact to 100% coverage

### DIFF
--- a/test/schooner/primitives/complex_test.exs
+++ b/test/schooner/primitives/complex_test.exs
@@ -201,6 +201,20 @@ defmodule Schooner.Primitives.ComplexTest do
     test "non-finite operand rejected" do
       e = assert_raise PError, fn -> run("(make-polar +inf.0 0)") end
       assert match?({:type_error, "make-polar", _, _}, e.reason)
+
+      e = assert_raise PError, fn -> run("(make-polar 1 +nan.0)") end
+      assert match?({:type_error, "make-polar", _, _}, e.reason)
+    end
+
+    test "rational magnitude/angle flow through the rational coercion" do
+      {:complex, r, i} = run("(make-polar 1/2 0)")
+      assert_in_delta r, 0.5, 1.0e-12
+      assert_in_delta i, 0.0, 1.0e-12
+    end
+
+    test "non-number operand rejected with type-error" do
+      e = assert_raise PError, fn -> run(~s|(make-polar "x" 0)|) end
+      assert match?({:type_error, "make-polar", _, _}, e.reason)
     end
   end
 
@@ -227,9 +241,18 @@ defmodule Schooner.Primitives.ComplexTest do
       assert run("(imag-part 1/2)") === 0
     end
 
+    test "imag-part on a non-finite real is inexact zero" do
+      assert run("(imag-part +inf.0)") === 0.0
+      assert run("(imag-part -inf.0)") === 0.0
+      assert run("(imag-part +nan.0)") === 0.0
+    end
+
     test "selectors reject non-numbers" do
       e = assert_raise PError, fn -> run("(real-part 'foo)") end
       assert match?({:type_error, "real-part", _, _}, e.reason)
+
+      e = assert_raise PError, fn -> run("(imag-part 'foo)") end
+      assert match?({:type_error, "imag-part", _, _}, e.reason)
     end
   end
 
@@ -242,15 +265,35 @@ defmodule Schooner.Primitives.ComplexTest do
       assert run("(magnitude 1+i)") == :math.sqrt(2.0)
     end
 
+    test "|float complex| flows through float-component path" do
+      assert_in_delta run("(magnitude 1.5+2.5i)"), :math.sqrt(1.5 * 1.5 + 2.5 * 2.5), 1.0e-12
+    end
+
+    test "|rational complex| flows through rational-component path" do
+      # |1/2 + 1/2 i| = sqrt(1/2)
+      assert_in_delta run("(magnitude 1/2+1/2i)"), :math.sqrt(0.5), 1.0e-12
+    end
+
     test "magnitude of a real is its absolute value" do
       assert run("(magnitude -7)") === 7
       assert run("(magnitude 1/2)") == {:rational, 1, 2}
       assert run("(magnitude -1/2)") == {:rational, 1, 2}
       assert run("(magnitude -inf.0)") == {:float_special, :pos_inf}
+      assert run("(magnitude +inf.0)") == {:float_special, :pos_inf}
+      assert run("(magnitude +nan.0)") == {:float_special, :nan}
     end
 
     test "magnitude with infinite component is +inf" do
       assert run("(magnitude (make-rectangular +inf.0 5))") == {:float_special, :pos_inf}
+    end
+
+    test "magnitude with NaN component propagates NaN" do
+      assert run("(magnitude (make-rectangular +nan.0 5))") == {:float_special, :nan}
+    end
+
+    test "magnitude rejects non-numbers" do
+      e = assert_raise PError, fn -> run("(magnitude 'foo)") end
+      assert match?({:type_error, "magnitude", _, _}, e.reason)
     end
   end
 
@@ -263,6 +306,17 @@ defmodule Schooner.Primitives.ComplexTest do
     test "angle of a negative real is π" do
       assert run("(angle -5)") == pi()
       assert run("(angle -1.5)") == pi()
+    end
+
+    test "angle of a positive rational is 0; negative rational is π" do
+      assert run("(angle 1/2)") === 0
+      assert run("(angle -1/2)") == pi()
+    end
+
+    test "angle of non-finite reals" do
+      assert run("(angle +inf.0)") === 0.0
+      assert run("(angle -inf.0)") == pi()
+      assert run("(angle +nan.0)") == {:float_special, :nan}
     end
 
     test "angle of +i is π/2" do
@@ -279,6 +333,46 @@ defmodule Schooner.Primitives.ComplexTest do
 
     test "angle of -1-i is -3π/4" do
       assert_in_delta run("(angle -1-i)"), -3.0 * pi() / 4.0, 1.0e-12
+    end
+
+    test "angle with NaN component propagates NaN" do
+      assert run("(angle (make-rectangular +nan.0 1))") == {:float_special, :nan}
+      assert run("(angle (make-rectangular 1 +nan.0))") == {:float_special, :nan}
+    end
+
+    test "angle of (±inf, ±inf) — IEEE-754 atan2 quadrant boundaries" do
+      assert_in_delta run("(angle (make-rectangular +inf.0 +inf.0))"), pi() / 4.0, 1.0e-12
+
+      assert_in_delta run("(angle (make-rectangular -inf.0 +inf.0))"),
+                      3.0 * pi() / 4.0,
+                      1.0e-12
+
+      assert_in_delta run("(angle (make-rectangular +inf.0 -inf.0))"), -pi() / 4.0, 1.0e-12
+
+      assert_in_delta run("(angle (make-rectangular -inf.0 -inf.0))"),
+                      -3.0 * pi() / 4.0,
+                      1.0e-12
+    end
+
+    test "angle with infinite imag, finite real → ±π/2" do
+      assert_in_delta run("(angle (make-rectangular 5 +inf.0))"), pi() / 2.0, 1.0e-12
+      assert_in_delta run("(angle (make-rectangular 5 -inf.0))"), -pi() / 2.0, 1.0e-12
+    end
+
+    test "angle with infinite real, finite imag → 0 / π with sign-of-imag" do
+      assert run("(angle (make-rectangular +inf.0 5))") === 0.0
+      assert run("(angle (make-rectangular +inf.0 -5))") === -0.0
+      assert_in_delta run("(angle (make-rectangular -inf.0 5))"), pi(), 1.0e-12
+      assert_in_delta run("(angle (make-rectangular -inf.0 -5))"), -pi(), 1.0e-12
+      # rational imag exercises real_negative? for {:rational, ...}
+      assert run("(angle (make-rectangular +inf.0 -1/2))") === -0.0
+      # float imag exercises real_negative? for is_float
+      assert run("(angle (make-rectangular +inf.0 -1.5))") === -0.0
+    end
+
+    test "angle rejects non-numbers" do
+      e = assert_raise PError, fn -> run("(angle 'foo)") end
+      assert match?({:type_error, "angle", _, _}, e.reason)
     end
   end
 

--- a/test/schooner/primitives/inexact_test.exs
+++ b/test/schooner/primitives/inexact_test.exs
@@ -228,4 +228,84 @@ defmodule Schooner.Primitives.InexactTest do
       assert_in_delta run("(exp 1.5)"), :math.exp(1.5), 1.0e-12
     end
   end
+
+  # ---------------------------------------------------------------------------
+  # Rational inputs — every transcendental coerces a rational to its float
+  # value and runs through the float path. Pin those branches.
+  # ---------------------------------------------------------------------------
+
+  describe "transcendentals on rational inputs" do
+    test "exp / log / sin / cos / tan / atan accept rationals" do
+      assert_in_delta run("(exp 1/2)"), :math.exp(0.5), 1.0e-12
+      assert_in_delta run("(log 1/2)"), :math.log(0.5), 1.0e-12
+      assert_in_delta run("(sin 1/2)"), :math.sin(0.5), 1.0e-12
+      assert_in_delta run("(cos 1/2)"), :math.cos(0.5), 1.0e-12
+      assert_in_delta run("(tan 1/2)"), :math.tan(0.5), 1.0e-12
+      assert_in_delta run("(atan 1/2)"), :math.atan(0.5), 1.0e-12
+    end
+
+    test "asin / acos accept in-range rationals" do
+      assert_in_delta run("(asin 1/2)"), :math.asin(0.5), 1.0e-12
+      assert_in_delta run("(acos 1/2)"), :math.acos(0.5), 1.0e-12
+    end
+
+    test "log of a negative rational lifts to complex" do
+      assert run("(log -1/2)") == {:complex, :math.log(0.5), :math.pi()}
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Complex inputs that bypass the lift-on-out-of-range branch — pin the
+  # `is_complex` clauses on asin/acos and the generic_expt path.
+  # ---------------------------------------------------------------------------
+
+  describe "transcendentals on direct complex inputs" do
+    test "asin / acos on a complex literal go through the complex clause" do
+      {:complex, r, i} = run("(asin 0+i)")
+      # asin(i) = i * asinh(1)
+      assert_in_delta r, 0.0, 1.0e-12
+      assert_in_delta i, :math.log(1.0 + :math.sqrt(2.0)), 1.0e-12
+
+      {:complex, r, i} = run("(acos 0+i)")
+      assert_in_delta r, :math.pi() / 2.0, 1.0e-12
+      assert_in_delta i, -:math.log(1.0 + :math.sqrt(2.0)), 1.0e-12
+    end
+
+    test "log of a complex with rational components flows through real_to_float" do
+      {:complex, r, i} = run("(log 1/2+1/2i)")
+      # |1/2 + 1/2 i| = sqrt(1/2); arg = π/4
+      assert_in_delta r, :math.log(:math.sqrt(0.5)), 1.0e-12
+      assert_in_delta i, :math.pi() / 4.0, 1.0e-12
+    end
+
+    test "two-arg log with a complex operand exits via the complex quotient path" do
+      # log_2(1+i) = log(1+i) / log(2)
+      {:complex, r, i} = run("(log 1+i 2)")
+      ln2 = :math.log(2.0)
+      assert_in_delta r, :math.log(:math.sqrt(2.0)) / ln2, 1.0e-12
+      assert_in_delta i, :math.pi() / 4.0 / ln2, 1.0e-12
+    end
+
+    test "expt with a complex exponent dispatches to generic_expt" do
+      # (expt 2 i) = exp(i * log 2) = cos(ln 2) + i sin(ln 2)
+      {:complex, r, i} = run("(expt 2 +i)")
+      ln2 = :math.log(2.0)
+      assert_in_delta r, :math.cos(ln2), 1.0e-12
+      assert_in_delta i, :math.sin(ln2), 1.0e-12
+    end
+
+    test "expt with both operands complex dispatches to generic_expt" do
+      {:complex, r, i} = run("(expt 1+i 1+i)")
+      # (1+i)^(1+i) = exp((1+i) * log(1+i))
+      # log(1+i) = ln(sqrt 2) + i*π/4
+      lr = :math.log(:math.sqrt(2.0))
+      li = :math.pi() / 4.0
+      # (1+i)*(lr + li i) = (lr - li) + (lr + li)i
+      pr = lr - li
+      pi_ = lr + li
+      ea = :math.exp(pr)
+      assert_in_delta r, ea * :math.cos(pi_), 1.0e-12
+      assert_in_delta i, ea * :math.sin(pi_), 1.0e-12
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Complex was at 62.16%, Inexact at 87.18%. Both now 100%. All gaps were unexercised dispatch paths (rational coercion, IEEE-754 atan2 quadrant boundaries, type-error tails, direct-complex-input branches), not dead code — no production changes.

- **Complex**: added tests for `angle`/`magnitude` on non-finite reals, the four `(±inf, ±inf)` `atan2` quadrant boundaries, finite-with-one-infinite-axis cases (which exercise `copy_sign` and `real_negative?`), float / rational component coercion in `complex_magnitude` / `complex_angle`, and the type-error tails of the four selectors and `make-polar`.
- **Inexact**: added tests for rational inputs to `exp` / `log` / `sin` / `cos` / `tan` / `asin` / `acos` / `atan`, direct complex inputs to `asin`/`acos` (the existing out-of-range tests went through the lift-and-call branch and skipped the `is_complex` clause), the complex two-arg `log` quotient, and `generic_expt` reached via `(expt 2 +i)` and `(expt 1+i 1+i)`.

## Test plan

- [x] `mix precommit` clean
- [x] 1256 tests, 0 failures (was 1234 — 22 new)
- [x] `mix test --cover` confirms `Schooner.Primitives.Complex` 100.00% and `Schooner.Primitives.Inexact` 100.00%