### PR TITLE
Issue #44: opaque foreign values for host payloads

### DIFF
--- a/lib/schooner/primitives/base.ex
+++ b/lib/schooner/primitives/base.ex
@@ -812,6 +812,7 @@ defmodule Schooner.Primitives.Base do
       {"vector?", 1, &vector_p/1},
       {"bytevector?", 1, &bytevector_p/1},
       {"procedure?", 1, &procedure_p/1},
+      {"foreign?", 1, &foreign_p/1},
       {"eof-object?", 1, &eof_p/1},
       {"eq?", 2, &eq_p/1},
       {"eqv?", 2, &eqv_p/1},
@@ -836,6 +837,7 @@ defmodule Schooner.Primitives.Base do
   defp vector_p([v]), do: Value.bool(Value.vector?(v))
   defp bytevector_p([v]), do: Value.bool(Value.bytevector?(v))
   defp procedure_p([v]), do: Value.bool(Value.procedure?(v))
+  defp foreign_p([v]), do: Value.bool(Value.foreign?(v))
   defp eof_p([v]), do: Value.bool(Value.eof?(v))
 
   defp eq_p([a, b]), do: Value.bool(Value.eq?(a, b))

--- a/lib/schooner/value.ex
+++ b/lib/schooner/value.ex
@@ -64,6 +64,17 @@ defmodule Schooner.Value do
       every value installed for the parameter (initial *or* via
       `parameterize`). Parameters are procedure values: calling one
       with zero arguments returns the current value.
+    * Foreign — `{:foreign, term}`. Opaque host payload: any Elixir
+      term wrapped so Scheme code can pass it around (bind, return,
+      stash in a pair/vector) but never inspect or forge it. Built by
+      the host via `foreign/1`; the wrapped term is read back from
+      Elixir with `foreign_ref/1`. Scheme code can ask `(foreign? x)`
+      to discriminate, but has no constructor and no accessor, and
+      `write` redacts the contents to `#<foreign>` — so the wrapped
+      term remains structurally invisible from Scheme. Identity
+      equality only: `eq?` / `eqv?` / `equal?` compare the wrapped
+      terms with `===`, so two foreigns that wrap structurally-equal-
+      but-distinct host values are not equal.
     * EOF — `:eof`
     * Unspecified — `:unspecified`
   """
@@ -87,6 +98,7 @@ defmodule Schooner.Value do
   @type error_obj_v :: {:error_obj, error_kind(), t(), [t()]}
   @type promise_v :: {:promise, :forced, t()} | {:promise, :lazy, term()}
   @type parameter_v :: {:parameter, integer(), t(), t() | nil}
+  @type foreign_v :: {:foreign, term()}
   @type arity_spec ::
           non_neg_integer()
           | {:at_least, non_neg_integer()}
@@ -113,6 +125,7 @@ defmodule Schooner.Value do
           | error_obj_v()
           | promise_v()
           | parameter_v()
+          | foreign_v()
           | :eof
           | :unspecified
 
@@ -206,6 +219,29 @@ defmodule Schooner.Value do
   def parameter(init, converter) do
     {:parameter, :erlang.unique_integer([:monotonic]), init, converter}
   end
+
+  @doc """
+  Wrap an arbitrary Elixir term as an opaque foreign Scheme value.
+  Scheme code can bind, store, and pass the result through any
+  value-shaped position (variables, pairs, vectors, closures) but
+  cannot inspect, deconstruct, or forge it: there is no surface
+  syntax that constructs a foreign and `write` redacts the wrapped
+  term to `#<foreign>`. The host retrieves the wrapped term with
+  `foreign_ref/1`.
+  """
+  @spec foreign(term()) :: foreign_v()
+  def foreign(term), do: {:foreign, term}
+
+  @doc """
+  Unwrap a foreign value, returning the host term it wraps. Raises
+  `ArgumentError` for any non-foreign — this accessor is host-only
+  and assumes the caller has already established the value is one.
+  """
+  @spec foreign_ref(foreign_v()) :: term()
+  def foreign_ref({:foreign, term}), do: term
+
+  def foreign_ref(other),
+    do: raise(ArgumentError, "expected foreign value, got #{inspect(other)}")
 
   @doc """
   Wrap `value` as an already-forced (eager) promise. Forcing it
