### PR TITLE
Make append tail-recursive on input list length

### DIFF
--- a/lib/schooner/primitives/base.ex
+++ b/lib/schooner/primitives/base.ex
@@ -973,15 +973,21 @@ defmodule Schooner.Primitives.Base do
 
   defp append_(args) do
     {fronts, [last]} = Enum.split(args, length(args) - 1)
-    Enum.each(fronts, &require_proper_list!("append", &1))
-    do_append(fronts, last)
+    do_append(Enum.reverse(fronts), last)
   end
 
   defp do_append([], tail), do: tail
-  defp do_append([list | rest], tail), do: append_pair(list, do_append(rest, tail))
 
-  defp append_pair([], tail), do: tail
-  defp append_pair([h | t], tail), do: [h | append_pair(t, tail)]
+  defp do_append([list | rest], tail) do
+    do_append(rest, prepend_reversed(reverse_proper(list, []), tail))
+  end
+
+  defp reverse_proper([], acc), do: acc
+  defp reverse_proper([h | t], acc), do: reverse_proper(t, [h | acc])
+  defp reverse_proper(other, _acc), do: raise(Error, reason: {:improper_list, "append", other})
+
+  defp prepend_reversed([], tail), do: tail
+  defp prepend_reversed([h | t], tail), do: prepend_reversed(t, [h | tail])
 
   defp list_tail([list, k]) do
     require_integer!("list-tail", k)

--- a/test/schooner/primitives/base_pairs_test.exs
+++ b/test/schooner/primitives/base_pairs_test.exs
@@ -89,6 +89,16 @@ defmodule Schooner.Primitives.BasePairsTest do
       e = assert_raise PError, fn -> run("(append (cons 1 2) '(3))") end
       assert match?({:improper_list, "append", _}, e.reason)
     end
+
+    test "appending a 100k-element list does not blow the stack" do
+      result =
+        run("""
+        (let ((xs (vector->list (make-vector 100000 0))))
+          (length (append xs '(a b c))))
+        """)
+
+      assert result == 100_003
+    end
   end
 
   describe "list-tail / list-ref" do


### PR DESCRIPTION
## Summary
- Replace `append_pair/2`'s non-tail-recursive walk with a `reverse_proper/2` + `prepend_reversed/2` pass; both are direct tail calls so stack usage stays flat regardless of input size.
- Walk fronts right-to-left so element order is preserved.
- Drop the pre-flight `Enum.each(fronts, &require_proper_list!("append", &1))` — `reverse_proper/2` raises with `{:improper_list, "append", _}` the moment it hits improperness.
- Add a 100k-element regression test that previously could overflow the BEAM stack.

Closes #19.

## Test plan
- [x] `mix precommit` (compile/format/credo/test) — 1268 tests pass
- [x] Existing append tests in `test/schooner/primitives/base_pairs_test.exs` unchanged
- [x] New regression test: `(append (vector->list (make-vector 100000 0)) '(a b c))` returns length 100003 without crashing

## Note on observable behaviour
Improper-list errors for non-final args now raise mid-walk rather than before any work happens. The reason tag is unchanged (`{:improper_list, "append", _}`), so `with-exception-handler` consumers see the same data — only the position in the call sequence shifts.