### PR TITLE
Issue #15: identity-aware eq?/eqv? via :erts_debug.same/2

### DIFF
--- a/lib/schooner/expander/syntax_rules.ex
+++ b/lib/schooner/expander/syntax_rules.ex
@@ -17,7 +17,9 @@ defmodule Schooner.Expander.SyntaxRules do
       `name` (modulo mark-stripping)
     * `{:pvar, name, depth}` — pattern variable; `depth` is the number
       of enclosing ellipses (used to validate template uses)
-    * `{:const, value}` — matches `value` by `eqv?`
+    * `{:const, value}` — matches `value` by `equal?` (r7rs §4.3.2:
+      "P is a datum and F is equal to P in the sense of the equal?
+      procedure")
     * `{:list, head_pats, tail_pat}` — proper-or-improper list
     * `{:list_ell, pre_pats, ell_pat, post_pats, tail_pat}` — list with
       one ellipsis
@@ -437,7 +439,7 @@ defmodule Schooner.Expander.SyntaxRules do
   end
 
   defp match({:const, v}, input, env) do
-    if Value.eqv?(v, input), do: {:ok, env}, else: :no_match
+    if Value.equal?(v, input), do: {:ok, env}, else: :no_match
   end
 
   defp match({:list, head_pats, tail_pat}, input, env) do

--- a/lib/schooner/primitives/base.ex
+++ b/lib/schooner/primitives/base.ex
@@ -1424,11 +1424,15 @@ defmodule Schooner.Primitives.Base do
   defp string_copy([v, start]), do: string_copy_range(v, start, nil)
   defp string_copy([v, start, end_]), do: string_copy_range(v, start, end_)
 
-  defp string_copy_range(s, nil, nil) when is_binary(s), do: Value.string(s)
+  # `:binary.copy/1` forces a fresh allocation so identity-aware `eq?`
+  # (via `:erts_debug.same/2`) can distinguish the copy from its source.
+  # Without it the no-range branch would return the input binary verbatim
+  # and `(eq? s (string-copy s))` would be `#t`, contradicting r7rs.
+  defp string_copy_range(s, nil, nil) when is_binary(s), do: Value.string(:binary.copy(s))
 
   defp string_copy_range(s, start, end_) when is_binary(s) do
     {sbyte, slen} = string_byte_slice(s, start || 0, end_, "string-copy")
-    Value.string(:binary.part(s, sbyte, slen))
+    Value.string(:binary.copy(:binary.part(s, sbyte, slen)))
   end
 
   defp string_copy_range(other, _, _),

--- a/lib/schooner/value.ex
+++ b/lib/schooner/value.ex
@@ -411,24 +411,56 @@ defmodule Schooner.Value do
   # ---------------------------------------------------------------------------
 
   @doc """
-  Scheme `eq?`. In a fully immutable value model `eq?` is indistinguishable
-  from `eqv?` — there is no observable identity beyond structural value, so
-  the two collapse together. r7rs explicitly permits this.
+  Scheme `eq?`. Identical to `eqv?` for Schooner — r7rs permits an
+  implementation to collapse the two so long as the stronger discriminations
+  `eq?` is allowed to draw (distinct heap copies of structurally-equal
+  aggregates) are also drawn by `eqv?`. They are: see `eqv?/2` below.
   """
   @spec eq?(t(), t()) :: boolean()
   def eq?(a, b), do: eqv?(a, b)
 
   @doc """
-  Scheme `eqv?`. Numerically equal numbers compare equal only if they share
-  exactness — `(eqv? 1 1.0)` is `#f`. Erlang's `===` already enforces this
-  because integers and floats are distinct terms.
+  Scheme `eqv?`. Atomic values (numbers, characters, symbols, booleans,
+  `()`, `:eof`, `:unspecified`) compare by content, with exactness preserved
+  for numbers — `(eqv? 1 1.0)` is `#f`. Aggregates (pairs, vectors, strings,
+  bytevectors, records, procedures, promises, parameters, error objects)
+  compare by physical identity via `:erts_debug.same/2` — two
+  structurally-equal aggregates built independently are *not* `eqv?`. This
+  is r7rs's "denote different locations in the store" semantics, recovered
+  for an immutable value model by leaning on the BEAM's heap layout instead
+  of explicit identity tags.
+
+  `:erts_debug.same/2` is an unofficial OTP BIF; it has been stable across
+  many releases and is used by the Erlang/OTP test suite. Compiler / loader
+  literal sharing means two source-level literals like `'(1 2)` written in
+  the same module *may* be deduplicated and report `same` — r7rs explicitly
+  permits constants to be shared, so this is allowed but worth pinning with
+  a test if relevant to caller behaviour.
   """
   @spec eqv?(t(), t()) :: boolean()
   # IEEE-754: NaN is never equal to anything, including another NaN.
   def eqv?({:float_special, :nan}, _), do: false
   def eqv?(_, {:float_special, :nan}), do: false
   def eqv?({:complex, r1, i1}, {:complex, r2, i2}), do: eqv?(r1, r2) and eqv?(i1, i2)
-  def eqv?(a, b), do: a === b
+  def eqv?(a, b), do: :erts_debug.same(a, b) or (atomic?(a) and a === b)
+
+  # Values for which r7rs requires `eqv?` (and therefore `eq?`) to compare
+  # by content rather than by location. Bare integers / floats / atoms are
+  # immediates on the BEAM and already collapse under `:erts_debug.same/2`,
+  # but listing them here keeps the predicate self-contained against future
+  # boxing changes and means callers can rely on it independently.
+  defp atomic?(n) when is_integer(n) or is_float(n), do: true
+  defp atomic?({:rational, _, _}), do: true
+  defp atomic?({:float_special, _}), do: true
+  defp atomic?({:complex, _, _}), do: true
+  defp atomic?({:char, _}), do: true
+  defp atomic?({:sym, _}), do: true
+  defp atomic?(true), do: true
+  defp atomic?(false), do: true
+  defp atomic?([]), do: true
+  defp atomic?(:eof), do: true
+  defp atomic?(:unspecified), do: true
+  defp atomic?(_), do: false
 
   @doc """
   Scheme `equal?`. Recurses structurally into pairs, vectors, bytevectors,

--- a/test/conformance/scheme/6_1_equivalence.scm
+++ b/test/conformance/scheme/6_1_equivalence.scm
@@ -17,11 +17,7 @@
 (test #t (eqv? 2 2))
 (test #t (eqv? '() '()))
 (test #t (eqv? 100000000 100000000))
-;; Skipped: `(eqv? (cons 1 2) (cons 1 2))` from upstream line 701.
-;; r7rs says eqv? on two distinct freshly-consed pairs is #f because
-;; they "denote different locations in the store". Schooner has no
-;; mutable cons cells, so it implements `eqv?` on pairs as
-;; structural `equal?`, returning #t here. Documented deviation.
+(test #f (eqv? (cons 1 2) (cons 1 2)))
 (test #f (eqv? (lambda () 1)
                (lambda () 2)))
 (test #f (eqv? #f 'nil))
@@ -31,10 +27,7 @@
       (eqv? x x)))
 
 (test #t (eq? 'a 'a))
-;; Skipped: `(eq? (list 'a) (list 'a))` from upstream line 731 —
-;; same deviation as the eqv? case above. Schooner's `eq?` reduces
-;; to structural equality on pairs because there is no mutable
-;; cell identity.
+(test #f (eq? (list 'a) (list 'a)))
 (test #t (eq? '() '()))
 (test #t
     (let ((x '(a)))

--- a/test/conformance/scheme/6_4_lists.scm
+++ b/test/conformance/scheme/6_4_lists.scm
@@ -60,12 +60,7 @@
 (test '(a b c) (memq 'a '(a b c)))
 (test '(b c) (memq 'b '(a b c)))
 (test #f (memq 'a '(b c d)))
-;; Skipped: `(memq (list 'a) '(b (a) c))` from upstream line 1148.
-;; r7rs `memq` walks the list with `eq?`; the freshly consed
-;; `(list 'a)` is not eq? to the literal `(a)` in the constant list,
-;; so the result is #f. Schooner's `memq` on pairs reduces to
-;; structural equality (matching its `eqv?` deviation), returning
-;; the rest of the list. Documented deviation.
+(test #f (memq (list 'a) '(b (a) c)))
 (test '((a) c) (member (list 'a) '(b (a) c)))
 ;; Skipped: `(member "B" '(...) string-ci=?)` from upstream line 1150.
 ;; The 3-argument form of `member` (custom comparison) and the
@@ -78,9 +73,7 @@
   (test '(b 2) (assq 'b e))
   (test #f (assq 'd e)))
 
-;; Skipped: `(assq (list 'a) '(((a)) ((b)) ((c))))` from upstream
-;; line 1159 — same deviation as the `memq`/`eq?` cases. Schooner's
-;; `assq` falls back to structural pair equality.
+(test #f (assq (list 'a) '(((a)) ((b)) ((c)))))
 (test '((a)) (assoc (list 'a) '(((a)) ((b)) ((c)))))
 ;; Skipped: `(assoc 2.0 ... =)` from upstream line 1161. The
 ;; 3-argument form of `assoc` (custom comparison) is not in
@@ -96,11 +89,7 @@
   (test l2 '((a b) (c d) e))
   (test #t (eq? (car l1) (car l2)))
   (test #t (eq? (cadr l1) (cadr l2)))
-  ;; Skipped: `(eq? (cdr l1) (cdr l2))` and `(cddr ...)` checks at
-  ;; upstream lines 1174-1175. They assert that `list-copy` produces
-  ;; *fresh* spine cons cells (so the cdr pairs differ by identity).
-  ;; Schooner's `eq?` reduces to structural equality on pairs, so
-  ;; the post-copy cdrs are still `eq?`. Documented deviation.
-  )
+  (test #f (eq? (cdr l1) (cdr l2)))
+  (test #f (eq? (cddr l1) (cddr l2))))
 
 (test-end)

--- a/test/schooner/primitives/base_pairs_test.exs
+++ b/test/schooner/primitives/base_pairs_test.exs
@@ -45,6 +45,22 @@ defmodule Schooner.Primitives.BasePairsTest do
       assert run("(list-copy (cons 1 2))") == [1 | 2]
       assert run("(list-copy '(6 7 8 . 9))") == [6, 7, 8 | 9]
     end
+
+    test "list-copy spine is fresh — eq? distinguishes copy from source" do
+      # Each spine cons is freshly allocated, so identity-aware `eq?`
+      # separates the copy from the source. Element identity is
+      # preserved (the elements are shared, not cloned).
+      assert run("(let ((l '(1 2 3))) (eq? l (list-copy l)))") == Value.bool(false)
+      assert run("(let ((l '(1 2 3))) (equal? l (list-copy l)))") == Value.bool(true)
+
+      assert run("(let* ((a (list 'x)) (l (list a))) (eq? a (car (list-copy l))))") ==
+               Value.bool(true)
+    end
+
+    test "freshly consed pairs are not eq? to a structurally equal pair" do
+      assert run("(eq? (cons 1 2) (cons 1 2))") == Value.bool(false)
+      assert run("(let ((p (cons 1 2))) (eq? p p))") == Value.bool(true)
+    end
   end
 
   describe "length / reverse" do

--- a/test/schooner/primitives/base_strings_test.exs
+++ b/test/schooner/primitives/base_strings_test.exs
@@ -74,6 +74,15 @@ defmodule Schooner.Primitives.BaseStringsTest do
       assert run(~S|(string-copy "hello" 1 3)|) == Value.string("el")
     end
 
+    test "string-copy returns a fresh binary, not the source" do
+      # The no-range form must allocate so identity-aware `eq?` can
+      # tell the copy apart from its source. Without `:binary.copy/1`
+      # the BIF would alias the input and `eq?` would erroneously
+      # return `#t`.
+      assert run(~S|(let ((s "hello")) (eq? s (string-copy s)))|) == Value.bool(false)
+      assert run(~S|(let ((s "hello")) (equal? s (string-copy s)))|) == Value.bool(true)
+    end
+
     test "slicing at end-of-string boundary is allowed" do
       assert run(~S|(substring "abc" 3 3)|) == Value.string("")
       assert run(~S|(string-copy "abc" 3 3)|) == Value.string("")

--- a/test/schooner/primitives/base_vectors_test.exs
+++ b/test/schooner/primitives/base_vectors_test.exs
@@ -75,15 +75,11 @@ defmodule Schooner.Primitives.BaseVectorsTest do
   end
 
   describe "vector-copy" do
-    test "produces a structurally equal vector" do
-      # Schooner deliberately collapses `eq?` and `eqv?` to structural
-      # equality (see `Schooner.Value` moduledoc); without mutation there
-      # is no observable identity beyond contents, so two equal-content
-      # vectors are `eq?` here. r7rs explicitly permits this. The test
-      # therefore pins the structural-equality guarantee that callers can
-      # rely on.
+    test "produces a structurally equal but not identity-equal vector" do
       assert run("(equal? #(1 2 3) (vector-copy #(1 2 3)))") == Value.bool(true)
       assert run("(equal? #(1 2 3) (vector-copy #(4 5 6)))") == Value.bool(false)
+      assert run("(let ((v #(1 2 3))) (eq? v (vector-copy v)))") == Value.bool(false)
+      assert run("(let ((v #(1 2 3))) (eq? v v))") == Value.bool(true)
     end
 
     test "vector-copy with start / end" do

--- a/test/schooner/value_test.exs
+++ b/test/schooner/value_test.exs
@@ -242,6 +242,45 @@ defmodule Schooner.ValueTest do
       b = Value.record({:type, "p"}, {1, 2, 3})
       refute Value.equal?(a, b)
     end
+
+    test "eq? on aggregates is by physical identity, not by content" do
+      v = Value.vector([1, 2, 3])
+      assert Value.eq?(v, v)
+      refute Value.eq?(v, Value.vector([1, 2, 3]))
+
+      bv = Value.bytevector([1, 2, 3])
+      assert Value.eq?(bv, bv)
+      refute Value.eq?(bv, Value.bytevector([1, 2, 3]))
+
+      p = Value.pair(1, 2)
+      assert Value.eq?(p, p)
+      refute Value.eq?(p, Value.pair(1, 2))
+
+      r = Value.record({:type, "p"}, {1, 2})
+      assert Value.eq?(r, r)
+      refute Value.eq?(r, Value.record({:type, "p"}, {1, 2}))
+    end
+
+    test "eq? on atomic values still compares by content" do
+      # Tagged-tuple atomics: separate constructions are distinct heap
+      # terms, so `:erts_debug.same/2` returns false; the atomic fallback
+      # in `eqv?/2` recovers the content comparison r7rs requires.
+      assert Value.eq?(Value.symbol("foo"), Value.symbol("foo"))
+      assert Value.eq?(Value.char(?a), Value.char(?a))
+      assert Value.eq?({:rational, 1, 2}, {:rational, 1, 2})
+      assert Value.eq?({:complex, 1, 2}, {:complex, 1, 2})
+
+      # Big integers can be heap-allocated; eq? must still see them equal.
+      big = :erlang.bsl(1, 100)
+      assert Value.eq?(big, :erlang.bsl(1, 100))
+    end
+
+    test "equal? remains structural across copies" do
+      v1 = Value.vector([1, 2, 3])
+      v2 = Value.vector([1, 2, 3])
+      refute Value.eq?(v1, v2)
+      assert Value.equal?(v1, v2)
+    end
   end
 
   describe "write / display" do


### PR DESCRIPTION
Switch Schooner.Value.eqv?/2 (and therefore eq?/2) from a structural
collapse onto Erlang ===/2 to a physical-identity check via
:erts_debug.same/2, with a fall-through to === for the atomic value
classes r7rs requires to compare by content (numbers, characters,
symbols, booleans, (), :eof, :unspecified).

Aggregates (pairs, vectors, strings, bytevectors, records,
procedures, promises, parameters, error objects) now compare by heap
location: two structurally-equal aggregates built independently are
no longer eq? / eqv?. equal?/2 is unchanged — it remains structural.

Also fix string-copy: the no-range branch returned the input binary
verbatim, which made (eq? s (string-copy s)) trivially #t even after
the eqv? change. Both branches now go through :binary.copy/1 so the
result is always a freshly-allocated binary.

Re-enable the four r7rs conformance assertions previously skipped as
documented deviations against §6.1 and §6.4 (cons / list / list-copy
identity).