### PR TITLE
Lift remaining primitive modules to 100% coverage (Base 99.59%)

### DIFF
--- a/test/schooner/primitives/base_rationals_test.exs
+++ b/test/schooner/primitives/base_rationals_test.exs
@@ -288,6 +288,9 @@ defmodule Schooner.Primitives.BaseRationalsTest do
     test "numerator / denominator type-check non-numbers" do
       e = assert_raise PError, fn -> run(~S|(numerator "foo")|) end
       assert match?({:type_error, "numerator", _, _}, e.reason)
+
+      e = assert_raise PError, fn -> run(~S|(denominator "foo")|) end
+      assert match?({:type_error, "denominator", _, _}, e.reason)
     end
   end
 
@@ -311,6 +314,19 @@ defmodule Schooner.Primitives.BaseRationalsTest do
       assert match?({:rational, _, _}, r)
       back = run("(exact->inexact (inexact->exact 0.1))")
       assert back === 0.1
+    end
+
+    test "exact / inexact->exact is identity on rationals" do
+      assert run("(exact 1/2)") == {:rational, 1, 2}
+      assert run("(inexact->exact 22/7)") == {:rational, 22, 7}
+    end
+
+    test "exact 0.0 yields exact integer 0 (signed-zero short-circuit)" do
+      # `Float.ratio(-0.0)` returns the giant subnormal pair, so the
+      # signed-zero case is handled ahead of the general float path.
+      assert run("(exact 0.0)") === 0
+      assert run("(exact (- 0.0))") === 0
+      assert run("(inexact->exact 0.0)") === 0
     end
 
     test "round-trip (exact->inexact (inexact->exact f)) is the identity for finite floats" do
@@ -361,6 +377,11 @@ defmodule Schooner.Primitives.BaseRationalsTest do
     test "rationalize with infinite tolerance yields 0.0" do
       assert run("(rationalize 1/3 +inf.0)") === 0.0
       assert run("(rationalize 100 -inf.0)") === 0.0
+    end
+
+    test "rationalize with infinite x yields x" do
+      assert run("(rationalize +inf.0 1)") == {:float_special, :pos_inf}
+      assert run("(rationalize -inf.0 1/10)") == {:float_special, :neg_inf}
     end
   end
 

--- a/test/schooner/primitives/base_test.exs
+++ b/test/schooner/primitives/base_test.exs
@@ -324,6 +324,18 @@ defmodule Schooner.Primitives.BaseTest do
       assert e.reason == {:division_by_zero, "/"}
     end
 
+    test "(/ +i 0) raises division_by_zero on the complex-divide path" do
+      e = assert_raise PError, fn -> run("(/ +i 0)") end
+      assert e.reason == {:division_by_zero, "/"}
+    end
+
+    test "(/ ±0.0 ±0.0) on every signed-zero combination yields +nan.0" do
+      assert run("(/ +0.0 +0.0)") == {:float_special, :nan}
+      assert run("(/ +0.0 (- 0.0))") == {:float_special, :nan}
+      assert run("(/ (- 0.0) +0.0)") == {:float_special, :nan}
+      assert run("(/ (- 0.0) (- 0.0))") == {:float_special, :nan}
+    end
+
     test "(modulo 5 0) raises division_by_zero" do
       e = assert_raise PError, fn -> run("(modulo 5 0)") end
       assert e.reason == {:division_by_zero, "modulo"}
@@ -615,6 +627,9 @@ defmodule Schooner.Primitives.BaseTest do
     test "min/max with NaN propagate NaN" do
       assert run("(min +nan.0 1 2)") == @nan
       assert run("(max 1 +nan.0 2)") == @nan
+      # NaN as the second argument hits the right-side pick_min/pick_max clause.
+      assert run("(min 1 +nan.0)") == @nan
+      assert run("(max 1 +nan.0)") == @nan
     end
 
     test "min/max with infinities" do
@@ -763,6 +778,11 @@ defmodule Schooner.Primitives.BaseTest do
 
     test "(expt 5 0) — int_pow base case" do
       assert run("(expt 5 0)") === 1
+    end
+
+    test "(expt 1+i 3) — complex int_pow odd-exponent recursion" do
+      # (1+i)^3 = (1+i) * (1+i)^2 = (1+i) * 2i = -2 + 2i
+      assert run("(expt 1+i 3)") == {:complex, -2, 2}
     end
   end
 

--- a/test/schooner/primitives/char_test.exs
+++ b/test/schooner/primitives/char_test.exs
@@ -79,8 +79,16 @@ defmodule Schooner.Primitives.CharTest do
     end
 
     test "char-foldcase on a multi-codepoint fold leaves the original char unchanged" do
