### PR TITLE
Issue #79: back globals with a process-dict Map to preserve heap identity

### DIFF
--- a/lib/schooner/env.ex
+++ b/lib/schooner/env.ex
@@ -3,17 +3,24 @@ defmodule Schooner.Env do
   Immutable-ish environment for the Scheme evaluator.
 
   An environment is a chain of lexical frames innermost-first plus a
-  *globals* table identified by an `:ets` table id. Lexical frames are
-  immutable maps; new frames are pushed by `extend/2`. The globals
-  table is mutable in the strict sense — `define/3` writes to it — so
-  closures that captured an env see top-level definitions added after
-  they were created. This is the standard `letrec`-style knot-tying
-  applied to the top-level frame: closures reference the frame by
-  identity, not by value-at-bind-time.
+  *globals* slot identified by a process-dictionary key (a fresh
+  reference). Lexical frames are immutable maps; new frames are
+  pushed by `extend/2`. The globals slot is mutable in the strict
+  sense — `define/3` writes to it — so closures that captured an env
+  see top-level definitions added after they were created. This is
+  the standard `letrec`-style knot-tying applied to the top-level
+  frame: closures reference the frame by identity, not by
+  value-at-bind-time.
 
-  The globals table is owned by the process that calls `new/0` and is
-  GC'd when that process exits, so per-execution sandboxing falls out
-  of the BEAM's process model.
+  Globals are stored as a Map on the process heap, not in `:ets`, so
+  consecutive lookups of the same name return the *same* heap term.
+  This preserves `:erts_debug.same/2` identity for aggregates bound
+  at top level — `(eq? x x)` answers `#t` for vectors, pairs,
+  parameters, and other aggregates, matching the lexical case.
+
+  The globals slot is owned by the process that calls `new/0` and is
+  reclaimed when that process exits, so per-execution sandboxing
+  falls out of the BEAM's process model.
 
   ## Recursive lexical frames
 
@@ -42,13 +49,14 @@ defmodule Schooner.Env do
   defstruct [:globals, :lex]
 
   @type frame :: %{optional(binary()) => Value.t()} | {:rec, reference()}
-  @type t :: %__MODULE__{globals: :ets.tid(), lex: [frame()]}
+  @type t :: %__MODULE__{globals: reference(), lex: [frame()]}
   @type lookup_result :: {:ok, Value.t()} | :error | {:uninitialised, binary()}
 
   @spec new() :: t()
   def new do
-    table = :ets.new(:schooner_globals, [:set, :protected])
-    %__MODULE__{globals: table, lex: []}
+    ref = make_ref()
+    Process.put(ref, %{})
+    %__MODULE__{globals: ref, lex: []}
   end
 
   @doc """
@@ -82,7 +90,7 @@ defmodule Schooner.Env do
       nil ->
         lex_lookup(rest, name)
 
-      frame ->
+      {:rec_frame, frame} ->
         case Map.fetch(frame, name) do
           {:ok, @rec_uninitialised} -> {:uninitialised, name}
           {:ok, _} = ok -> ok
@@ -98,10 +106,10 @@ defmodule Schooner.Env do
     end
   end
 
-  defp globals_lookup(table, name) do
-    case :ets.lookup(table, name) do
-      [{^name, value}] -> {:ok, value}
-      [] -> :error
+  defp globals_lookup(ref, name) do
+    case Map.fetch(Process.get(ref), name) do
+      {:ok, _} = ok -> ok
+      :error -> :error
     end
   end
 
@@ -110,8 +118,8 @@ defmodule Schooner.Env do
   captured this env, regardless of when it was created.
   """
   @spec define(t(), binary(), Value.t()) :: t()
-  def define(%__MODULE__{globals: globals} = env, name, value) when is_binary(name) do
-    :ets.insert(globals, {name, value})
+  def define(%__MODULE__{globals: ref} = env, name, value) when is_binary(name) do
+    Process.put(ref, Map.put(Process.get(ref), name, value))
     env
   end
 
@@ -136,7 +144,7 @@ defmodule Schooner.Env do
 
     Process.put(
       ref,
-      Map.new(names, fn name when is_binary(name) -> {name, @rec_uninitialised} end)
+      {:rec_frame, Map.new(names, fn name when is_binary(name) -> {name, @rec_uninitialised} end)}
     )
 
     %{env | lex: [{:rec, ref} | lex]}
