### PR TITLE
Phase 15.2: Schooner.Host.library/1 + anonymous library names

### DIFF
--- a/lib/schooner/host.ex
+++ b/lib/schooner/host.ex
@@ -56,6 +56,7 @@ defmodule Schooner.Host do
   """
 
   alias Schooner.Host.TypeError
+  alias Schooner.Library
   alias Schooner.Value
 
   # ---------------------------------------------------------------------------
@@ -93,6 +94,114 @@ defmodule Schooner.Host do
 
   @spec primitive(binary(), Value.arity_spec(), (list() -> Value.t())) :: Value.primitive_v()
   defdelegate primitive(name, arity, fun), to: Value
+
+  # ---------------------------------------------------------------------------
+  # Library builder
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Build a `Schooner.Library` from host-supplied primitive specs and
+  arbitrary value bindings.
+
+  ## Options
+
+    * `:name` — canonical library name as a list of binary or
+      non-negative-integer segments. Defaults to `[]`, which marks
+      the library as **anonymous**: it cannot be reached via Scheme
+      `(import ...)`, and its bindings are applied directly to the
+      runtime environment when the embedder lists it. Named
+      libraries (e.g. `["myapp", "log"]`) are sandbox-safe — the
+      script must explicitly `(import (myapp log))` to see them.
+
+    * `:primitives` — list of `{name, arity, fun}` triples
+      registered as `Schooner.Value.primitive/3` bindings. `arity`
+      may be an integer, `{:at_least, n}`, or `{:between, lo, hi}`.
+      `fun` must be `(list() -> Schooner.Value.t())` — the
+      underlying primitive ABI.
+
+    * `:values` — list of `{name, value}` pairs for arbitrary
+      `Schooner.Value.t/0` bindings (constants, foreign-wrapped
+      service handles, pre-built closures). Useful when the host
+      wants to expose data, not just procedures.
+
+  Names within a library must be unique across `:primitives` and
+  `:values` combined; a collision raises `ArgumentError`.
+
+  ## Examples
+
+  Named library — script must import:
+
+      Schooner.Host.library(
+        name: ["myapp", "log"],
+        primitives: [
+          {"info", 1, &MyApp.SchemeLib.info/1}
+        ]
+      )
+
+  Anonymous library — bindings auto-applied, no import required.
+  Sandbox-loosening; list deliberately:
+
+      Schooner.Host.library(
+        primitives: [
+          {"now-ms", 0, fn [] -> System.system_time(:millisecond) end}
+        ]
+      )
+  """
+  @spec library(keyword()) :: Library.t()
+  def library(opts) when is_list(opts) do
+    name = Keyword.get(opts, :name, [])
+    primitives = Keyword.get(opts, :primitives, [])
+    values = Keyword.get(opts, :values, [])
+
+    exports =
+      %{}
+      |> merge_primitives!(primitives)
+      |> merge_values!(values)
+
+    Library.new(name: name, exports: exports)
+  end
+
+  defp merge_primitives!(exports, primitives) when is_list(primitives) do
+    Enum.reduce(primitives, exports, fn
+      {pname, arity, fun}, acc when is_binary(pname) and is_function(fun, 1) ->
+        put_export!(acc, pname, {:var, Value.primitive(pname, arity, fun)})
+
+      bad, _acc ->
+        raise ArgumentError,
+              "host primitive must be {binary, arity_spec, (list() -> Value.t())}, " <>
+                "got #{inspect(bad)}"
+    end)
+  end
+
+  defp merge_primitives!(_exports, other) do
+    raise ArgumentError, ":primitives must be a list, got #{inspect(other)}"
+  end
+
+  defp merge_values!(exports, values) when is_list(values) do
+    Enum.reduce(values, exports, fn
+      {vname, value}, acc when is_binary(vname) ->
+        put_export!(acc, vname, {:var, value})
+
+      bad, _acc ->
+        raise ArgumentError, "host value binding must be {binary, value}, got #{inspect(bad)}"
+    end)
+  end
+
+  defp merge_values!(_exports, other) do
+    raise ArgumentError, ":values must be a list, got #{inspect(other)}"
+  end
+
+  defp put_export!(exports, name, binding) do
+    case Map.fetch(exports, name) do
+      :error ->
+        Map.put(exports, name, binding)
+
+      {:ok, _existing} ->
+        raise ArgumentError,
+              "duplicate host library export: #{inspect(name)} appears more than once " <>
+                "in :primitives / :values"
+    end
+  end
 
   # ---------------------------------------------------------------------------
   # Asserting accessors — to_*!/2

