### PR TITLE
Issue #18: report arity overflow with got-count, not :too_many sentinel

### DIFF
--- a/lib/schooner/eval.ex
+++ b/lib/schooner/eval.ex
@@ -251,6 +251,14 @@ defmodule Schooner.Eval do
     end
   end
 
+  defp check_primitive_arity!({:between, lo, hi}, args, name) do
+    got = length(args)
+
+    if got < lo or got > hi do
+      raise(Error, reason: {:arity_mismatch, name, {:between, lo, hi}, got})
+    end
+  end
+
   # `letrec*` is the workhorse for both user-facing recursive bindings
   # (the `let`, `let*`, `letrec`, `letrec*`, named-`let` bootstrap
   # macros all expand to it eventually) and for internal-define

--- a/lib/schooner/eval/error.ex
+++ b/lib/schooner/eval/error.ex
@@ -49,6 +49,10 @@ defmodule Schooner.Eval.Error do
     "arity mismatch in #{name_str(name)}: expected at most #{expected}, got #{got}"
   end
 
+  defp format({:arity_mismatch, name, {:between, lo, hi}, got}) do
+    "arity mismatch in #{name_str(name)}: expected between #{lo} and #{hi}, got #{got}"
+  end
+
   defp name_str(nil), do: "anonymous procedure"
   defp name_str(name) when is_binary(name), do: "`#{name}`"
 end

