### PR TITLE
Make run/1 vs eval/2 trust posture unmissable (#45)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,29 @@
 
 An embeddable, sandboxed Scheme interpreter for the BEAM, targeting the
 r7rs-small language minus its mutable operations. Schooner is intended as
-a scripting layer for Elixir applications: hosts hand a script source to
-`Schooner.run/1`, get back an Elixir term, and resource-bound the work
-with the standard process tools (`:max_heap_size`, `Task.shutdown/2`).
+a scripting layer for Elixir applications: hosts hand a script source
+to one of the entry points below, get back an Elixir term, and
+resource-bound the work with the standard process tools
+(`:max_heap_size`, `Task.shutdown/2`).
+
+## Choosing an entry point
+
+Schooner has two top-level evaluation entry points. **The trust posture
+differs — picking the wrong one for untrusted input is a sandbox-shaped
+hole.** The naming is the opposite of what reflex suggests: `run/1` is
+the lax convenience, `eval/2` is the strict embedding path.
+
+| Entry point        | Auto-imports                                                                              | Trust posture                                       | Use for                                                            |
+| ---                | ---                                                                                       | ---                                                 | ---                                                                |
+| `Schooner.run/1`   | injects `(import ...)` of every shipped standard library when the script declares none    | **Not sandbox-safe.** Every primitive is in scope.  | tests, REPL-style use, your own scripts where you control the source |
+| `Schooner.eval/2`  | none — bindings come exclusively from `env` and the script's own `(import ...)`           | **Sandbox-safe.** The embedder controls the surface.| embedding untrusted or semi-trusted scripts                        |
+
+The implicit-import behaviour of `run/1` is opt-in via
+`Schooner.eval(source, env, implicit_imports: :all)`; `run/1` is just
+that call with a fresh `Schooner.Env`. Use `eval/2` (no options) for
+anything you would not paste into your own REPL — a script that omits
+`(import ...)` cannot reach any primitive, so the host gets to set the
+surface deliberately.
 
 ## Installation
 

--- a/lib/schooner.ex
+++ b/lib/schooner.ex
@@ -10,17 +10,37 @@ defmodule Schooner do
   live in a separate `Schooner.Expander.SyntaxEnv` threaded through
   expansion only.
 
-  ## Entry points
+  ## Choosing an entry point
 
-    * `run/1` — convenience entry that pre-populates the environment
-      via implicit `(import ...)` of every shipped standard library
-      when the script has no explicit imports of its own. Use this
-      from tests and quick-evaluations where ergonomics matter more
-      than a tight surface.
-    * `eval/2` — strict path: bindings only come from `(import ...)`
-      declarations in the script source plus whatever is already in
-      the supplied env. Use this when an embedder cares about which
-      bindings a script can see.
+  Schooner has two top-level evaluation entry points. **The trust
+  posture differs — picking the wrong one for untrusted input is a
+  sandbox-shaped hole.** The naming is the opposite of what reflex
+  suggests: `run/1` is the lax convenience, `eval/2` is the strict
+  embedding path.
+
+  | Entry point | Auto-imports | Trust posture | Use for |
+  | ---         | ---          | ---           | --- |
+  | `run/1`     | injects `(import ...)` of every shipped standard library when the script declares none | **Not sandbox-safe.** Every shipped primitive is in scope by default. | tests, REPL-style use, your own scripts where you control the source |
+  | `eval/2`    | none — bindings come exclusively from `env` and the script's own `(import ...)` declarations | **Sandbox-safe.** The embedder controls the surface. | embedding untrusted or semi-trusted scripts |
+
+  The implicit-import behaviour of `run/1` is opt-in via the
+  `implicit_imports: :all` option on `eval/3`; `run/1` is exactly
+  `eval(source, Env.new(), implicit_imports: :all)`. Embedders who want
+  the convenience without the rename can call `eval/3` with the option
+  themselves.
+
+  ### Embedding untrusted code
+
+  Use `eval/2` and require the script to declare exactly which libraries
+  it needs. A script that omits `(import ...)` cannot reach any
+  primitive — even `+` is unbound:
+
+      iex> Schooner.eval("(import (only (scheme base) +)) (+ 1 2)", Schooner.Env.new())
+      3
+
+  Pair this with BEAM-level resource limits — run `eval/2` inside a
+  spawned process with `:max_heap_size` and a `Task.shutdown/2` timeout
+  so a runaway script cannot exhaust the host.
 
   The full embedding API (`Schooner.Environment.new/1`,
   `Schooner.compile/1`, `Schooner.Host`) arrives in phase 14.
@@ -37,35 +57,33 @@ defmodule Schooner do
   alias Schooner.Reader
   alias Schooner.Value
 
-  # Implicit imports applied by `run/1` when the script has no
-  # explicit `(import ...)` of its own. Pre-parsed at compile time so
-  # the default path does not pay reader cost on every call.
-  @default_run_imports_forms Reader.read_string(
-                               "(import (scheme base) (scheme cxr) (scheme char) " <>
-                                 "(scheme inexact) (scheme complex) (scheme write) " <>
-                                 "(scheme read) (scheme case-lambda) (scheme lazy))"
-                             )
+  # Implicit imports applied when `implicit_imports: :all` is set and
+  # the script has no explicit `(import ...)` of its own. Pre-parsed at
+  # compile time so the option path does not pay reader cost on every
+  # call.
+  @default_implicit_imports_forms Reader.read_string(
+                                    "(import (scheme base) (scheme cxr) (scheme char) " <>
+                                      "(scheme inexact) (scheme complex) (scheme write) " <>
+                                      "(scheme read) (scheme case-lambda) (scheme lazy))"
+                                  )
 
   @doc """
-  Read and evaluate `source` in a fresh empty env. If `source`
-  contains no top-level `(import ...)` declarations, an implicit
-  import of every standard library is injected so quick-eval scripts
-  can use `+`, `cond`, `display`, etc. without ceremony. Scripts that
-  declare even a single explicit import skip the injection — the user
-  has signalled they want to control the surface.
+  Read and evaluate `source` in a fresh empty env, with every shipped
+  standard library implicitly imported when the script declares no
+  imports of its own.
+
+  This is a one-line convenience over `eval/3`:
+
+      Schooner.eval(source, Schooner.Env.new(), implicit_imports: :all)
+
+  **Not for untrusted input.** A script with no `(import ...)` form
+  reaches every primitive Schooner ships with. Use `eval/2` for
+  embedding scripts you do not control — see "Choosing an entry point"
+  in the moduledoc.
   """
   @spec run(binary()) :: Value.t()
   def run(source) when is_binary(source) do
-    forms = Reader.read_string(source)
-    {explicit_imports, _body} = LibImport.extract_program_imports(forms)
-
-    forms =
-      case explicit_imports do
-        [] -> @default_run_imports_forms ++ forms
-        _ -> forms
-      end
-
-    do_eval(forms, Env.new())
+    eval(source, Env.new(), implicit_imports: :all)
   end
 
   @doc """
@@ -73,10 +91,57 @@ defmodule Schooner do
   definitions and any explicit `(import ...)` bindings into it. No
   implicit imports are added — bindings come exclusively from `env`
   and from the script's own `(import ...)` declarations.
+
+  This is the strict path: it is the right entry point for embedding
+  scripts whose source the host does not control. See "Choosing an
+  entry point" in the moduledoc.
+
+  Equivalent to `eval(source, env, [])`.
   """
   @spec eval(binary(), Env.t()) :: Value.t()
   def eval(source, %Env{} = env) when is_binary(source) do
-    do_eval(Reader.read_string(source), env)
+    eval(source, env, [])
+  end
+
+  @doc """
+  Read and evaluate `source` against `env` with `opts`.
+
+  Options:
+
+    * `:implicit_imports` — controls implicit imports prepended to a
+      script that declares none of its own.
+        * `:none` (default) — no implicit imports. Bindings come
+          exclusively from `env` and the script's own
+          `(import ...)` declarations. Use this for untrusted input.
+        * `:all` — implicitly import every shipped standard library.
+          Skipped if the script already declares any `(import ...)`,
+          on the principle that an explicit import means the user has
+          opted in to a tighter surface.
+  """
+  @spec eval(binary(), Env.t(), keyword()) :: Value.t()
+  def eval(source, %Env{} = env, opts) when is_binary(source) and is_list(opts) do
+    forms = Reader.read_string(source)
+
+    forms =
+      case Keyword.get(opts, :implicit_imports, :none) do
+        :none ->
+          forms
+
+        :all ->
+          {explicit_imports, _body} = LibImport.extract_program_imports(forms)
+
+          case explicit_imports do
+            [] -> @default_implicit_imports_forms ++ forms
+            _ -> forms
+          end
+
+        other ->
+          raise ArgumentError,
+                "invalid value for :implicit_imports — expected :none or :all, got: " <>
+                  inspect(other)
+      end
+
+    do_eval(forms, env)
   end
 
   defp do_eval(forms, %Env{} = env) do

--- a/test/schooner/import_only_path_test.exs
+++ b/test/schooner/import_only_path_test.exs
@@ -34,6 +34,21 @@ defmodule Schooner.ImportOnlyPathTest do
       end
     end
 
+    test "the strict default does not pull in (scheme base)" do
+      # Pin the sandbox guarantee that `eval/2` advertises in the
+      # moduledoc: no auto-import of any shipped library, including
+      # (scheme base). If this regresses, embedders relying on the
+      # strict surface for untrusted input would silently lose it.
+      # Names checked here are primitive procedure bindings — not
+      # special forms or bootstrap-supplied macros, which dispatch on
+      # the literal symbol regardless of imports.
+      for binding <- ~w(+ - * / car cdr cons list display) do
+        assert_raise EvalError, fn ->
+          Schooner.eval("(#{binding})", Env.new())
+        end
+      end
+    end
+
     test "explicit (only (scheme base) car) hides '+' from the script" do
       assert Schooner.eval(
                "(import (only (scheme base) car)) (car '(1 2 3))",
@@ -54,6 +69,56 @@ defmodule Schooner.ImportOnlyPathTest do
                "(import (scheme base) (scheme inexact)) (sin 0)",
                Env.new()
              ) == 0.0
+    end
+  end
+
+  describe "Schooner.eval/3 :implicit_imports option" do
+    test ":implicit_imports defaults to :none" do
+      assert_raise EvalError, fn ->
+        Schooner.eval("(+ 1 2)", Env.new(), [])
+      end
+    end
+
+    test ":implicit_imports: :none matches the eval/2 strict default" do
+      assert_raise EvalError, fn ->
+        Schooner.eval("(+ 1 2)", Env.new(), implicit_imports: :none)
+      end
+    end
+
+    test ":implicit_imports: :all auto-imports the standard libraries" do
+      assert Schooner.eval("(+ 1 2)", Env.new(), implicit_imports: :all) == 3
+      assert Schooner.eval("(sin 0)", Env.new(), implicit_imports: :all) == 0.0
+    end
+
+    test ":implicit_imports: :all is suppressed by an explicit import" do
+      # Same opt-in semantics run/1 has: a single explicit import
+      # disables the injection.
+      assert Schooner.eval(
+               "(import (only (scheme base) +)) (+ 1 2)",
+               Env.new(),
+               implicit_imports: :all
+             ) == 3
+
+      assert_raise EvalError, fn ->
+        Schooner.eval(
+          "(import (only (scheme base) +)) (sin 0)",
+          Env.new(),
+          implicit_imports: :all
+        )
+      end
+    end
+
+    test "run/1 is equivalent to eval/3 with implicit_imports: :all on a fresh env" do
+      for source <- ["(+ 1 2)", "(sin 0)", "(import (only (scheme base) +)) (+ 1 2)"] do
+        assert Schooner.run(source) ==
+                 Schooner.eval(source, Env.new(), implicit_imports: :all)
+      end
+    end
+
+    test "an unknown :implicit_imports value raises ArgumentError" do
+      assert_raise ArgumentError, ~r/:implicit_imports/, fn ->
+        Schooner.eval("(+ 1 2)", Env.new(), implicit_imports: :everything)
+      end
     end
   end
 end


### PR DESCRIPTION
Closes #45.

`Schooner.run/1`'s implicit `(import ...)` of every shipped standard library was a sandboxing footgun: the obviously-named entry point silently widened the surface for any script that happened to omit imports — exactly the case where untrusted input is most likely to omit them. The naming was the opposite of the trust posture: `run/1` lax, `eval/2` strict.

## Summary

- **Mitigation (3): split the implicit-import behaviour into an explicit option.** New `Schooner.eval/3` accepts `implicit_imports: :all | :none` (default `:none`). `run/1` is now a one-liner: `eval(source, Env.new(), implicit_imports: :all)`. The implicit-import set lives in one place; the behaviour is discoverable via the function signature instead of by docstring.
- **Mitigation (2): loud moduledoc + README.** Both gain a "Choosing an entry point" section with a comparison table (auto-imports, trust posture, intended audience) and a doctest demonstrating the correct embedding pattern.
- **No rename, no breaking change.** `run/1` and `eval/2` keep their signatures and meanings; existing call sites are unaffected.

## Test plan

- [x] `mix precommit` green (compile-warn-as-errors, format, credo --strict, 1275 tests + 1 doctest, 0 failures)
- [x] New tests pin: `eval/2` with no opts does not pull in `(scheme base)` (covers `+`, `-`, `*`, `/`, `car`, `cdr`, `cons`, `list`, `display`)
- [x] New tests pin: `eval/3` with `implicit_imports: :all` matches `run/1` semantics (including the "explicit import suppresses injection" rule)
- [x] New tests pin: unknown `:implicit_imports` value raises `ArgumentError`
- [x] Doctest in moduledoc demonstrates the correct embedding pattern