@@ -398,6 +434,10 @@ defmodule Schooner.Value do
   def promise?({:promise, kind, _}) when kind in [:forced, :lazy], do: true
   def promise?(_), do: false
 
+  @spec foreign?(term()) :: boolean()
+  def foreign?({:foreign, _}), do: true
+  def foreign?(_), do: false
+
   @doc """
   Scheme truthiness: only `false` is false; every other value is
   truthy, including `:null`, `0`, and the empty string.
@@ -442,6 +482,13 @@ defmodule Schooner.Value do
   def eqv?({:float_special, :nan}, _), do: false
   def eqv?(_, {:float_special, :nan}), do: false
   def eqv?({:complex, r1, i1}, {:complex, r2, i2}), do: eqv?(r1, r2) and eqv?(i1, i2)
+  # Foreign wrappers compare by `===` on the wrapped host term: pids,
+  # refs, and atoms have meaningful identity equality; structurally
+  # equal heap terms (tuples, maps) also collapse, which is the price
+  # of not walking a Scheme-opaque payload. Bypasses the
+  # `:erts_debug.same/2` aggregate path so two foreigns that wrap the
+  # same pid (but live in distinct outer tuples) still compare equal.
+  def eqv?({:foreign, a}, {:foreign, b}), do: a === b
   def eqv?(a, b), do: :erts_debug.same(a, b) or (atomic?(a) and a === b)
 
   # Values for which r7rs requires `eqv?` (and therefore `eq?`) to compare
@@ -533,6 +580,8 @@ defmodule Schooner.Value do
   defp render({:record, type_id, _}, _), do: ["#<record ", inspect(type_id), ">"]
   defp render({:promise, _, _}, _), do: "#<promise>"
   defp render({:parameter, _, _, _}, _), do: "#<parameter>"
+  # Redacted: never inspect or include the wrapped term in output.
+  defp render({:foreign, _}, _), do: "#<foreign>"
 
   defp render({:error_obj, kind, message, irritants}, mode),
     do: render_error(kind, message, irritants, mode)

--- a/test/schooner/eval_test.exs
+++ b/test/schooner/eval_test.exs
@@ -337,4 +337,83 @@ defmodule Schooner.EvalTest do
              """) == 2
     end
   end