@@ -145,7 +153,8 @@ defmodule Schooner.Env do
   @doc "Set a binding in the topmost recursive frame on `env`."
   @spec rec_set(t(), binary(), Value.t()) :: t()
   def rec_set(%__MODULE__{lex: [{:rec, ref} | _]} = env, name, value) when is_binary(name) do
-    Process.put(ref, Map.put(Process.get(ref), name, value))
+    {:rec_frame, frame} = Process.get(ref)
+    Process.put(ref, {:rec_frame, Map.put(frame, name, value)})
     env
   end
 

--- a/test/schooner/env_test.exs
+++ b/test/schooner/env_test.exs
@@ -7,7 +7,7 @@ defmodule Schooner.EnvTest do
   test "new/0 returns an env with no lexical frames" do
     env = Env.new()
     assert env.lex == []
-    assert is_reference(env.globals) or is_integer(env.globals)
+    assert is_reference(env.globals)
   end
 
   test "lookup of an unbound name returns :error" do

--- a/test/schooner/eval_internal_defines_test.exs
+++ b/test/schooner/eval_internal_defines_test.exs
@@ -22,7 +22,10 @@ defmodule Schooner.EvalInternalDefinesTest do
   end
 
   defp count_rec_slots do
-    Process.get_keys() |> Enum.count(&is_reference/1)
+    Process.get_keys()
+    |> Enum.count(fn k ->
+      is_reference(k) and match?({:rec_frame, _}, Process.get(k))
+    end)
   end
 
   describe "internal defines in lambda body" do

--- a/test/schooner/eval_test.exs
+++ b/test/schooner/eval_test.exs
@@ -176,6 +176,26 @@ defmodule Schooner.EvalTest do
     test "redefining a name overwrites it" do
       assert run("(define x 1) (define x 2) x") == 2
     end
+
+    # Regression for issue #79: globals previously lived in an `:ets`
+    # table, which copies terms on lookup. Two consecutive resolutions
+    # of the same name therefore returned distinct heap aggregates and
+    # `(eq? x x)` answered #f. Backing globals with a process-dict
+    # Map slot keeps consecutive lookups identity-preserving.
+    test "global aggregates are eq? to themselves" do
+      assert run("(define v (vector 1 2 3)) (eq? v v)") == Value.bool(true)
+      assert run("(define p (cons 1 2)) (eq? p p)") == Value.bool(true)
+      assert run("(define s (string-copy \"hi\")) (eq? s s)") == Value.bool(true)
+      assert run("(define b (bytevector 1 2 3)) (eq? b b)") == Value.bool(true)
+      assert run("(define q (make-parameter 1)) (eq? q q)") == Value.bool(true)
+
+      assert run(~S|
+               (define-record-type point
+                 (make-point x y) point?
+                 (x point-x) (y point-y))
+               (define pt (make-point 1 2))
+               (eq? pt pt)|) == Value.bool(true)
+    end
   end
 
   describe "begin" do


### PR DESCRIPTION
## Summary

- Fixes #79 — `(eq? x x)` previously returned `#f` for any aggregate (vector, pair, string, bytevector, parameter, record) bound at top level, because `:ets.lookup/2` copies terms out of the table on every read.
- Replaces the ETS-backed globals table with a process-dictionary slot keyed by `make_ref()` holding a `%{name => value}` map — the same model `extend_rec/2` already uses for recursive lexical frames. Map storage returns the same physical term on consecutive fetches, so `:erts_debug.same/2` (and therefore `eq?`/`eqv?`) treats global aggregates as identity-preserving.
- Per-execution sandboxing is unchanged: the slot is reclaimed when the owning process exits, matching ETS's process-linked GC.
- The rec-frame value is now tagged `{:rec_frame, map}` so the leak detector in `eval_internal_defines_test.exs` can positively match rec frames and ignore the new globals ref now living alongside them in the process dict.

## Test plan

- [x] `mix precommit` clean (compile, deps.unlock --unused, format, credo --strict, 1278 tests + 27 properties + 1 doctest, 0 failures).
- [x] Issue's reproduction (`(define v (vector 1 2 3)) (eq? v v)`, …) now returns `#t` end-to-end.
- [x] Added regression in `test/schooner/eval_test.exs` covering vector, pair, string, bytevector, parameter, and record at top level.
- [x] PR #78's parameter test (`the same parameter is eq? to itself`) passes without a parameter-specific special case.
- [x] `EnvTest` and rec-frame slot-lifecycle tests still pass; `count_rec_slots` no longer counts globals.