### PR TITLE
Phase 15.1: Schooner.Host conversion helpers and TypeError

### DIFF
--- a/lib/schooner/host.ex
+++ b/lib/schooner/host.ex
@@ -1,0 +1,292 @@
+defmodule Schooner.Host do
+  @moduledoc """
+  Helpers for authoring Elixir-side host functions exposed to Scheme.
+
+  Schooner does not auto-marshal across the host boundary. A host
+  function has the same shape as a built-in primitive — it consumes a
+  list of `Schooner.Value.t/0` arguments and returns a
+  `Schooner.Value.t/0` — and uses the helpers in this module to move
+  between Scheme values and idiomatic Elixir terms. The named
+  constructors and accessors form the seam that future
+  representation changes pivot on; even when the underlying impl is
+  the identity (Schooner strings are bare Elixir binaries today),
+  host code stays representation-agnostic by going through the
+  helpers.
+
+  ## Naming convention
+
+  Asserting accessors (`to_*!/2`) raise `Schooner.Host.TypeError` when
+  the input does not match the expected shape. They take a keyword
+  argument with `:op` set to a host-supplied label for the call site
+  so the error points at the wrapper, not the bare predicate.
+
+  Total accessors (`to_*/1`) return `{:ok, term()} | :error` for the
+  "branch on shape" case where a type mismatch is not an error.
+
+  ## Recommended use pattern
+
+  Several accessor names — `to_string/1`, `to_string!/2` — collide
+  with `Kernel.to_string/1`. **Don't `import Schooner.Host`.** Use
+  `alias Schooner.Host` and call the accessors as `Host.to_string!`
+  etc.; the alias is one line and the call sites stay explicit.
+
+  ## Worked example
+
+      defmodule MyApp.SchemeLib do
+        alias Schooner.Host
+
+        @spec specs() :: [{binary(), Schooner.Value.arity_spec(), fun()}]
+        def specs do
+          [
+            {"info", 1, &info/1},
+            {"now-ms", 0, &now_ms/1}
+          ]
+        end
+
+        defp info([msg]) do
+          text = Host.to_string!(msg, op: "myapp/info")
+          IO.puts(text)
+          :unspecified
+        end
+
+        defp now_ms([]) do
+          System.system_time(:millisecond)
+        end
+      end
+  """
+
+  alias Schooner.Host.TypeError
+  alias Schooner.Value
+
+  # ---------------------------------------------------------------------------
+  # Constructors — re-exports of Value's constructors so host code
+  # never names the internal tag shape directly. Future representation
+  # changes update Value; host code stays put.
+  # ---------------------------------------------------------------------------
+
+  @spec bool(boolean()) :: Value.bool_v()
+  defdelegate bool(b), to: Value
+
+  @spec string(binary()) :: Value.string_v()
+  defdelegate string(s), to: Value
+
+  @spec symbol(binary()) :: Value.sym_v()
+  defdelegate symbol(name), to: Value
+
+  @spec char(non_neg_integer()) :: Value.char_v()
+  defdelegate char(cp), to: Value
+
+  @spec pair(Value.t(), Value.t()) :: Value.pair_v()
+  defdelegate pair(car, cdr), to: Value
+
+  @spec list([Value.t()]) :: Value.t()
+  defdelegate list(items), to: Value
+
+  @spec vector([Value.t()]) :: Value.vector_v()
+  defdelegate vector(items), to: Value
+
+  @spec bytevector([byte()] | binary()) :: Value.bytevector_v()
+  defdelegate bytevector(bs), to: Value
+
+  @spec foreign(term()) :: Value.foreign_v()
+  defdelegate foreign(term), to: Value
+
+  @spec primitive(binary(), Value.arity_spec(), (list() -> Value.t())) :: Value.primitive_v()
+  defdelegate primitive(name, arity, fun), to: Value
+
+  # ---------------------------------------------------------------------------
+  # Asserting accessors — to_*!/2
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Assert `value` is an exact integer and return the bare Elixir
+  integer. Rejects rationals, floats, the float specials, and
+  complex.
+  """
+  @spec to_integer!(Value.t(), keyword()) :: integer()
+  def to_integer!(value, _opts) when is_integer(value), do: value
+  def to_integer!(value, opts), do: type_error!(opts, "integer", value)
+
+  @doc """
+  Assert `value` is a bare inexact real and return the Elixir float.
+  Rejects integers, rationals, the float specials (`+inf.0`,
+  `-inf.0`, `+nan.0`), and complex. Hosts that want "any real
+  number, coerced" should call `to_real!/2` instead.
+  """
+  @spec to_float!(Value.t(), keyword()) :: float()
+  def to_float!(value, _opts) when is_float(value), do: value
+  def to_float!(value, opts), do: type_error!(opts, "float", value)
+
+  @doc """
+  Assert `value` is any real number and return it as an Elixir
+  number. Integers and floats pass through; rationals are coerced
+  to their float approximation; the float specials are rejected
+  (no plain BEAM-float representation).
+  """
+  @spec to_real!(Value.t(), keyword()) :: number()
+  def to_real!(value, _opts) when is_integer(value) or is_float(value), do: value
+  def to_real!({:rational, n, d}, _opts), do: n / d
+  def to_real!(value, opts), do: type_error!(opts, "real", value)
+
+  @doc """
+  Assert `value` is a Scheme string and return the underlying Elixir
+  binary. Rejects symbols, bytevectors, and any non-string.
+  """
+  @spec to_string!(Value.t(), keyword()) :: binary()
+  def to_string!(value, _opts) when is_binary(value), do: value
+  def to_string!(value, opts), do: type_error!(opts, "string", value)
+
+  @doc """
+  Assert `value` is a Scheme symbol and return its name as an Elixir
+  binary.
+  """
+  @spec to_symbol_name!(Value.t(), keyword()) :: binary()
+  def to_symbol_name!({:sym, name}, _opts), do: name
+  def to_symbol_name!(value, opts), do: type_error!(opts, "symbol", value)
+
+  @doc """
+  Assert `value` is a Scheme character and return the codepoint
+  integer.
+  """
+  @spec to_char!(Value.t(), keyword()) :: non_neg_integer()
+  def to_char!({:char, cp}, _opts), do: cp
+  def to_char!(value, opts), do: type_error!(opts, "character", value)
+
+  @doc """
+  Assert `value` is a Scheme boolean and return the Elixir
+  `true | false`. Note: this differs from "truthy" — only `false`
+  is Scheme-falsy, but every other value is *not* a Scheme boolean.
+  Use `Schooner.Value.truthy?/1` for the truthiness test.
+  """
+  @spec to_bool!(Value.t(), keyword()) :: boolean()
+  def to_bool!(value, _opts) when is_boolean(value), do: value
+  def to_bool!(value, opts), do: type_error!(opts, "boolean", value)
+
+  @doc """
+  Assert `value` is a proper Scheme list and return the underlying
+  Elixir list. Raises on improper lists and non-list values.
+  """
+  @spec to_list!(Value.t(), keyword()) :: [Value.t()]
+  def to_list!([], _opts), do: []
+
+  def to_list!([_ | _] = list, opts) do
+    if Value.list?(list) do
+      list
+    else
+      type_error!(opts, "proper list", list)
+    end
+  end
+
+  def to_list!(value, opts), do: type_error!(opts, "proper list", value)
+
+  @doc """
+  Assert `value` is a Scheme vector and return its elements as an
+  Elixir list. The list shape is more idiomatic for Elixir
+  iteration; hosts that want a tuple can call `Tuple.to_list/1`'s
+  inverse, but most use cases want `Enum`.
+  """
+  @spec to_vector!(Value.t(), keyword()) :: [Value.t()]
+  def to_vector!({:vector, t}, _opts), do: Tuple.to_list(t)
+  def to_vector!(value, opts), do: type_error!(opts, "vector", value)
+
+  @doc """
+  Assert `value` is a Scheme bytevector and return the underlying
+  Elixir binary.
+  """
+  @spec to_bytevector!(Value.t(), keyword()) :: binary()
+  def to_bytevector!({:bytevector, b}, _opts), do: b
+  def to_bytevector!(value, opts), do: type_error!(opts, "bytevector", value)
+
+  @doc """
+  Assert `value` is a foreign-wrapped host term and return the
+  wrapped term. Mirrors `Schooner.Value.foreign_ref/1` but raises
+  the host-facing `TypeError` instead of `ArgumentError`.
+  """
+  @spec to_foreign_ref!(Value.t(), keyword()) :: term()
+  def to_foreign_ref!({:foreign, term}, _opts), do: term
+  def to_foreign_ref!(value, opts), do: type_error!(opts, "foreign", value)
+
+  @doc """
+  Assert `value` is callable from Elixir — a closure, a primitive,
+  or a parameter — and return it unchanged. Use this to validate
+  the shape of a callback argument before passing it to
+  `Schooner.apply/2`.
+  """
+  @spec to_proc!(Value.t(), keyword()) :: Value.t()
+  def to_proc!(value, opts) do
+    if Value.procedure?(value) do
+      value
+    else
+      type_error!(opts, "procedure", value)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Total accessors — to_*/1
+  # ---------------------------------------------------------------------------
+
+  @spec to_integer(Value.t()) :: {:ok, integer()} | :error
+  def to_integer(value) when is_integer(value), do: {:ok, value}
+  def to_integer(_), do: :error
+
+  @spec to_float(Value.t()) :: {:ok, float()} | :error
+  def to_float(value) when is_float(value), do: {:ok, value}
+  def to_float(_), do: :error
+
+  @spec to_real(Value.t()) :: {:ok, number()} | :error
+  def to_real(value) when is_integer(value) or is_float(value), do: {:ok, value}
+  def to_real({:rational, n, d}), do: {:ok, n / d}
+  def to_real(_), do: :error
+
+  @spec to_string(Value.t()) :: {:ok, binary()} | :error
+  def to_string(value) when is_binary(value), do: {:ok, value}
+  def to_string(_), do: :error
+
+  @spec to_symbol_name(Value.t()) :: {:ok, binary()} | :error
+  def to_symbol_name({:sym, name}), do: {:ok, name}
+  def to_symbol_name(_), do: :error
+
+  @spec to_char(Value.t()) :: {:ok, non_neg_integer()} | :error
+  def to_char({:char, cp}), do: {:ok, cp}
+  def to_char(_), do: :error
+
+  @spec to_bool(Value.t()) :: {:ok, boolean()} | :error
+  def to_bool(value) when is_boolean(value), do: {:ok, value}
+  def to_bool(_), do: :error
+
+  @spec to_list(Value.t()) :: {:ok, [Value.t()]} | :error
+  def to_list([]), do: {:ok, []}
+
+  def to_list([_ | _] = list) do
+    if Value.list?(list), do: {:ok, list}, else: :error
+  end
+
+  def to_list(_), do: :error
+
+  @spec to_vector(Value.t()) :: {:ok, [Value.t()]} | :error
+  def to_vector({:vector, t}), do: {:ok, Tuple.to_list(t)}
+  def to_vector(_), do: :error
+
+  @spec to_bytevector(Value.t()) :: {:ok, binary()} | :error
+  def to_bytevector({:bytevector, b}), do: {:ok, b}
+  def to_bytevector(_), do: :error
+
+  @spec to_foreign_ref(Value.t()) :: {:ok, term()} | :error
+  def to_foreign_ref({:foreign, term}), do: {:ok, term}
+  def to_foreign_ref(_), do: :error
+
+  @spec to_proc(Value.t()) :: {:ok, Value.t()} | :error
+  def to_proc(value) do
+    if Value.procedure?(value), do: {:ok, value}, else: :error
+  end
+
+  # ---------------------------------------------------------------------------
+  # Internals
+  # ---------------------------------------------------------------------------
+
+  @spec type_error!(keyword(), binary(), term()) :: no_return()
+  defp type_error!(opts, expected, got) do
+    op = Keyword.fetch!(opts, :op)
+    raise TypeError, op: op, expected: expected, got: got
+  end
+end

--- a/lib/schooner/host/type_error.ex
+++ b/lib/schooner/host/type_error.ex
@@ -1,0 +1,40 @@
+defmodule Schooner.Host.TypeError do
+  @moduledoc """
+  Raised by `Schooner.Host` asserting accessors (`to_*!/2`) when a
+  Scheme value does not match the shape the host expected.
+
+  The exception carries `:op` (a host-supplied label naming the call
+  site, e.g. `"my-lib/info"`), `:expected` (a short description of the
+  shape that was demanded, e.g. `"string"`, `"proper list"`), and
+  `:got` (the actual value, rendered with `inspect/1` in the
+  message). Tests can pattern on `:op` and `:expected` without
+  coupling to wording.
+  """
+
+  defexception [:op, :expected, :got, :message]
+
+  @type t :: %__MODULE__{
+          op: binary(),
+          expected: binary(),
+          got: term(),
+          message: binary()
+        }
+
+  @impl true
+  def exception(opts) do
+    op = Keyword.fetch!(opts, :op)
+    expected = Keyword.fetch!(opts, :expected)
+    got = Keyword.fetch!(opts, :got)
+
+    %__MODULE__{
+      op: op,
+      expected: expected,
+      got: got,
+      message: format(op, expected, got)
+    }
+  end
+
+  defp format(op, expected, got) do
+    "host conversion in `#{op}`: expected #{expected}, got #{inspect(got)}"
+  end
+end

--- a/test/schooner/host_test.exs
+++ b/test/schooner/host_test.exs
@@ -1,0 +1,320 @@
+defmodule Schooner.HostTest do
+  use ExUnit.Case, async: true
+
+  alias Schooner.Host
+  alias Schooner.Host.TypeError
+  alias Schooner.Value
+
+  describe "constructors" do
+    test "bool/1 produces Scheme booleans" do
+      assert Host.bool(true) === true
+      assert Host.bool(false) === false
+    end
+
+    test "string/1 produces a Scheme string" do
+      assert Host.string("hello") === "hello"
+    end
+
+    test "symbol/1 produces a Scheme symbol" do
+      assert Host.symbol("foo") === {:sym, "foo"}
+    end
+
+    test "char/1 produces a Scheme character" do
+      assert Host.char(?a) === {:char, ?a}
+    end
+
+    test "pair/2 produces a Scheme pair" do
+      assert Host.pair(1, 2) === [1 | 2]
+      assert Host.pair(1, []) === [1]
+    end
+
+    test "list/1 produces a proper Scheme list" do
+      assert Host.list([1, 2, 3]) === [1, 2, 3]
+      assert Host.list([]) === []
+    end
+
+    test "vector/1 produces a Scheme vector" do
+      assert Host.vector([1, 2, 3]) === {:vector, {1, 2, 3}}
+    end
+
+    test "bytevector/1 accepts a list of bytes or a binary" do
+      assert Host.bytevector([1, 2, 3]) === {:bytevector, <<1, 2, 3>>}
+      assert Host.bytevector(<<4, 5>>) === {:bytevector, <<4, 5>>}
+    end
+
+    test "foreign/1 wraps an arbitrary host term" do
+      pid = self()
+      assert Host.foreign(pid) === {:foreign, pid}
+    end
+
+    test "primitive/3 builds a primitive value" do
+      fun = fn [x] -> x end
+      assert {:primitive, "id", 1, ^fun} = Host.primitive("id", 1, fun)
+    end
+  end
+
+  describe "to_integer!/2" do
+    test "returns the integer for a bare exact integer" do
+      assert Host.to_integer!(42, op: "t") === 42
+      assert Host.to_integer!(-1, op: "t") === -1
+      assert Host.to_integer!(0, op: "t") === 0
+    end
+
+    test "raises on non-integer values with op + expected populated" do
+      assert_raise TypeError, fn -> Host.to_integer!(1.0, op: "t") end
+      assert_raise TypeError, fn -> Host.to_integer!({:rational, 1, 2}, op: "t") end
+      assert_raise TypeError, fn -> Host.to_integer!("42", op: "t") end
+      assert_raise TypeError, fn -> Host.to_integer!({:sym, "n"}, op: "t") end
+    end
+
+    test "TypeError carries op, expected, and got" do
+      err =
+        try do
+          Host.to_integer!(1.5, op: "myapp/count")
+          flunk("should have raised")
+        rescue
+          e in TypeError -> e
+        end
+
+      assert err.op === "myapp/count"
+      assert err.expected === "integer"
+      assert err.got === 1.5
+      assert err.message =~ "myapp/count"
+      assert err.message =~ "integer"
+    end
+  end
+
+  describe "to_float!/2" do
+    test "returns the bare float" do
+      assert Host.to_float!(1.5, op: "t") === 1.5
+      assert Host.to_float!(0.0, op: "t") === 0.0
+    end
+
+    test "rejects integers (host should call to_real! for coercion)" do
+      assert_raise TypeError, fn -> Host.to_float!(1, op: "t") end
+    end
+
+    test "rejects float specials and non-numbers" do
+      assert_raise TypeError, fn -> Host.to_float!({:float_special, :pos_inf}, op: "t") end
+      assert_raise TypeError, fn -> Host.to_float!("1.0", op: "t") end
+    end
+  end
+
+  describe "to_real!/2" do
+    test "passes through integers and floats" do
+      assert Host.to_real!(42, op: "t") === 42
+      assert Host.to_real!(1.5, op: "t") === 1.5
+    end
+
+    test "coerces rationals to floats" do
+      assert Host.to_real!({:rational, 1, 2}, op: "t") === 0.5
+    end
+
+    test "rejects float specials and complex" do
+      assert_raise TypeError, fn -> Host.to_real!({:float_special, :nan}, op: "t") end
+      assert_raise TypeError, fn -> Host.to_real!({:complex, 1, 1}, op: "t") end
+      assert_raise TypeError, fn -> Host.to_real!("1", op: "t") end
+    end
+  end
+
+  describe "to_string!/2" do
+    test "returns the underlying binary" do
+      assert Host.to_string!("hello", op: "t") === "hello"
+      assert Host.to_string!("", op: "t") === ""
+    end
+
+    test "rejects symbols, bytevectors, and non-strings" do
+      assert_raise TypeError, fn -> Host.to_string!({:sym, "foo"}, op: "t") end
+      assert_raise TypeError, fn -> Host.to_string!({:bytevector, <<1>>}, op: "t") end
+      assert_raise TypeError, fn -> Host.to_string!(42, op: "t") end
+    end
+  end
+
+  describe "to_symbol_name!/2" do
+    test "extracts the binary name from a symbol" do
+      assert Host.to_symbol_name!({:sym, "foo"}, op: "t") === "foo"
+    end
+
+    test "rejects strings and non-symbols" do
+      assert_raise TypeError, fn -> Host.to_symbol_name!("foo", op: "t") end
+      assert_raise TypeError, fn -> Host.to_symbol_name!(42, op: "t") end
+    end
+  end
+
+  describe "to_char!/2" do
+    test "extracts the codepoint" do
+      assert Host.to_char!({:char, ?a}, op: "t") === ?a
+      assert Host.to_char!({:char, 0x1F600}, op: "t") === 0x1F600
+    end
+
+    test "rejects integers and non-chars" do
+      assert_raise TypeError, fn -> Host.to_char!(?a, op: "t") end
+      assert_raise TypeError, fn -> Host.to_char!("a", op: "t") end
+    end
+  end
+
+  describe "to_bool!/2" do
+    test "returns true / false for booleans" do
+      assert Host.to_bool!(true, op: "t") === true
+      assert Host.to_bool!(false, op: "t") === false
+    end
+
+    test "rejects truthy non-booleans" do
+      assert_raise TypeError, fn -> Host.to_bool!(0, op: "t") end
+      assert_raise TypeError, fn -> Host.to_bool!([], op: "t") end
+      assert_raise TypeError, fn -> Host.to_bool!("true", op: "t") end
+    end
+  end
+
+  describe "to_list!/2" do
+    test "accepts the empty list" do
+      assert Host.to_list!([], op: "t") === []
+    end
+
+    test "accepts proper Scheme lists" do
+      assert Host.to_list!([1, 2, 3], op: "t") === [1, 2, 3]
+      assert Host.to_list!([Value.string("a")], op: "t") === ["a"]
+    end
+
+    test "rejects improper lists" do
+      assert_raise TypeError, fn -> Host.to_list!([1, 2 | 3], op: "t") end
+      assert_raise TypeError, fn -> Host.to_list!(Value.improper_list([1, 2], 3), op: "t") end
+    end
+
+    test "rejects non-list atoms" do
+      assert_raise TypeError, fn -> Host.to_list!(42, op: "t") end
+      assert_raise TypeError, fn -> Host.to_list!({:sym, "foo"}, op: "t") end
+    end
+  end
+
+  describe "to_vector!/2" do
+    test "returns the elements as an Elixir list" do
+      assert Host.to_vector!({:vector, {1, 2, 3}}, op: "t") === [1, 2, 3]
+      assert Host.to_vector!({:vector, {}}, op: "t") === []
+    end
+
+    test "rejects non-vectors" do
+      assert_raise TypeError, fn -> Host.to_vector!([1, 2, 3], op: "t") end
+      assert_raise TypeError, fn -> Host.to_vector!(42, op: "t") end
+    end
+  end
+
+  describe "to_bytevector!/2" do
+    test "returns the underlying binary" do
+      assert Host.to_bytevector!({:bytevector, <<1, 2, 3>>}, op: "t") === <<1, 2, 3>>
+    end
+
+    test "rejects strings and non-bytevectors" do
+      assert_raise TypeError, fn -> Host.to_bytevector!("abc", op: "t") end
+      assert_raise TypeError, fn -> Host.to_bytevector!({:vector, {1, 2}}, op: "t") end
+    end
+  end
+
+  describe "to_foreign_ref!/2" do
+    test "unwraps a foreign payload" do
+      pid = self()
+      assert Host.to_foreign_ref!({:foreign, pid}, op: "t") === pid
+      assert Host.to_foreign_ref!({:foreign, %{a: 1}}, op: "t") === %{a: 1}
+    end
+
+    test "rejects non-foreign values" do
+      assert_raise TypeError, fn -> Host.to_foreign_ref!(42, op: "t") end
+      assert_raise TypeError, fn -> Host.to_foreign_ref!({:sym, "foo"}, op: "t") end
+    end
+  end
+
+  describe "to_proc!/2" do
+    test "accepts closures, primitives, and parameters" do
+      closure = Value.closure({:fixed, 0, []}, [], :no_env, nil)
+      primitive = Value.primitive("id", 1, fn [x] -> x end)
+      parameter = Value.parameter(0, nil)
+
+      assert Host.to_proc!(closure, op: "t") === closure
+      assert Host.to_proc!(primitive, op: "t") === primitive
+      assert Host.to_proc!(parameter, op: "t") === parameter
+    end
+
+    test "rejects non-procedures" do
+      assert_raise TypeError, fn -> Host.to_proc!(42, op: "t") end
+      assert_raise TypeError, fn -> Host.to_proc!({:sym, "foo"}, op: "t") end
+    end
+  end
+
+  describe "total accessors return {:ok, _} | :error" do
+    test "to_integer/1" do
+      assert Host.to_integer(42) === {:ok, 42}
+      assert Host.to_integer(1.0) === :error
+    end
+
+    test "to_float/1" do
+      assert Host.to_float(1.5) === {:ok, 1.5}
+      assert Host.to_float(1) === :error
+    end
+
+    test "to_real/1" do
+      assert Host.to_real(2) === {:ok, 2}
+      assert Host.to_real(1.5) === {:ok, 1.5}
+      assert Host.to_real({:rational, 1, 4}) === {:ok, 0.25}
+      assert Host.to_real({:float_special, :nan}) === :error
+    end
+
+    test "to_string/1" do
+      assert Host.to_string("hi") === {:ok, "hi"}
+      assert Host.to_string({:sym, "hi"}) === :error
+    end
+
+    test "to_symbol_name/1" do
+      assert Host.to_symbol_name({:sym, "hi"}) === {:ok, "hi"}
+      assert Host.to_symbol_name("hi") === :error
+    end
+
+    test "to_char/1" do
+      assert Host.to_char({:char, ?z}) === {:ok, ?z}
+      assert Host.to_char(?z) === :error
+    end
+
+    test "to_bool/1" do
+      assert Host.to_bool(true) === {:ok, true}
+      assert Host.to_bool(false) === {:ok, false}
+      assert Host.to_bool([]) === :error
+    end
+
+    test "to_list/1" do
+      assert Host.to_list([]) === {:ok, []}
+      assert Host.to_list([1, 2, 3]) === {:ok, [1, 2, 3]}
+      assert Host.to_list([1 | 2]) === :error
+      assert Host.to_list(42) === :error
+    end
+
+    test "to_vector/1" do
+      assert Host.to_vector({:vector, {1, 2}}) === {:ok, [1, 2]}
+      assert Host.to_vector(42) === :error
+    end
+
+    test "to_bytevector/1" do
+      assert Host.to_bytevector({:bytevector, <<1>>}) === {:ok, <<1>>}
+      assert Host.to_bytevector("a") === :error
+    end
+
+    test "to_foreign_ref/1" do
+      assert Host.to_foreign_ref({:foreign, :payload}) === {:ok, :payload}
+      assert Host.to_foreign_ref(42) === :error
+    end
+
+    test "to_proc/1" do
+      primitive = Value.primitive("id", 1, fn [x] -> x end)
+      assert Host.to_proc(primitive) === {:ok, primitive}
+      assert Host.to_proc(42) === :error
+    end
+  end
+
+  describe "TypeError shape" do
+    test "exception/1 builds the message from op + expected + got" do
+      err = TypeError.exception(op: "lib/foo", expected: "string", got: 42)
+      assert err.op === "lib/foo"
+      assert err.expected === "string"
+      assert err.got === 42
+      assert err.message === "host conversion in `lib/foo`: expected string, got 42"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

First slice of the **Phase 15 embedding API**. Introduces `Schooner.Host` as the documented seam between Scheme values and Elixir terms, with no automatic marshalling — host functions still take `[Schooner.Value.t()]` and return `Schooner.Value.t()`, but go through named helpers so future representation changes don't ripple into host code.

- **Constructors** — `Host.bool/1`, `string/1`, `symbol/1`, `char/1`, `pair/2`, `list/1`, `vector/1`, `bytevector/1`, `foreign/1`, `primitive/3`, all delegating to `Schooner.Value`.
- **Asserting accessors** — `to_integer!/2`, `to_float!/2`, `to_real!/2`, `to_string!/2`, `to_symbol_name!/2`, `to_char!/2`, `to_bool!/2`, `to_list!/2`, `to_vector!/2`, `to_bytevector!/2`, `to_foreign_ref!/2`, `to_proc!/2`. Take `:op` so the error points at the host call site.
- **Total accessors** — same names without `!`, returning `{:ok, _} | :error` for the "branch on shape" case (Elixir `to_string/to_string!` convention).
- **`Schooner.Host.TypeError`** — raised by the bang form, carries `:op`, `:expected`, `:got` so tests can pin behaviour.

The strict-vs-coercive split is deliberate: `to_float!/2` rejects integers and rationals (host should call `to_real!/2` for the lenient "give me a number" case), and `to_real!/2` rejects the float specials (no plain BEAM-float representation for `+inf.0`/`+nan.0`).

`Host.to_string/1` shadows `Kernel.to_string/1` for any module that does `import Schooner.Host`. The moduledoc documents the recommended `alias Schooner.Host` pattern instead.

## Sub-phase context

This is **15.1 of 5** in the Phase 15 plan agreed in chat:
- 15.1 (this PR) — `Schooner.Host` conversion helpers + `TypeError`
- 15.2 — `Schooner.Host.library/1` builder + relax `Library.validate_name!` to accept `[]` for anonymous host libraries
- 15.3 — `%Schooner.Environment{}` + bang/tagged-tuple split for `eval` and `run`
- 15.4 — `Schooner.apply/2,!`, `Schooner.compile/2,!`, `%Schooner.Compiled{}`
- 15.5 — ExDoc dep + four guides (embedding, host-functions, sandbox, deviations)

## Test plan

- [x] 52 new unit tests under `test/schooner/host_test.exs` — every constructor and accessor (asserting + total) with happy-path + rejected-shape coverage
- [x] `TypeError` shape pinned: `:op`, `:expected`, `:got`, message format
- [x] `mix precommit` green — 1431 tests, 0 failures, credo --strict clean