--- a/lib/schooner/primitives/base.ex
+++ b/lib/schooner/primitives/base.ex
@@ -57,7 +57,7 @@ defmodule Schooner.Primitives.Base do
   `Schooner.Library.Standard` consumes this to assemble the
   `(scheme base)` library entry.
   """
-  @spec specs() :: [{binary(), non_neg_integer() | {:at_least, non_neg_integer()}, fun()}]
+  @spec specs() :: [{binary(), Value.arity_spec(), fun()}]
   def specs do
     arithmetic_specs() ++
       comparison_specs() ++
@@ -1103,14 +1103,14 @@ defmodule Schooner.Primitives.Base do
   defp vector_specs do
     [
       {"vector", {:at_least, 0}, &vector_ctor/1},
-      {"make-vector", {:at_least, 1}, &make_vector/1},
+      {"make-vector", {:between, 1, 2}, &make_vector/1},
       {"vector-length", 1, &vector_length/1},
       {"vector-ref", 2, &vector_ref/1},
-      {"vector->list", {:at_least, 1}, &vector_to_list/1},
+      {"vector->list", {:between, 1, 3}, &vector_to_list/1},
       {"list->vector", 1, &list_to_vector/1},
       {"vector-map", {:at_least, 2}, &vector_map/1},
       {"vector-for-each", {:at_least, 2}, &vector_for_each/1},
-      {"vector-copy", {:at_least, 1}, &vector_copy/1},
+      {"vector-copy", {:between, 1, 3}, &vector_copy/1},
       {"vector-append", {:at_least, 0}, &vector_append/1}
     ]
   end
@@ -1122,10 +1122,6 @@ defmodule Schooner.Primitives.Base do
   defp make_vector([k, fill]) do
     n = require_size!("make-vector", k)
     Value.vector(List.duplicate(fill, n))
-  end
-
-  defp make_vector([_, _ | _]) do
-    raise(Error, reason: {:type_error, "make-vector", "1 or 2 arguments", :too_many})
   end
 
   defp vector_length([{:vector, t}]), do: tuple_size(t)
@@ -1196,10 +1192,6 @@ defmodule Schooner.Primitives.Base do
   defp vector_copy([v, start]), do: vector_copy_range(v, start, nil)
   defp vector_copy([v, start, end_]), do: vector_copy_range(v, start, end_)
 
-  defp vector_copy([_, _, _, _ | _]) do
-    raise(Error, reason: {:type_error, "vector-copy", "1 to 3 arguments", :too_many})
-  end
-
   defp vector_copy_range({:vector, t}, start, end_) do
     n = tuple_size(t)
     s = if start == nil, do: 0, else: require_bound!("vector-copy", start, 0, n)
@@ -1227,13 +1219,13 @@ defmodule Schooner.Primitives.Base do
   defp bytevector_specs do
     [
       {"bytevector", {:at_least, 0}, &bytevector_ctor/1},
-      {"make-bytevector", {:at_least, 1}, &make_bytevector/1},
+      {"make-bytevector", {:between, 1, 2}, &make_bytevector/1},
       {"bytevector-length", 1, &bytevector_length/1},
       {"bytevector-u8-ref", 2, &bytevector_u8_ref/1},
-      {"bytevector-copy", {:at_least, 1}, &bytevector_copy/1},
+      {"bytevector-copy", {:between, 1, 3}, &bytevector_copy/1},
       {"bytevector-append", {:at_least, 0}, &bytevector_append/1},
-      {"utf8->string", {:at_least, 1}, &utf8_to_string/1},
-      {"string->utf8", {:at_least, 1}, &string_to_utf8/1}
+      {"utf8->string", {:between, 1, 3}, &utf8_to_string/1},
+      {"string->utf8", {:between, 1, 3}, &string_to_utf8/1}
     ]
   end
 
@@ -1248,10 +1240,6 @@ defmodule Schooner.Primitives.Base do
     n = require_size!("make-bytevector", k)
     b = require_byte!("make-bytevector", fill)
     Value.bytevector(:binary.copy(<<b>>, n))
-  end
-
-  defp make_bytevector([_, _ | _]) do
-    raise(Error, reason: {:type_error, "make-bytevector", "1 or 2 arguments", :too_many})
   end
 
   defp bytevector_length([{:bytevector, b}]), do: byte_size(b)
@@ -1270,10 +1258,6 @@ defmodule Schooner.Primitives.Base do
   defp bytevector_copy([v]), do: bytevector_copy_range(v, nil, nil)
   defp bytevector_copy([v, start]), do: bytevector_copy_range(v, start, nil)
   defp bytevector_copy([v, start, end_]), do: bytevector_copy_range(v, start, end_)
-
-  defp bytevector_copy([_, _, _, _ | _]) do
-    raise(Error, reason: {:type_error, "bytevector-copy", "1 to 3 arguments", :too_many})
-  end
 
   defp bytevector_copy_range({:bytevector, b}, start, end_) do
     n = byte_size(b)
@@ -1295,10 +1279,6 @@ defmodule Schooner.Primitives.Base do
   defp utf8_to_string([v, start]), do: utf8_to_string_range(v, start, nil)
   defp utf8_to_string([v, start, end_]), do: utf8_to_string_range(v, start, end_)
 
-  defp utf8_to_string([_, _, _, _ | _]) do
-    raise(Error, reason: {:type_error, "utf8->string", "1 to 3 arguments", :too_many})
-  end
-
   defp utf8_to_string_range({:bytevector, b}, start, end_) do
     n = byte_size(b)
     s = if start == nil, do: 0, else: require_bound!("utf8->string", start, 0, n)
@@ -1317,10 +1297,6 @@ defmodule Schooner.Primitives.Base do
   defp string_to_utf8([v, start]), do: string_to_utf8_range(v, start, nil)
   defp string_to_utf8([v, start, end_]), do: string_to_utf8_range(v, start, end_)
 
-  defp string_to_utf8([_, _, _, _ | _]) do
-    raise(Error, reason: {:type_error, "string->utf8", "1 to 3 arguments", :too_many})
-  end
-
   defp string_to_utf8_range(s, start, end_) when is_binary(s) do
     {sbyte, slen} = string_byte_slice(s, start || 0, end_, "string->utf8")
     Value.bytevector(:binary.part(s, sbyte, slen))
@@ -1336,7 +1312,7 @@ defmodule Schooner.Primitives.Base do
   defp string_specs do
     [
       {"string", {:at_least, 0}, &string_ctor/1},
-      {"make-string", {:at_least, 1}, &make_string/1},
+      {"make-string", {:between, 1, 2}, &make_string/1},
       {"string-length", 1, &string_length/1},
       {"string-ref", 2, &string_ref/1},
       {"string-append", {:at_least, 0}, &string_append/1},
@@ -1346,11 +1322,11 @@ defmodule Schooner.Primitives.Base do
       {"string<=?", {:at_least, 2}, &string_le/1},
       {"string>?", {:at_least, 2}, &string_gt/1},
       {"string>=?", {:at_least, 2}, &string_ge/1},
-      {"string->list", {:at_least, 1}, &string_to_list/1},
+      {"string->list", {:between, 1, 3}, &string_to_list/1},
       {"list->string", 1, &list_to_string/1},
       {"string-upcase", 1, &string_upcase/1},
       {"string-downcase", 1, &string_downcase/1},
-      {"string-copy", {:at_least, 1}, &string_copy/1}
+      {"string-copy", {:between, 1, 3}, &string_copy/1}
     ]
   end
 
@@ -1369,10 +1345,6 @@ defmodule Schooner.Primitives.Base do
     n = require_size!("make-string", k)
     cp = require_char!("make-string", char)
     Value.string(:binary.copy(codepoint_to_utf8(cp), n))
-  end
-
-  defp make_string([_, _ | _]) do
-    raise(Error, reason: {:type_error, "make-string", "1 or 2 arguments", :too_many})
   end
 
   defp string_length([s]) when is_binary(s), do: string_codepoint_length(s)
@@ -1428,10 +1400,6 @@ defmodule Schooner.Primitives.Base do
   defp string_to_list([v, start]), do: string_to_list_range(v, start, nil)
   defp string_to_list([v, start, end_]), do: string_to_list_range(v, start, end_)
 
-  defp string_to_list([_, _, _, _ | _]) do
-    raise(Error, reason: {:type_error, "string->list", "1 to 3 arguments", :too_many})
-  end
-
   defp string_to_list_range(s, start, end_) when is_binary(s) do
     cps = slice_codepoints(s, start || 0, end_, "string->list")
     Value.list(Enum.map(cps, &Value.char/1))
@@ -1463,10 +1431,6 @@ defmodule Schooner.Primitives.Base do
   defp string_copy([v]), do: string_copy_range(v, nil, nil)
   defp string_copy([v, start]), do: string_copy_range(v, start, nil)
   defp string_copy([v, start, end_]), do: string_copy_range(v, start, end_)
-
-  defp string_copy([_, _, _, _ | _]) do
-    raise(Error, reason: {:type_error, "string-copy", "1 to 3 arguments", :too_many})
-  end
 
   defp string_copy_range(s, nil, nil) when is_binary(s), do: Value.string(s)
 

--- a/lib/schooner/primitives/char.ex
+++ b/lib/schooner/primitives/char.ex
@@ -26,7 +26,7 @@ defmodule Schooner.Primitives.Char do
   tuple. Used by `Schooner.Library.Standard` to assemble
   `(scheme char)`.
   """