--- a/lib/schooner/library.ex
+++ b/lib/schooner/library.ex
@@ -40,7 +40,11 @@ defmodule Schooner.Library do
             features: []
 
   @type segment :: binary() | non_neg_integer()
-  @type name :: [segment(), ...]
+  # Non-empty lists denote standard r7rs-style library names like
+  # `(scheme base)`. The empty list `[]` is reserved for anonymous
+  # host libraries — see `Schooner.Host.library/1` and the comment
+  # on `validate_name!/1`.
+  @type name :: [segment()]
   @type export :: {:var, term()} | {:macro, term()}
   @type source :: :native | {:file, binary(), term()}
   @type t :: %__MODULE__{
@@ -187,9 +191,14 @@ defmodule Schooner.Library do
   end
 
   @doc """
-  Render `name` in `(scheme base)` form for diagnostics.
+  Render `name` in `(scheme base)` form for diagnostics. The empty
+  list (an anonymous host library) renders as
+  `"(anonymous host library)"` — there is no Scheme syntax that can
+  produce that name, so a literal `()` rendering would be misleading.
   """
   @spec render_name(name()) :: binary()
+  def render_name([]), do: "(anonymous host library)"
+
   def render_name(name) when is_list(name) do
     "(" <> Enum.map_join(name, " ", &render_segment/1) <> ")"
   end
@@ -218,6 +227,16 @@ defmodule Schooner.Library do
   defp render_segment(seg) when is_binary(seg), do: seg
   defp render_segment(seg) when is_integer(seg), do: Integer.to_string(seg)
 
+  # The empty list is a valid library name and denotes an *anonymous*
+  # host library — one whose bindings are applied directly to the
+  # runtime environment (see `Schooner.Environment.new/1`) rather
+  # than registered for `(import ...)` resolution. There is no
+  # Scheme syntax that can produce an empty library-name datum, so
+  # an anonymous library is unreachable from the script side: the
+  # only way its bindings enter scope is by the host listing the
+  # library when constructing the environment.
+  defp validate_name!([] = name), do: name
+
   defp validate_name!([_ | _] = name) do
     Enum.each(name, fn
       seg when is_binary(seg) ->
@@ -235,7 +254,7 @@ defmodule Schooner.Library do
   end
 
   defp validate_name!(other) do
-    raise ArgumentError, "library name must be a non-empty list, got #{inspect(other)}"
+    raise ArgumentError, "library name must be a list, got #{inspect(other)}"
   end
 
   defp validate_exports!(map) when is_map(map) do

--- a/test/schooner/host_test.exs
+++ b/test/schooner/host_test.exs
@@ -317,4 +317,136 @@ defmodule Schooner.HostTest do
       assert err.message === "host conversion in `lib/foo`: expected string, got 42"
     end
   end
+
+  describe "library/1 — named library" do
+    test "builds a Schooner.Library with the named primitives as exports" do
+      fun = fn [x] -> x end
+
+      lib =
+        Host.library(
+          name: ["myapp", "log"],
+          primitives: [{"info", 1, fun}]
+        )
+
+      assert lib.name == ["myapp", "log"]
+      assert {:var, {:primitive, "info", 1, ^fun}} = lib.exports["info"]
+    end
+
+    test "supports {:at_least, n} and {:between, lo, hi} arity specs" do
+      fun = fn _args -> :unspecified end
+
+      lib =
+        Host.library(
+          name: ["x"],
+          primitives: [
+            {"variadic", {:at_least, 1}, fun},
+            {"bounded", {:between, 0, 3}, fun}
+          ]
+        )
+
+      assert {:var, {:primitive, "variadic", {:at_least, 1}, _}} = lib.exports["variadic"]
+      assert {:var, {:primitive, "bounded", {:between, 0, 3}, _}} = lib.exports["bounded"]
+    end
+
+    test "values exposes arbitrary Scheme values as variable bindings" do
+      lib =
+        Host.library(
+          name: ["myapp", "config"],
+          values: [
+            {"version", Host.string("1.0.0")},
+            {"handle", Host.foreign(self())}
+          ]
+        )
+
+      assert lib.exports["version"] == {:var, "1.0.0"}
+      assert lib.exports["handle"] == {:var, {:foreign, self()}}
+    end
+
+    test "primitives and values can coexist" do
+      lib =
+        Host.library(
+          name: ["x"],
+          primitives: [{"identity", 1, fn [v] -> v end}],
+          values: [{"pi", 3.14159}]
+        )
+
+      assert {:var, {:primitive, "identity", 1, _}} = lib.exports["identity"]
+      assert lib.exports["pi"] == {:var, 3.14159}
+    end
+  end
+
+  describe "library/1 — anonymous library" do
+    test "defaults to name: [] when no name is given" do
+      lib =
+        Host.library(primitives: [{"now-ms", 0, fn [] -> 0 end}])
+
+      assert lib.name == []
+      assert {:var, {:primitive, "now-ms", 0, _}} = lib.exports["now-ms"]
+    end
+
+    test "explicit name: [] is also accepted" do
+      lib = Host.library(name: [], primitives: [{"x", 0, fn [] -> :unspecified end}])
+      assert lib.name == []
+    end
+  end
+
+  describe "library/1 — validation" do
+    test "rejects malformed primitive triples" do
+      assert_raise ArgumentError, ~r/host primitive must be/, fn ->
+        Host.library(primitives: [{"bad", 1}])
+      end
+
+      assert_raise ArgumentError, ~r/host primitive must be/, fn ->
+        Host.library(primitives: [{:not_a_binary, 1, fn [] -> 1 end}])
+      end
+
+      assert_raise ArgumentError, ~r/host primitive must be/, fn ->
+        Host.library(primitives: [{"wrong-arity-fn", 1, fn -> 1 end}])
+      end
+    end
+
+    test "rejects malformed value pairs" do
+      assert_raise ArgumentError, ~r/host value binding must be/, fn ->
+        Host.library(values: [{:not_a_binary, 1}])
+      end
+    end
+
+    test "rejects non-list :primitives" do
+      assert_raise ArgumentError, ~r/:primitives must be a list/, fn ->
+        Host.library(primitives: %{})
+      end
+    end
+
+    test "rejects non-list :values" do
+      assert_raise ArgumentError, ~r/:values must be a list/, fn ->
+        Host.library(values: %{})
+      end
+    end
+
+    test "rejects duplicate names within :primitives" do
+      assert_raise ArgumentError, ~r/duplicate host library export/, fn ->
+        Host.library(
+          primitives: [
+            {"dup", 0, fn [] -> 1 end},
+            {"dup", 0, fn [] -> 2 end}
+          ]
+        )
+      end
+    end
+
+    test "rejects duplicate names within :values" do
+      assert_raise ArgumentError, ~r/duplicate host library export/, fn ->
+        Host.library(values: [{"dup", 1}, {"dup", 2}])
+      end
+    end
+
+    test "rejects collisions between :primitives and :values" do
+      assert_raise ArgumentError, ~r/duplicate host library export/, fn ->
+        Host.library(
+          primitives: [{"shared", 0, fn [] -> 1 end}],
+          values: [{"shared", 2}]
+        )
+      end
+    end
+  end
 end

--- a/test/schooner/library_test.exs
+++ b/test/schooner/library_test.exs
@@ -29,12 +29,15 @@ defmodule Schooner.LibraryTest do
       end
     end
 
-    test "rejects empty name" do
-      assert_raise ArgumentError, ~r/non-empty list/, fn -> Library.new(name: []) end
+    test "accepts empty name (anonymous host library)" do
+      lib = Library.new(name: [])
+      assert lib.name == []
     end
 
     test "rejects non-list name" do
-      assert_raise ArgumentError, ~r/non-empty list/, fn -> Library.new(name: "scheme.base") end
+      assert_raise ArgumentError, ~r/library name must be a list/, fn ->
+        Library.new(name: "scheme.base")
+      end
     end
 
     test "rejects negative integer segment" do
@@ -72,7 +75,7 @@ defmodule Schooner.LibraryTest do
     end
 
     test "validates each import name" do
-      assert_raise ArgumentError, ~r/non-empty list/, fn ->
+      assert_raise ArgumentError, ~r/library name must be a list/, fn ->
         Library.new(name: ["x"], imports: [["scheme", "base"], "not-a-list"])
       end
     end
@@ -149,6 +152,10 @@ defmodule Schooner.LibraryTest do
 
     test "formats integer segments" do
       assert Library.render_name(["srfi", 1]) == "(srfi 1)"
+    end
+
+    test "renders the empty name as the anonymous label" do
+      assert Library.render_name([]) == "(anonymous host library)"
     end
   end
 


### PR DESCRIPTION
## Summary

Builds on #93. Adds the host-side library builder and the **anonymous-library** convention that lets embedders inject bindings directly into a runtime environment without giving them an importable name.

- **`Schooner.Host.library/1`** — produces a `%Schooner.Library{}` from host-supplied primitive specs and arbitrary value bindings. Options: `:name` (default `[]`), `:primitives` (`[{name, arity, fun}, ...]`), `:values` (`[{name, Schooner.Value.t()}, ...]`).
- **Anonymous libraries** — `name: []` (the default). There is no Scheme syntax that produces an empty library-name datum, so an anonymous library is unreachable from script code; its bindings only enter scope when the embedder lists it on `Schooner.Environment.new/1` (next sub-phase). Named libraries (`["myapp", "log"]`) require explicit `(import ...)` and stay sandbox-safe.
- **`Library.validate_name!/1`** — relaxed to accept `[]`. Type spec changed from `[segment(), ...]` to `[segment()]`.
- **`Library.render_name/1`** — special-cases `[]` as `"(anonymous host library)"` rather than the misleading literal `"()"`.

Validation is strict: malformed primitive triples, malformed value pairs, non-list option values, and duplicate export names all raise `ArgumentError` with a clear message naming the offender.

## Sub-phase context

This is **15.2 of 5** in the Phase 15 plan:
- 15.1 — `Schooner.Host` conversion helpers + `TypeError` (#93, merged)
- 15.2 (this PR) — `Schooner.Host.library/1` + anonymous library names
- 15.3 — `%Schooner.Environment{}` + bang/tagged-tuple split for `eval` and `run`
- 15.4 — `Schooner.apply/2,!`, `Schooner.compile/2,!`, `%Schooner.Compiled{}`
- 15.5 — ExDoc dep + four guides

## Test plan

- [x] 14 new tests — named library, anonymous library, primitives + values + collisions, malformed inputs
- [x] Existing `Library` tests updated for the relaxed `[]` acceptance and new error message wording
- [x] New `render_name([])` test pinning the anonymous-label rendering
- [x] `mix precommit` green — 1445 tests, 0 failures, credo --strict clean