+
+  describe "foreign values — host-provided opaque payloads" do
+    # Build a base env with a single host-side binding `host` that
+    # holds a foreign-wrapped pid. Tests can also rely on every
+    # `(scheme base)` primitive without an explicit `(import ...)`.
+    defp run_with_foreign(source, term) do
+      env = base_env() |> Env.define("host", Value.foreign(term))
+      Schooner.eval(source, env)
+    end
+
+    test "self-evaluates: a bare reference returns the foreign unchanged" do
+      pid = self()
+      assert run_with_foreign("host", pid) == Value.foreign(pid)
+    end
+
+    test "round-trips through let, lambda, pair, vector without inspection" do
+      pid = self()
+
+      assert run_with_foreign("(let ((x host)) x)", pid) == Value.foreign(pid)
+
+      assert run_with_foreign("((lambda (x) x) host)", pid) == Value.foreign(pid)
+
+      # Inside an aggregate, the foreign element survives untouched.
+      result = run_with_foreign("(car (cons host 0))", pid)
+      assert result == Value.foreign(pid)
+      assert Value.foreign_ref(result) === pid
+
+      v = run_with_foreign("(vector-ref (vector 'a host 'c) 1)", pid)
+      assert v == Value.foreign(pid)
+    end
+
+    test "no other Scheme-level shape predicate matches a foreign value" do
+      pid = self()
+
+      for pred <- ~w[procedure? vector? pair? null? boolean? symbol? string?
+                     char? bytevector? number? integer? real? rational?
+                     complex? exact? inexact?] do
+        assert run_with_foreign("(#{pred} host)", pid) == false,
+               "(#{pred} host) should be #f"
+      end
+    end
+
+    test "(foreign? x) discriminates host-wrapped values from everything else" do
+      pid = self()
+
+      assert run_with_foreign("(foreign? host)", pid) == true
+
+      # Every other shape we can name in Scheme source must be #f.
+      assert run("(foreign? 1)") == false
+      assert run("(foreign? 1.5)") == false
+      assert run("(foreign? #t)") == false
+      assert run("(foreign? #f)") == false
+      assert run("(foreign? '())") == false
+      assert run("(foreign? 'sym)") == false
+      assert run(~S|(foreign? "hi")|) == false
+      assert run(~S|(foreign? #\a)|) == false
+      assert run("(foreign? '(1 2))") == false
+      assert run("(foreign? (cons 1 2))") == false
+      assert run("(foreign? (vector 1 2))") == false
+      assert run("(foreign? (lambda (x) x))") == false
+      assert run("(foreign? car)") == false
+    end
+
+    test "eq? / eqv? / equal? compare wrapped terms with === at the Scheme level" do
+      pid = self()
+      # Two foreigns that wrap the same pid live in distinct outer
+      # tuples but must still be eq?/eqv?/equal?.
+      assert run_with_foreign("(eq?    host (let ((x host)) x))", pid) == true
+      assert run_with_foreign("(eqv?   host (let ((x host)) x))", pid) == true
+      assert run_with_foreign("(equal? host (let ((x host)) x))", pid) == true
+    end
+
+    test "write redacts the wrapped term" do
+      assert run_with_foreign(
+               "(import (scheme write)) (write host)",
+               {:secret, [1, 2, 3]}
+             ) == Value.string("#<foreign>")
+    end
+  end
 end

--- a/test/schooner/value_test.exs
+++ b/test/schooner/value_test.exs
@@ -438,4 +438,105 @@ defmodule Schooner.ValueTest do
       assert Value.display(@nan) == "+nan.0"
     end
   end
+
+  describe "foreign values" do
+    test "constructor / predicate / accessor round-trip arbitrary host terms" do
+      for term <- [self(), make_ref(), :some_atom, {:user, 5}, %{a: 1}, "raw bin"] do
+        f = Value.foreign(term)
+        assert f == {:foreign, term}
+        assert Value.foreign?(f)
+        assert Value.foreign_ref(f) === term
+      end
+    end
+
+    test "foreign? rejects every other shape" do
+      refute Value.foreign?(false)
+      refute Value.foreign?([])
+      refute Value.foreign?(1)
+      refute Value.foreign?({:sym, "x"})
+      refute Value.foreign?(Value.vector([1]))
+      refute Value.foreign?({:closure, [], [], %{}, nil})
+      refute Value.foreign?({:primitive, "p", 0, fn _ -> :unspecified end})
+    end
+
+    test "foreign_ref/1 raises on non-foreign" do
+      assert_raise ArgumentError, fn -> Value.foreign_ref(:not_foreign) end
+    end
+
+    test "no built-in shape predicate matches a foreign value" do
+      f = Value.foreign(self())
+
+      refute Value.boolean?(f)
+      refute Value.null?(f)
+      refute Value.pair?(f)
+      refute Value.symbol?(f)
+      refute Value.string?(f)
+      refute Value.char?(f)
+      refute Value.vector?(f)
+      refute Value.bytevector?(f)
+      refute Value.procedure?(f)
+      refute Value.parameter?(f)
+      refute Value.record?(f)
+      refute Value.error_object?(f)
+      refute Value.eof?(f)
+      refute Value.unspecified?(f)
+      refute Value.number?(f)
+      refute Value.integer?(f)
+      refute Value.rational?(f)
+      refute Value.real?(f)
+      refute Value.complex?(f)
+      refute Value.exact?(f)
+      refute Value.inexact?(f)
+      refute Value.float_special?(f)
+      refute Value.promise?(f)
+      refute Value.list?(f)
+    end
+
+    test "write / display redact the wrapped term to #<foreign>" do
+      # Wrap a term whose own rendering would be loud; the redaction
+      # must hide it entirely and not depend on the term's shape.
+      f = Value.foreign({:secret, "shh", [1, 2, 3]})
+      assert Value.write(f) == "#<foreign>"
+      assert Value.display(f) == "#<foreign>"
+
+      # And inside an aggregate, the redaction still wins per element.
+      assert Value.write(Value.list([Value.foreign(:p), 1])) == "(#<foreign> 1)"
+      assert Value.write(Value.vector([Value.foreign(:p)])) == "#(#<foreign>)"
+    end
+
+    test "eq? / eqv? compare wrapped terms with === (identity for pids/refs)" do
+      pid = self()
+      f1 = Value.foreign(pid)
+      f2 = Value.foreign(pid)
+      assert Value.eq?(f1, f2)
+      assert Value.eqv?(f1, f2)
+
+      # Different host pids — distinct identity, never equal.
+      other = spawn(fn -> :ok end)
+      refute Value.eq?(f1, Value.foreign(other))
+
+      # Refs are unique identities even when "fresh".
+      r = make_ref()
+      assert Value.eqv?(Value.foreign(r), Value.foreign(r))
+      refute Value.eqv?(Value.foreign(make_ref()), Value.foreign(make_ref()))
+    end
+
+    test "equal? agrees with eqv? — no structural recursion into the payload" do
+      pid = self()
+      assert Value.equal?(Value.foreign(pid), Value.foreign(pid))
+      refute Value.equal?(Value.foreign(make_ref()), Value.foreign(make_ref()))
+
+      # NaN is never equal to anything, even when wrapped — `===`
+      # propagates IEEE-754 semantics through the foreign tuple.
+      nan = :nan
+      assert Value.equal?(Value.foreign(nan), Value.foreign(nan))
+    end
+
+    test "foreign vs non-foreign is never equal" do
+      f = Value.foreign(:x)
+      refute Value.eq?(f, Value.symbol("x"))
+      refute Value.eqv?(f, :x)
+      refute Value.equal?(f, Value.symbol("x"))
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Closes #44. Adds a `{:foreign, term}` value variant so host code can hand arbitrary Elixir terms to Scheme and get them back unchanged.

- `Schooner.Value`: new `foreign/1` constructor, `foreign?/1` predicate, `foreign_ref/1` host-side accessor, `eqv?` clause (`===` on wrapped term — identity for pids/refs, structural collapse for plain data), and a `#<foreign>` redaction in `write`/`display`.
- `Schooner.Primitives.Base`: `(foreign? x)` exposed via `(scheme base)` so Scheme code can discriminate host-wrapped values.
- No surface constructor or accessor — Scheme sees opaque, non-forgeable tokens; every other shape predicate (`procedure?`, `vector?`, `pair?`, …) returns `#f`.
- `Schooner.Eval` is unchanged: foreign values self-evaluate via the existing fall-through clause.

### Decisions on the issue's open questions

- **Name**: `:foreign` (FFI convention).
- **Equality**: `===` on the wrapped term, as the issue described. Two foreigns wrapping the same pid/ref are equal; two foreigns wrapping structurally-equal-but-distinct host tuples are also equal.
- **Surface predicate**: shipped — `(foreign? x)` is reachable from `(scheme base)`. Constructor/accessor remain host-only.
- **Print form**: bare `#<foreign>` (deterministic; no per-instance tag).

## Test plan

- [x] `mix precommit` (compile --warnings-as-errors, deps.unlock --unused, format, credo --strict, test) — 1298 tests, 0 failures
- [x] Value-level tests: constructor/predicate/accessor round-trip, write/display redaction, identity equality on pids/refs, no built-in shape predicate matches
- [x] Eval-level tests: round-trip through let/lambda/pair/vector, `(foreign? x)` discriminates host-wrapped vs every Scheme-source-constructible shape, write redacts at the Scheme level