-      # ß folds to "ss" — two codepoints — so char-foldcase keeps ß.
-      assert run(~s|(char-foldcase #\\ß)|) == Value.char(0x00DF)
+      # Turkish capital letter I with dot above (U+0130) downcases under the
+      # `:default` Unicode mapping to "i̇" (two codepoints), so
+      # char-foldcase falls through to the cp-unchanged branch and returns İ.
+      assert run(~s|(char-foldcase #\\İ)|) == Value.char(0x0130)
+    end
+
+    test "char-ci=? on a multi-codepoint-fold char compares the unfolded codepoint" do
+      # Same multi-codepoint fold path, exercised through the comparator.
+      assert run(~s|(char-ci=? #\\İ #\\İ)|) == Value.bool(true)
+      assert run(~s|(char-ci=? #\\İ #\\I)|) == Value.bool(false)
     end
   end
 

--- a/test/schooner/primitives/exceptions_test.exs
+++ b/test/schooner/primitives/exceptions_test.exs
@@ -238,4 +238,24 @@ defmodule Schooner.Primitives.ExceptionsTest do
       assert heap < 5_000_000, "heap grew to #{heap} words — TCO likely broken"
     end
   end
+
+  describe "with-exception-handler argument validation" do
+    test "non-procedure handler raises a type error" do
+      e =
+        assert_raise Schooner.Primitive.Error, fn ->
+          run("(with-exception-handler 42 (lambda () 1))")
+        end
+
+      assert match?({:type_error, "with-exception-handler", "procedure", _}, e.reason)
+    end
+
+    test "non-procedure thunk raises a type error" do
+      e =
+        assert_raise Schooner.Primitive.Error, fn ->
+          run("(with-exception-handler (lambda (c) c) 42)")
+        end
+
+      assert match?({:type_error, "with-exception-handler", "procedure", _}, e.reason)
+    end
+  end
 end

--- a/test/schooner/primitives/parameters_test.exs
+++ b/test/schooner/primitives/parameters_test.exs
@@ -156,5 +156,13 @@ defmodule Schooner.Primitives.ParametersTest do
                  (let ((q (make-parameter 7)))
                    (q)))|) == 7
     end
+
+    test "%parameterize-apply rejects a non-list bindings argument" do
+      # `parameterize` macro always builds a proper list, but the runtime
+      # primitive is exposed and must reject callers that hand it junk.
+      assert_raise Schooner.Primitive.Error, ~r/list of \(parameter . value\) pairs/, fn ->
+        run("(%parameterize-apply 'not-a-list (lambda () 1))")
+      end
+    end
   end
 end

--- a/test/schooner/primitives/record_test.exs
+++ b/test/schooner/primitives/record_test.exs
@@ -81,4 +81,20 @@ defmodule Schooner.Primitives.RecordTest do
       run("(%record-ref id1 'not-a-record 0)", env)
     end
   end
+
+  test "%record-ref raises with an inspected name when the type-id isn't a record-type tuple" do
+    # `%record-instance` accepts any first argument as a type id, so it's
+    # possible to construct a record whose id is a bare symbol. The error
+    # path falls through to `inspect/1` for the type name.
+    env = env()
+    real = {:record_type, "real", 1}
+    Env.define(env, "real", real)
+
+    e =
+      assert_raise PError, fn ->
+        run("(%record-ref 'junk (%record-instance real 0) 0)", env)
+      end
+
+    assert match?({:wrong_record_type, "%record-ref", _}, e.reason)
+  end
 end


### PR DESCRIPTION
## Summary

Char, Record, Parameters, and Exceptions all reach 100%. Base climbs from 98.50% to 99.59%. All gaps were unexercised dispatch / type-error tails — no production changes.

| module | before | after |
| --- | --- | --- |
| Base | 98.50% | 99.59% |
| Char | 98.53% | 100% |
| Exceptions | 95.45% | 100% |
| Parameters | 94.74% | 100% |
| Record | 92.31% | 100% |

### What was added

- **Base**: complex-divide-by-zero `(/ +i 0)`, the four signed-zero `/` combinations producing NaN, second-arg NaN in `(min ...)`, the odd-exponent recursion in `complex_int_pow` via `(expt 1+i 3)`, `(exact 1/2)` rational round-trip, the signed-zero `(exact 0.0)` short-circuit, the `denominator` type-error tail, and `rationalize` with an infinite `x`.
- **Char**: a multi-codepoint `:default`-mode downcase (Turkish capital İ, U+0130) that exercises the cp-unchanged fallthrough in both `char-foldcase` and `char-ci=?`. The previous ß test claimed to cover this but `:default` mode actually leaves ß as a single codepoint.
- **Record**: `(%record-ref 'junk ...)` with a non-record-type id exercises the `inspect/1` tail of `type_name/1`.
- **Parameters**: `(%parameterize-apply 'not-a-list ...)` exercises the improper-bindings tail of `build_frame/2`.
- **Exceptions**: non-procedure handler / thunk hit `with-exception-handler`'s type-check tail.

### Remaining gap (Base 99.59%)

Three defensive fallbacks in `odd_integer?/1` (482), `do_sqrt/1` (532), and `signum/1` (1574). Each is unreachable from any current call site:

- `odd_integer?/_` — `special_expt` only invokes it after `finite_exp_sign(exp) == 1`, which restricts `exp` to positive int / float; the prior clauses cover both.
- `do_sqrt/_` raise — `sqrt_/1` calls `require_number!` first, and the recognised number types are exactly the ones the prior clauses cover.
- `signum(0)` — the only caller (`modulo`) gates on `r != 0` and `b != 0`, so neither argument is ever zero.

These are documentation-grade defensive tails. Removing them would close the gap but trade defence-in-depth for a coverage metric — flagging for visibility rather than acting on unilaterally.

## Test plan

- [x] `mix precommit` clean
- [x] 1267 tests, 0 failures (was 1234 before this branch + #71's 1234 → +33)
- [x] `mix test --cover` confirms each module above and the totals quoted