-  @spec specs() :: [{binary(), non_neg_integer() | {:at_least, non_neg_integer()}, fun()}]
+  @spec specs() :: [{binary(), Value.arity_spec(), fun()}]
   def specs do
     [
       {"char->integer", 1, &char_to_integer/1},

--- a/lib/schooner/primitives/continuations.ex
+++ b/lib/schooner/primitives/continuations.ex
@@ -54,7 +54,7 @@ defmodule Schooner.Primitives.Continuations do
   Consumed by `Schooner.Library.Standard` as part of the
   `(scheme base)` assembly.
   """
-  @spec specs() :: [{binary(), non_neg_integer() | {:at_least, non_neg_integer()}, fun()}]
+  @spec specs() :: [{binary(), Value.arity_spec(), fun()}]
   def specs do
     [
       {"call-with-current-continuation", 1, &call_cc/1},

--- a/lib/schooner/primitives/exceptions.ex
+++ b/lib/schooner/primitives/exceptions.ex
@@ -24,7 +24,7 @@ defmodule Schooner.Primitives.Exceptions do
   Consumed by `Schooner.Library.Standard` as part of the
   `(scheme base)` assembly.
   """
-  @spec specs() :: [{binary(), non_neg_integer() | {:at_least, non_neg_integer()}, fun()}]
+  @spec specs() :: [{binary(), Value.arity_spec(), fun()}]
   def specs do
     [
       {"error", {:at_least, 1}, &error/1},

--- a/lib/schooner/primitives/inexact.ex
+++ b/lib/schooner/primitives/inexact.ex
@@ -31,17 +31,17 @@ defmodule Schooner.Primitives.Inexact do
   tuple. Used by `Schooner.Library.Standard` to assemble
   `(scheme inexact)`.
   """
-  @spec specs() :: [{binary(), non_neg_integer() | {:at_least, non_neg_integer()}, fun()}]
+  @spec specs() :: [{binary(), Value.arity_spec(), fun()}]
   def specs do
     [
       {"exp", 1, &exp_/1},
-      {"log", {:at_least, 1}, &log_/1},
+      {"log", {:between, 1, 2}, &log_/1},
       {"sin", 1, &sin_/1},
       {"cos", 1, &cos_/1},
       {"tan", 1, &tan_/1},
       {"asin", 1, &asin_/1},
       {"acos", 1, &acos_/1},
-      {"atan", {:at_least, 1}, &atan_/1},
+      {"atan", {:between, 1, 2}, &atan_/1},
       {"finite?", 1, &finite_p/1},
       {"infinite?", 1, &infinite_p/1},
       {"nan?", 1, &nan_p/1}
@@ -151,7 +151,6 @@ defmodule Schooner.Primitives.Inexact do
 
   defp atan_([x]), do: atan_one(x, "atan")
   defp atan_([y, x]), do: atan_two(y, x, "atan")
-  defp atan_(_), do: raise(Error, reason: {:type_error, "atan", "1 or 2 arguments", :too_many})
 
   defp atan_one(z, _) when is_complex(z), do: complex_atan(z)
   defp atan_one({:float_special, :pos_inf}, _), do: :math.pi() / 2.0

--- a/lib/schooner/primitives/record.ex
+++ b/lib/schooner/primitives/record.ex
@@ -44,7 +44,7 @@ defmodule Schooner.Primitives.Record do
   `(scheme base)` assembly (record machinery is in r7rs §5.4 of
   base).
   """
-  @spec specs() :: [{binary(), non_neg_integer() | {:at_least, non_neg_integer()}, fun()}]
+  @spec specs() :: [{binary(), Value.arity_spec(), fun()}]
   def specs do
     [
       {@instance_name, {:at_least, 1}, &record_instance/1},

--- a/lib/schooner/value.ex
+++ b/lib/schooner/value.ex
@@ -87,7 +87,10 @@ defmodule Schooner.Value do
   @type error_obj_v :: {:error_obj, error_kind(), t(), [t()]}
   @type promise_v :: {:promise, :forced, t()} | {:promise, :lazy, term()}
   @type parameter_v :: {:parameter, integer(), t(), t() | nil}
-  @type arity_spec :: non_neg_integer() | {:at_least, non_neg_integer()}
+  @type arity_spec ::
+          non_neg_integer()
+          | {:at_least, non_neg_integer()}
+          | {:between, non_neg_integer(), non_neg_integer()}
 
   @type t ::
           bool_v()

--- a/test/schooner/eval_test.exs
+++ b/test/schooner/eval_test.exs
@@ -294,6 +294,20 @@ defmodule Schooner.EvalTest do
     end
   end
 
+  describe "primitive arity_mismatch surfaces on out-of-range supply to {:between, lo, hi}" do
+    test "make-vector with 3 args reports got count, not the :too_many sentinel" do
+      e = assert_raise Error, fn -> run("(make-vector 1 2 3)") end
+      assert e.reason == {:arity_mismatch, "make-vector", {:between, 1, 2}, 3}
+      assert e.message =~ "expected between 1 and 2, got 3"
+      refute e.message =~ ":too_many"
+    end
+
+    test "under-supply to a {:between, lo, hi} primitive also raises arity_mismatch" do
+      e = assert_raise Error, fn -> run("(make-vector)") end
+      assert e.reason == {:arity_mismatch, "make-vector", {:between, 1, 2}, 0}
+    end
+  end
+
   describe "guard clause whose test evaluates to literal #f" do
     test "false-test clause is skipped, next clause matches" do
       assert run("""

--- a/test/schooner/primitives/base_test.exs
+++ b/test/schooner/primitives/base_test.exs
@@ -1,6 +1,7 @@
 defmodule Schooner.Primitives.BaseTest do
   use ExUnit.Case, async: true
 
+  alias Schooner.Eval.Error, as: EvalError
   alias Schooner.Primitive.Error, as: PError
   alias Schooner.Value
 
@@ -873,8 +874,9 @@ defmodule Schooner.Primitives.BaseTest do
     end
 
     test "make-vector with too many args" do
-      e = assert_raise PError, fn -> run("(make-vector 3 0 0)") end
-      assert match?({:type_error, "make-vector", "1 or 2 arguments", :too_many}, e.reason)
+      e = assert_raise EvalError, fn -> run("(make-vector 3 0 0)") end
+      assert e.reason == {:arity_mismatch, "make-vector", {:between, 1, 2}, 3}
+      assert e.message =~ "expected between 1 and 2, got 3"
     end
 
     test "bytevector ops reject non-bytevector arg" do
@@ -891,14 +893,14 @@ defmodule Schooner.Primitives.BaseTest do
     end
 
     test "make-bytevector / bytevector-copy / utf8->string with too many args" do
-      for {op, src} <- [
-            {"make-bytevector", "(make-bytevector 3 0 0)"},
-            {"bytevector-copy", "(bytevector-copy #u8(1 2 3) 0 1 2)"},
-            {"utf8->string", "(utf8->string #u8(1) 0 1 2)"},
-            {"string->utf8", ~S|(string->utf8 "x" 0 1 2)|}
+      for {op, src, hi} <- [
+            {"make-bytevector", "(make-bytevector 3 0 0)", 2},
+            {"bytevector-copy", "(bytevector-copy #u8(1 2 3) 0 1 2)", 3},
+            {"utf8->string", "(utf8->string #u8(1) 0 1 2)", 3},
+            {"string->utf8", ~S|(string->utf8 "x" 0 1 2)|, 3}
           ] do
-        e = assert_raise PError, fn -> run(src) end
-        assert match?({:type_error, ^op, _, :too_many}, e.reason)
+        e = assert_raise EvalError, fn -> run(src) end
+        assert match?({:arity_mismatch, ^op, {:between, 1, ^hi}, _}, e.reason)
       end
     end
 
@@ -923,13 +925,13 @@ defmodule Schooner.Primitives.BaseTest do
     end
 
     test "make-string / string-copy / string->list with too many args" do
-      for {op, src} <- [
-            {"make-string", ~S|(make-string 3 #\a #\b)|},
-            {"string-copy", ~S|(string-copy "abc" 0 1 2)|},
-            {"string->list", ~S|(string->list "abc" 0 1 2)|}
+      for {op, src, hi} <- [
+            {"make-string", ~S|(make-string 3 #\a #\b)|, 2},
+            {"string-copy", ~S|(string-copy "abc" 0 1 2)|, 3},
+            {"string->list", ~S|(string->list "abc" 0 1 2)|, 3}
           ] do
-        e = assert_raise PError, fn -> run(src) end
-        assert match?({:type_error, ^op, _, :too_many}, e.reason)
+        e = assert_raise EvalError, fn -> run(src) end
+        assert match?({:arity_mismatch, ^op, {:between, 1, ^hi}, _}, e.reason)
       end
     end
   end
@@ -1001,23 +1003,24 @@ defmodule Schooner.Primitives.BaseTest do
 
   describe "1-to-3-argument primitives reject too many args" do
     test "vector-copy with 4 args" do
-      e = assert_raise PError, fn -> run("(vector-copy #(1 2 3) 0 3 99)") end
-      assert e.reason == {:type_error, "vector-copy", "1 to 3 arguments", :too_many}
+      e = assert_raise EvalError, fn -> run("(vector-copy #(1 2 3) 0 3 99)") end
+      assert e.reason == {:arity_mismatch, "vector-copy", {:between, 1, 3}, 4}
+      assert e.message =~ "expected between 1 and 3, got 4"
     end
 
     test "bytevector-copy with 4 args" do
-      e = assert_raise PError, fn -> run("(bytevector-copy #u8(1 2 3) 0 3 99)") end
-      assert e.reason == {:type_error, "bytevector-copy", "1 to 3 arguments", :too_many}
+      e = assert_raise EvalError, fn -> run("(bytevector-copy #u8(1 2 3) 0 3 99)") end
+      assert e.reason == {:arity_mismatch, "bytevector-copy", {:between, 1, 3}, 4}
     end
 
     test "utf8->string with 4 args" do
-      e = assert_raise PError, fn -> run("(utf8->string #u8(97 98 99) 0 3 99)") end
-      assert e.reason == {:type_error, "utf8->string", "1 to 3 arguments", :too_many}
+      e = assert_raise EvalError, fn -> run("(utf8->string #u8(97 98 99) 0 3 99)") end
+      assert e.reason == {:arity_mismatch, "utf8->string", {:between, 1, 3}, 4}
     end
 
     test "string->utf8 with 4 args" do
-      e = assert_raise PError, fn -> run(~S|(string->utf8 "abc" 0 3 99)|) end
-      assert e.reason == {:type_error, "string->utf8", "1 to 3 arguments", :too_many}
+      e = assert_raise EvalError, fn -> run(~S|(string->utf8 "abc" 0 3 99)|) end
+      assert e.reason == {:arity_mismatch, "string->utf8", {:between, 1, 3}, 4}
     end
   end
 

--- a/test/schooner/primitives/inexact_test.exs
+++ b/test/schooner/primitives/inexact_test.exs
@@ -1,6 +1,7 @@
 defmodule Schooner.Primitives.InexactTest do
   use ExUnit.Case, async: true
 
+  alias Schooner.Eval.Error, as: EvalError
   alias Schooner.Primitive.Error, as: PError
   alias Schooner.Value
 
@@ -183,9 +184,10 @@ defmodule Schooner.Primitives.InexactTest do
       assert match?({:type_error, "atan", "number", _}, e.reason)
     end
 
-    test "atan with too many arguments raises an arity-shaped type error" do
-      e = assert_raise PError, fn -> run("(atan 1 2 3)") end
-      assert e.reason == {:type_error, "atan", "1 or 2 arguments", :too_many}
+    test "atan with too many arguments raises an arity_mismatch with got count" do
+      e = assert_raise EvalError, fn -> run("(atan 1 2 3)") end
+      assert e.reason == {:arity_mismatch, "atan", {:between, 1, 2}, 3}
+      assert e.message =~ "expected between 1 and 2, got 3"
     end
   end
 


### PR DESCRIPTION
## Summary
- Closes #18.
- Extends the primitive arity-spec system with `{:between, lo, hi}` so the spec dispatcher in `Schooner.Eval.check_primitive_arity!/3` enforces both lower and upper bounds, with a matching `Schooner.Eval.Error` format clause.
- Migrates `make-vector`, `make-bytevector`, `make-string`, `vector-copy`, `bytevector-copy`, `utf8->string`, `string->utf8`, `vector->list`, `string->list`, `string-copy`, plus `log` / `atan` in `inexact.ex`, off `{:at_least, n}` + defensive `:too_many` clauses and onto the new spec.
- Removes ten redundant `[_, _, _ | _]` / `[_, _, _, _ | _]` guard clauses (nine in base.ex, one in inexact.ex). `(make-vector 1 2 3)` now reports "expected between 1 and 2, got 3" instead of "got \`:too_many\`".

## Test plan
- [x] `mix precommit` passes (1 doctest, 27 properties, 1277 tests, 0 failures).
- [x] `eval_test.exs` regression pins `(make-vector 1 2 3)` to `{:arity_mismatch, "make-vector", {:between, 1, 2}, 3}` and asserts the rendered message no longer contains `:too_many`.
- [x] Existing `:too_many` assertions in `base_test.exs` and `inexact_test.exs` updated to the new `arity_mismatch` shape.