### PR TITLE
Issue #70: run guard cond clauses in guard's dynamic extent

### DIFF
--- a/lib/schooner/eval.ex
+++ b/lib/schooner/eval.ex
@@ -532,7 +532,7 @@ defmodule Schooner.Eval do
   defp eval_guard([[{:sym, var} | clauses_form] | body], env)
        when is_binary(var) and body != [] do
     tag = make_ref()
-    handler = build_guard_handler(var, clauses_form, env, tag)
+    handler = build_guard_handler(tag)
     # Snapshot/restore the whole stack rather than `pop`ing once in
     # the after-clause: by the time we exit (matched-and-thrown,
     # re-raised, or normal-return) the handler may already have been
@@ -544,7 +544,18 @@ defmodule Schooner.Eval do
     try do
       eval_body(body, env)
     catch
-      :throw, {:schooner_guard, ^tag, value} -> value
+      # R7RS §6.11: cond clauses run in the guard form's dynamic
+      # extent, so the handler only escapes back here with the raw
+      # raised value; the clauses are evaluated *after* control has
+      # unwound past any parameterize/handler frames between the raise
+      # site and this guard.
+      :throw, {:schooner_guard, ^tag, raised} ->
+        handler_env = Env.extend(env, [{var, raised}])
+
+        case eval_guard_clauses(clauses_form, handler_env) do
+          {:matched, value} -> value
+          :no_match -> ExceptionState.raise_value(raised)
+        end
     after
       ExceptionState.restore(prev)
     end
@@ -552,14 +563,9 @@ defmodule Schooner.Eval do
 
   defp eval_guard(_, _env), do: raise(Error, reason: {:bad_special_form, "guard"})
 
-  defp build_guard_handler(var, clauses_form, env, tag) do
+  defp build_guard_handler(tag) do
     Value.primitive("%guard-handler", 1, fn [raised] ->
-      handler_env = Env.extend(env, [{var, raised}])
-
-      case eval_guard_clauses(clauses_form, handler_env) do
-        {:matched, value} -> throw({:schooner_guard, tag, value})
-        :no_match -> ExceptionState.raise_value(raised)
-      end
+      throw({:schooner_guard, tag, raised})
     end)
   end
 

--- a/test/schooner/primitives/exceptions_test.exs
+++ b/test/schooner/primitives/exceptions_test.exs
@@ -213,6 +213,18 @@ defmodule Schooner.Primitives.ExceptionsTest do
                   (guard (c ((number? c) c))
                     (raise 5)))|) == 105
     end
+
+    test "clauses see guard's dynamic environment, not raise's (R7RS §6.11)" do
+      # Per R7RS §6.11, the guard's cond clauses run with the
+      # continuation and dynamic environment of the guard expression,
+      # not the raise's. The parameter must read its outer (1) value,
+      # not the parameterize'd (99) value still in scope at the raise.
+      assert run(~S|
+               (define p (make-parameter 1))
+               (guard (c (#t (p)))
+                 (parameterize ((p 99))
+                   (error "x")))|) == 1
+    end
   end
 
   describe "TCO + exceptions" do


### PR DESCRIPTION
## Summary
- Per R7RS §6.11, `guard` cond clauses must run in the guard's dynamic environment, not the raise's. Previously they ran inside the handler-procedure call, so any `parameterize` / handler frames between the raise site and the guard were still installed when the clauses evaluated.
- The handler now just throws the raised value back out; the guard's `catch` evaluates the clauses, so they run only after control has unwound to the guard form.
- Closes #70.

## Test plan
- [x] `mix test test/schooner/primitives/exceptions_test.exs` (29 tests)
- [x] `mix test test/conformance/r7rs_section_6_11_exceptions_test.exs` (16 tests)
- [x] `mix test test/schooner/primitives/parameters_test.exs` (24 tests)
- [x] `mix precommit` — full suite (1312 tests) passes, credo clean
- [x] New regression test asserts the parameter-object case from the issue returns `1`, not `99`.