### PR TITLE
Phase 15.3: Schooner.Environment + bang/tagged eval split

### DIFF
--- a/lib/schooner.ex
+++ b/lib/schooner.ex
@@ -1,7 +1,7 @@
 defmodule Schooner do
   @moduledoc """
-  An embeddable, sandboxed Scheme interpreter for the BEAM, targeting the
-  r7rs-small language minus its mutable operations.
+  An embeddable, sandboxed Scheme interpreter for the BEAM, targeting
+  the r7rs-small language minus its mutable operations.
 
   The pipeline is `Schooner.Lexer` → `Schooner.Reader` →
   `Schooner.Expander` → `Schooner.Eval`, with `Schooner.Value` providing
@@ -12,41 +12,56 @@ defmodule Schooner do
 
   ## Choosing an entry point
 
-  Schooner has two top-level evaluation entry points. **The trust
-  posture differs — picking the wrong one for untrusted input is a
-  sandbox-shaped hole.** The naming is the opposite of what reflex
-  suggests: `run/1` is the lax convenience, `eval/2` is the strict
-  embedding path.
+  Schooner's entry points come in pairs following the Elixir
+  convention: a tagged-tuple form (`run/1`, `eval/2,3`) and a bang
+  form (`run!/1`, `eval!/2,3`) that raises on failure. Picking
+  between `run*` and `eval*` is a **trust-posture decision** — the
+  naming is the opposite of what reflex suggests.
 
-  | Entry point | Auto-imports | Trust posture | Use for |
-  | ---         | ---          | ---           | --- |
-  | `run/1`     | injects `(import ...)` of every shipped standard library when the script declares none | **Not sandbox-safe.** Every shipped primitive is in scope by default. | tests, REPL-style use, your own scripts where you control the source |
-  | `eval/2`    | none — bindings come exclusively from `env` and the script's own `(import ...)` declarations | **Sandbox-safe.** The embedder controls the surface. | embedding untrusted or semi-trusted scripts |
+  | Family        | Auto-imports                                                                              | Trust posture                                       | Use for                                                            |
+  | ---           | ---                                                                                       | ---                                                 | --- |
+  | `run/1`/`run!/1`     | injects `(import ...)` of every shipped standard library when the script declares none | **Not sandbox-safe.** Every shipped primitive is in scope by default. | tests, REPL-style use, your own scripts where you control the source |
+  | `eval/2,3`/`eval!/2,3` | none — bindings come exclusively from the `env` argument and the script's own `(import ...)` declarations | **Sandbox-safe.** The embedder controls the surface. | embedding untrusted or semi-trusted scripts |
 
-  The implicit-import behaviour of `run/1` is opt-in via the
-  `implicit_imports: :all` option on `eval/3`; `run/1` is exactly
-  `eval(source, Env.new(), implicit_imports: :all)`. Embedders who want
-  the convenience without the rename can call `eval/3` with the option
-  themselves.
+  The implicit-import behaviour of `run`/`run!` is opt-in via the
+  `implicit_imports: :all` option on the 3-arity `eval/3` and
+  `eval!/3`. Embedders who want the convenience without the rename
+  can call `eval!/3` (or `eval/3`) with the option themselves.
+
+  Within each family, the bang form raises one of:
+
+    * `Schooner.Error` — uncaught Scheme `(raise ...)` in the script
+    * `Schooner.Eval.Error` — runtime evaluation failure
+    * `Schooner.Primitive.Error` — primitive type / arity / domain error
+    * `Schooner.Library.NotFoundError` — `(import ...)` of a missing library
+    * `Schooner.Lexer.Error`, `Schooner.Reader.Error`,
+      `Schooner.Expander.Error` — source-level failures
+
+  The non-bang form returns `{:ok, value}` on success or
+  `{:error, exception}` for any of the above. `ArgumentError`
+  raised by malformed options is **not** caught — that is an
+  embedder bug, not a script-level failure.
 
   ### Embedding untrusted code
 
-  Use `eval/2` and require the script to declare exactly which libraries
-  it needs. A script that omits `(import ...)` cannot reach any
-  primitive — even `+` is unbound:
+  Use `eval/2` (or `eval!/2`) and require the script to declare
+  exactly which libraries it needs. A script that omits
+  `(import ...)` cannot reach any primitive — even `+` is unbound:
 
-      iex> Schooner.eval("(import (only (scheme base) +)) (+ 1 2)", Schooner.Env.new())
+      iex> Schooner.eval!("(import (only (scheme base) +)) (+ 1 2)", Schooner.Env.new())
       3
 
-  Pair this with BEAM-level resource limits — run `eval/2` inside a
-  spawned process with `:max_heap_size` and a `Task.shutdown/2` timeout
-  so a runaway script cannot exhaust the host.
+  Pair this with BEAM-level resource limits — run `eval!/2` inside
+  a spawned process with `:max_heap_size` and a `Task.shutdown/2`
+  timeout so a runaway script cannot exhaust the host.
 
-  The full embedding API (`Schooner.Environment.new/1`,
-  `Schooner.compile/1`, `Schooner.Host`) arrives in phase 14.
+  For richer sandbox composition (registering host libraries,
+  pre-imports, etc.), construct a `Schooner.Environment` via
+  `Schooner.Environment.new/1` and pass it to `eval/2`.
   """
 
   alias Schooner.Env
+  alias Schooner.Environment
   alias Schooner.Eval
   alias Schooner.Eval.ContinuationState
   alias Schooner.Eval.ExceptionState
@@ -56,6 +71,20 @@ defmodule Schooner do
   alias Schooner.Library.Import, as: LibImport
   alias Schooner.Reader
   alias Schooner.Value
+
+  # Exception types caught by the tagged-tuple wrappers and surfaced
+  # as `{:error, exception}`. Anything else propagates — those are
+  # embedder bugs (e.g. ArgumentError on malformed options) and
+  # should not be silently swallowed.
+  @script_exceptions [
+    Schooner.Error,
+    Schooner.Eval.Error,
+    Schooner.Primitive.Error,
+    Schooner.Library.NotFoundError,
+    Schooner.Lexer.Error,
+    Schooner.Reader.Error,
+    Schooner.Expander.Error
+  ]
 
   # Implicit imports applied when `implicit_imports: :all` is set and
   # the script has no explicit `(import ...)` of its own. Pre-parsed at
@@ -72,79 +101,131 @@ defmodule Schooner do
   standard library implicitly imported when the script declares no
   imports of its own.
 
-  This is a one-line convenience over `eval/3`:
+  Returns `{:ok, value}` on success, `{:error, exception}` for
+  any script-level failure. Use `run!/1` for the raising variant.
 
-      Schooner.eval(source, Schooner.Env.new(), implicit_imports: :all)
-
-  **Not for untrusted input.** A script with no `(import ...)` form
-  reaches every primitive Schooner ships with. Use `eval/2` for
-  embedding scripts you do not control — see "Choosing an entry point"
-  in the moduledoc.
+  **Not for untrusted input.** A script with no `(import ...)`
+  form reaches every primitive Schooner ships with. Use `eval/2`
+  for embedding scripts you do not control — see "Choosing an
+  entry point" in the moduledoc.
   """
-  @spec run(binary()) :: Value.t()
+  @spec run(binary()) :: {:ok, Value.t()} | {:error, Exception.t()}
   def run(source) when is_binary(source) do
-    eval(source, Env.new(), implicit_imports: :all)
+    {:ok, run!(source)}
+  rescue
+    e -> rescue_script_error(e, __STACKTRACE__)
+  end
+
+  @doc """
+  Bang form of `run/1` — raises on script-level failure.
+  """
+  @spec run!(binary()) :: Value.t()
+  def run!(source) when is_binary(source) do
+    eval!(source, Env.new(), implicit_imports: :all)
   end
 
   @doc """
   Read and evaluate `source` against `env`, threading top-level
-  definitions and any explicit `(import ...)` bindings into it. No
-  implicit imports are added — bindings come exclusively from `env`
-  and from the script's own `(import ...)` declarations.
+  definitions and any explicit `(import ...)` bindings into it.
 
-  This is the strict path: it is the right entry point for embedding
-  scripts whose source the host does not control. See "Choosing an
-  entry point" in the moduledoc.
+  Returns `{:ok, value}` on success, `{:error, exception}` for
+  any script-level failure. Use `eval!/2` for the raising variant.
 
-  Equivalent to `eval(source, env, [])`.
+  `env` may be either a `Schooner.Env` (low-level) or a
+  `Schooner.Environment` (the embedding-friendly bundle of env +
+  registry + syntax env produced by `Schooner.Environment.new/1`).
+  When given an `Env`, no implicit imports are added — bindings
+  come exclusively from `env` and the script's own `(import ...)`
+  declarations.
+
+  This is the strict path: it is the right entry point for
+  embedding scripts whose source the host does not control. See
+  "Choosing an entry point" in the moduledoc.
   """
-  @spec eval(binary(), Env.t()) :: Value.t()
-  def eval(source, %Env{} = env) when is_binary(source) do
-    eval(source, env, [])
+  @spec eval(binary(), Env.t() | Environment.t()) ::
+          {:ok, Value.t()} | {:error, Exception.t()}
+  def eval(source, env_or_environment) do
+    {:ok, eval!(source, env_or_environment)}
+  rescue
+    e -> rescue_script_error(e, __STACKTRACE__)
   end
 
   @doc """
-  Read and evaluate `source` against `env` with `opts`.
+  Read and evaluate `source` against `env` with `opts`. Returns
+  `{:ok, value}` on success, `{:error, exception}` for any
+  script-level failure. Use `eval!/3` for the raising variant.
+
+  Options match `eval!/3`. The `Environment` overload of `eval/2`
+  does not accept options — pre-imports and library composition
+  are baked into the `Environment` at construction time.
+  """
+  @spec eval(binary(), Env.t(), keyword()) ::
+          {:ok, Value.t()} | {:error, Exception.t()}
+  def eval(source, %Env{} = env, opts) when is_binary(source) and is_list(opts) do
+    {:ok, eval!(source, env, opts)}
+  rescue
+    e -> rescue_script_error(e, __STACKTRACE__)
+  end
+
+  @doc """
+  Bang form of `eval/2` — raises on script-level failure.
+  """
+  @spec eval!(binary(), Env.t() | Environment.t()) :: Value.t()
+  def eval!(source, %Env{} = env) when is_binary(source) do
+    eval!(source, env, [])
+  end
+
+  def eval!(source, %Environment{env: env, syntax_env: syntax_env, registry: registry})
+      when is_binary(source) do
+    forms = Reader.read_string(source)
+    do_eval(forms, env, syntax_env, registry)
+  end
+
+  @doc """
+  Bang form of `eval/3` — raises on script-level failure.
 
   Options:
 
-    * `:implicit_imports` — controls implicit imports prepended to a
-      script that declares none of its own.
+    * `:implicit_imports` — controls implicit imports prepended
+      to a script that declares none of its own.
         * `:none` (default) — no implicit imports. Bindings come
           exclusively from `env` and the script's own
-          `(import ...)` declarations. Use this for untrusted input.
-        * `:all` — implicitly import every shipped standard library.
-          Skipped if the script already declares any `(import ...)`,
-          on the principle that an explicit import means the user has
-          opted in to a tighter surface.
+          `(import ...)` declarations. Use this for untrusted
+          input.
+        * `:all` — implicitly import every shipped standard
+          library. Skipped if the script already declares any
+          `(import ...)`, on the principle that an explicit
+          import means the user has opted in to a tighter
+          surface.
   """
-  @spec eval(binary(), Env.t(), keyword()) :: Value.t()
-  def eval(source, %Env{} = env, opts) when is_binary(source) and is_list(opts) do
+  @spec eval!(binary(), Env.t(), keyword()) :: Value.t()
+  def eval!(source, %Env{} = env, opts) when is_binary(source) and is_list(opts) do
     forms = Reader.read_string(source)
-
-    forms =
-      case Keyword.get(opts, :implicit_imports, :none) do
-        :none ->
-          forms
-
-        :all ->
-          {explicit_imports, _body} = LibImport.extract_program_imports(forms)
-
-          case explicit_imports do
-            [] -> @default_implicit_imports_forms ++ forms
-            _ -> forms
-          end
-
-        other ->
-          raise ArgumentError,
-                "invalid value for :implicit_imports — expected :none or :all, got: " <>
-                  inspect(other)
-      end
-
-    do_eval(forms, env)
+    forms = apply_implicit_imports(forms, opts)
+    do_eval(forms, env, Expander.bootstrap_env(), Library.standard())
   end
 
-  defp do_eval(forms, %Env{} = env) do
+  defp apply_implicit_imports(forms, opts) do
+    case Keyword.get(opts, :implicit_imports, :none) do
+      :none ->
+        forms
+
+      :all ->
+        {explicit_imports, _body} = LibImport.extract_program_imports(forms)
+
+        case explicit_imports do
+          [] -> @default_implicit_imports_forms ++ forms
+          _ -> forms
+        end
+
+      other ->
+        raise ArgumentError,
+              "invalid value for :implicit_imports — expected :none or :all, got: " <>
+                inspect(other)
+    end
+  end
+
+  defp do_eval(forms, %Env{} = env, syntax_env, registry) do
     # Snapshot/restore the per-process control state so each top-level
     # call starts clean. Without this, a script that pushes a handler
     # or registers a `call/cc` tag then escapes via a host-side throw
@@ -159,10 +240,9 @@ defmodule Schooner do
 
     try do
       {import_specs, body} = LibImport.extract_program_imports(forms)
-      bindings = LibImport.resolve(import_specs, Library.standard())
+      bindings = LibImport.resolve(import_specs, registry)
 
-      {env, syntax_env} =
-        LibImport.apply_bindings(bindings, env, Expander.bootstrap_env())
+      {env, syntax_env} = LibImport.apply_bindings(bindings, env, syntax_env)
 
       body
       |> Expander.expand_program(syntax_env)
@@ -172,6 +252,14 @@ defmodule Schooner do
       ExceptionState.restore(prev_handlers)
       ContinuationState.restore(prev_conts)
       ParameterState.restore(prev_params)
+    end
+  end
+
+  defp rescue_script_error(e, stacktrace) do
+    if e.__struct__ in @script_exceptions do
+      {:error, e}
+    else
+      reraise e, stacktrace
     end
   end
 end

--- a/lib/schooner/environment.ex
+++ b/lib/schooner/environment.ex
@@ -1,0 +1,231 @@
+defmodule Schooner.Environment do
+  @moduledoc """
+  Opaque embedding-friendly environment that bundles a runtime
+  `Schooner.Env`, an expander `SyntaxEnv`, and a library registry.
+
+  An `%Environment{}` is the recommended argument to
+  `Schooner.eval/2,3` and `Schooner.eval!/2,3` for embedders. It
+  carries everything needed to evaluate a script in a controlled
+  surface — which standard libraries are reachable via `(import ...)`,
+  which host libraries are pre-applied, which named host libraries
+  are available for the script to import. The struct is opaque:
+  embedders must not pattern-match on its internals; the public
+  surface is `new/1`.
+
+  ## Library composition
+
+    * **Standard libraries** populate the registry from
+      `Schooner.Library.standard/0`. The `:standard_libraries`
+      option controls which ones are available. Default `:default`
+      registers everything Schooner ships with; `:none` ships none;
+      a list of canonical names like `[["scheme", "base"], ["scheme",
+      "char"]]` ships exactly those.
+
+    * **Named host libraries** (built with
+      `Schooner.Host.library/1` and a non-empty `:name`) join the
+      registry alongside the standard libraries. The script must
+      `(import ...)` them to bring their bindings into scope.
+      Sandbox-safe — the embedder controls the menu, the script
+      controls which dishes it orders.
+
+    * **Anonymous host libraries** (`name: []`) bypass the registry
+      entirely. Their bindings are applied directly to the runtime
+      env at construction time, so they are in scope from the
+      script's first form without any `(import ...)`. **This is
+      sandbox-loosening** — list anonymous libraries deliberately.
+
+    * **`:pre_imports`** auto-apply specific named libraries to the
+      runtime env, equivalent to the script having
+      `(import (foo bar))` at the top. Useful when the embedder
+      always wants a specific surface available without making the
+      script repeat the import. Only canonical names are accepted
+      at this level (no modifiers); use anonymous libraries or
+      script-side `(import (only ...))` for finer control.
+
+  ## Re-use across evaluations
+
+  An `%Environment{}` can be passed to many `Schooner.eval/2,3`
+  calls. The runtime `env`'s globals slot persists across
+  evaluations, so a script's top-level `define`s remain visible to
+  later scripts evaluated against the same environment. This is
+  the embedding-friendly model for things like rule-loading: load
+  rule definitions once, evaluate many trigger scripts that call
+  them.
+
+  Each call to `eval` snapshots and restores the per-process
+  exception / continuation / parameter state, so leftover state
+  from a script that escaped via `raise` does not bleed into the
+  next call.
+  """
+
+  alias Schooner.Env
+  alias Schooner.Expander
+  alias Schooner.Expander.SyntaxEnv
+  alias Schooner.Library
+  alias Schooner.Library.Import, as: LibImport
+
+  @enforce_keys [:env, :syntax_env, :registry]
+  defstruct [:env, :syntax_env, :registry]
+
+  @type t :: %__MODULE__{
+          env: Env.t(),
+          syntax_env: SyntaxEnv.t(),
+          registry: Library.registry()
+        }
+
+  @standard_shortcuts %{
+    base: ["scheme", "base"],
+    cxr: ["scheme", "cxr"],
+    char: ["scheme", "char"],
+    inexact: ["scheme", "inexact"],
+    complex: ["scheme", "complex"],
+    write: ["scheme", "write"],
+    read: ["scheme", "read"],
+    "case-lambda": ["scheme", "case-lambda"],
+    case_lambda: ["scheme", "case-lambda"],
+    lazy: ["scheme", "lazy"]
+  }
+
+  @doc """
+  Build a new `%Environment{}`.
+
+  ## Options
+
+    * `:standard_libraries` — controls which shipped libraries
+      enter the registry. One of:
+        * `:default` (default) — every shipped library.
+        * `:none` — empty registry.
+        * a list of canonical names (e.g.
+          `[["scheme", "base"], ["scheme", "char"]]`) or atom
+          shortcuts (`:base`, `:char`, `:inexact`, `:complex`,
+          `:cxr`, `:write`, `:read`, `:lazy`, `:case_lambda` /
+          `:"case-lambda"`).
+
+    * `:libraries` — list of `Schooner.Library.t/0` (typically
+      built via `Schooner.Host.library/1`). Named libraries join
+      the registry; anonymous libraries (`name: []`) have their
+      bindings applied directly to the runtime env.
+
+    * `:pre_imports` — list of canonical library names to
+      auto-import at construction time. Each name must resolve
+      against the assembled registry (standard + named host
+      libraries) — a missing name raises
+      `Schooner.Library.NotFoundError`.
+
+  Returns the constructed `%Environment{}`. Raises `ArgumentError`
+  for malformed option values.
+  """
+  @spec new(keyword()) :: t()
+  def new(opts \\ []) when is_list(opts) do
+    standard = Keyword.get(opts, :standard_libraries, :default)
+    libraries = Keyword.get(opts, :libraries, [])
+    pre_imports = Keyword.get(opts, :pre_imports, [])
+
+    standard_registry = standard_registry!(standard)
+    {named_libs, anonymous_libs} = split_libraries!(libraries)
+
+    registry = Enum.reduce(named_libs, standard_registry, &Library.register(&2, &1))
+
+    env = Env.new()
+    syntax_env = Expander.bootstrap_env()
+
+    {env, syntax_env} = apply_anonymous!(anonymous_libs, env, syntax_env)
+    {env, syntax_env} = apply_pre_imports!(pre_imports, registry, env, syntax_env)
+
+    %__MODULE__{env: env, syntax_env: syntax_env, registry: registry}
+  end
+
+  defp standard_registry!(:default), do: Library.standard()
+  defp standard_registry!(:none), do: %{}
+
+  defp standard_registry!(names) when is_list(names) do
+    full = Library.standard()
+
+    Enum.reduce(names, %{}, fn name, acc ->
+      canonical = canonical_standard_name!(name)
+
+      case Map.fetch(full, canonical) do
+        {:ok, lib} ->
+          Map.put(acc, canonical, lib)
+
+        :error ->
+          raise ArgumentError,
+                ":standard_libraries names a library that is not shipped: " <>
+                  Library.render_name(canonical)
+      end
+    end)
+  end
+
+  defp standard_registry!(other) do
+    raise ArgumentError,
+          ":standard_libraries must be :default, :none, or a list, got #{inspect(other)}"
+  end
+
+  defp canonical_standard_name!(name) when is_atom(name) do
+    case Map.fetch(@standard_shortcuts, name) do
+      {:ok, canonical} ->
+        canonical
+
+      :error ->
+        raise ArgumentError,
+              ":standard_libraries shortcut #{inspect(name)} is not recognised"
+    end
+  end
+
+  defp canonical_standard_name!(name) when is_list(name), do: name
+
+  defp canonical_standard_name!(other) do
+    raise ArgumentError,
+          ":standard_libraries entry must be a canonical name list or atom shortcut, " <>
+            "got #{inspect(other)}"
+  end
+
+  defp split_libraries!(libraries) when is_list(libraries) do
+    Enum.reduce(libraries, {[], []}, fn
+      %Library{name: []} = lib, {named, anon} ->
+        {named, [lib | anon]}
+
+      %Library{} = lib, {named, anon} ->
+        {[lib | named], anon}
+
+      bad, _ ->
+        raise ArgumentError, ":libraries entry must be a Schooner.Library, got #{inspect(bad)}"
+    end)
+    |> then(fn {named, anon} -> {Enum.reverse(named), Enum.reverse(anon)} end)
+  end
+
+  defp split_libraries!(other) do
+    raise ArgumentError, ":libraries must be a list, got #{inspect(other)}"
+  end
+
+  defp apply_anonymous!(anonymous_libs, env, syntax_env) do
+    Enum.reduce(anonymous_libs, {env, syntax_env}, fn %Library{exports: exports}, {e, se} ->
+      LibImport.apply_bindings(exports, e, se)
+    end)
+  end
+
+  defp apply_pre_imports!([], _registry, env, syntax_env), do: {env, syntax_env}
+
+  defp apply_pre_imports!(pre_imports, registry, env, syntax_env) when is_list(pre_imports) do
+    bindings =
+      Enum.reduce(pre_imports, %{}, fn name, acc ->
+        canonical = canonical_pre_import_name!(name)
+        lib = Library.fetch!(registry, canonical)
+        Map.merge(acc, lib.exports)
+      end)
+
+    LibImport.apply_bindings(bindings, env, syntax_env)
+  end
+
+  defp apply_pre_imports!(other, _registry, _env, _syntax_env) do
+    raise ArgumentError, ":pre_imports must be a list, got #{inspect(other)}"
+  end
+
+  defp canonical_pre_import_name!(name) when is_list(name), do: name
+
+  defp canonical_pre_import_name!(other) do
+    raise ArgumentError,
+          ":pre_imports entry must be a canonical name list (e.g. " <>
+            ~s|["myapp", "log"]| <> "), got #{inspect(other)}"
+  end
+end

--- a/test/conformance/chibi_r7rs_test.exs
+++ b/test/conformance/chibi_r7rs_test.exs
@@ -47,7 +47,7 @@ defmodule Schooner.Conformance.ChibiR7rsTest do
 
     test "Chibi r7rs subset — #{section_name}" do
       source = unquote(@harness_source) <> "\n" <> File.read!(unquote(path))
-      Schooner.run(source)
+      Schooner.run!(source)
     end
   end
 end

--- a/test/conformance/r7rs_section_4_3_macros_test.exs
+++ b/test/conformance/r7rs_section_4_3_macros_test.exs
@@ -21,7 +21,7 @@ defmodule Schooner.Conformance.R7rsSection43MacrosTest do
   alias Schooner.Eval.Error
   alias Schooner.Value
 
-  defp run(source), do: Schooner.run(source)
+  defp run(source), do: Schooner.run!(source)
 
   # ---------------------------------------------------------------------------
   # §4.3.1 — Binding constructs for syntactic keywords

--- a/test/conformance/r7rs_section_4_test.exs
+++ b/test/conformance/r7rs_section_4_test.exs
@@ -19,7 +19,7 @@ defmodule Schooner.Conformance.R7rsSection4Test do
 
   alias Schooner.Value
 
-  defp run(source), do: Schooner.run(source)
+  defp run(source), do: Schooner.run!(source)
 
   # --- §4.1.2 — Literal expressions -----------------------------------------
 

--- a/test/conformance/r7rs_section_5_3_definitions_test.exs
+++ b/test/conformance/r7rs_section_5_3_definitions_test.exs
@@ -12,7 +12,7 @@ defmodule Schooner.Conformance.R7rsSection53DefinitionsTest do
 
   alias Schooner.Value
 
-  defp run(source), do: Schooner.run(source)
+  defp run(source), do: Schooner.run!(source)
 
   describe "§5.3.2 define-values" do
     # Spec example:

--- a/test/conformance/r7rs_section_5_4_records_test.exs
+++ b/test/conformance/r7rs_section_5_4_records_test.exs
@@ -15,7 +15,7 @@ defmodule Schooner.Conformance.R7rsSection54RecordsTest do
 
   alias Schooner.Value
 
-  defp run(source), do: Schooner.run(source)
+  defp run(source), do: Schooner.run!(source)
 
   describe "§5.4 the canonical kons example" do
     # Spec example:

--- a/test/conformance/r7rs_section_6_10_continuations_test.exs
+++ b/test/conformance/r7rs_section_6_10_continuations_test.exs
@@ -35,7 +35,7 @@ defmodule Schooner.Conformance.R7rsSection610ContinuationsTest do
   @recorder_key {__MODULE__, :record}
   @imports "(import (scheme base) (scheme cxr) (scheme char))\n"
 
-  defp run(source), do: Schooner.eval(@imports <> source, recording_env())
+  defp run(source), do: Schooner.eval!(@imports <> source, recording_env())
 
   defp recording_env do
     Process.delete(@recorder_key)

--- a/test/conformance/r7rs_section_6_11_exceptions_test.exs
+++ b/test/conformance/r7rs_section_6_11_exceptions_test.exs
@@ -24,7 +24,7 @@ defmodule Schooner.Conformance.R7rsSection611ExceptionsTest do
 
   alias Schooner.Value
 
-  defp run(source), do: Schooner.run(source)
+  defp run(source), do: Schooner.run!(source)
 
   # ---------------------------------------------------------------------------
   # §6.11 with-exception-handler

--- a/test/schooner/environment_test.exs
+++ b/test/schooner/environment_test.exs
@@ -1,0 +1,200 @@
+defmodule Schooner.EnvironmentTest do
+  use ExUnit.Case, async: true
+
+  alias Schooner.Environment
+  alias Schooner.Eval.Error, as: EvalError
+  alias Schooner.Host
+  alias Schooner.Library
+  alias Schooner.Library.NotFoundError
+
+  describe "new/1 — defaults" do
+    test "no opts gives the default standard registry, no host libs, no pre-imports" do
+      env = Environment.new()
+      assert %Environment{} = env
+      assert env.registry == Library.standard()
+    end
+
+    test "scripts evaluated against the default env still need imports for the strict surface" do
+      env = Environment.new()
+
+      assert_raise EvalError, fn -> Schooner.eval!("(+ 1 2)", env) end
+      assert Schooner.eval!("(import (scheme base)) (+ 1 2)", env) == 3
+    end
+  end
+
+  describe "new/1 — :standard_libraries" do
+    test ":none gives an empty registry — no library is importable" do
+      env = Environment.new(standard_libraries: :none)
+      assert env.registry == %{}
+
+      assert_raise NotFoundError, fn ->
+        Schooner.eval!("(import (scheme base)) 1", env)
+      end
+    end
+
+    test "atom shortcuts include exactly the named standard libraries" do
+      env = Environment.new(standard_libraries: [:base, :char])
+      assert Map.has_key?(env.registry, ["scheme", "base"])
+      assert Map.has_key?(env.registry, ["scheme", "char"])
+      refute Map.has_key?(env.registry, ["scheme", "inexact"])
+    end
+
+    test "canonical-name lists are accepted alongside atom shortcuts" do
+      env = Environment.new(standard_libraries: [["scheme", "base"]])
+      assert Map.has_key?(env.registry, ["scheme", "base"])
+      assert map_size(env.registry) == 1
+    end
+
+    test "case_lambda and :case-lambda atom shortcuts both resolve" do
+      env_underscored = Environment.new(standard_libraries: [:case_lambda])
+      env_dashed = Environment.new(standard_libraries: [:"case-lambda"])
+
+      assert Map.has_key?(env_underscored.registry, ["scheme", "case-lambda"])
+      assert Map.has_key?(env_dashed.registry, ["scheme", "case-lambda"])
+    end
+
+    test "unknown atom shortcut raises ArgumentError" do
+      assert_raise ArgumentError, ~r/shortcut :unknown is not recognised/, fn ->
+        Environment.new(standard_libraries: [:unknown])
+      end
+    end
+
+    test "non-shipped canonical name raises ArgumentError" do
+      assert_raise ArgumentError, ~r/not shipped/, fn ->
+        Environment.new(standard_libraries: [["scheme", "file"]])
+      end
+    end
+
+    test "non-list non-:default non-:none value raises ArgumentError" do
+      assert_raise ArgumentError, ~r/:standard_libraries must be/, fn ->
+        Environment.new(standard_libraries: :everything)
+      end
+    end
+  end
+
+  describe "new/1 — host libraries (named)" do
+    test "named host libraries register and the script can import them" do
+      lib =
+        Host.library(
+          name: ["myapp", "log"],
+          primitives: [
+            {"info", 1, fn [_msg] -> :unspecified end}
+          ]
+        )
+
+      env = Environment.new(libraries: [lib])
+      assert Map.has_key?(env.registry, ["myapp", "log"])
+      assert Schooner.eval!(~s|(import (myapp log)) (info "hi")|, env) == :unspecified
+    end
+
+    test "named host libraries do not enter scope without (import ...)" do
+      lib =
+        Host.library(
+          name: ["myapp", "log"],
+          primitives: [{"info", 1, fn [_msg] -> :unspecified end}]
+        )
+
+      env = Environment.new(libraries: [lib])
+
+      assert_raise EvalError, fn ->
+        Schooner.eval!(~s|(info "hi")|, env)
+      end
+    end
+  end
+
+  describe "new/1 — host libraries (anonymous)" do
+    test "anonymous library bindings are auto-applied without an import" do
+      lib =
+        Host.library(primitives: [{"now-ms", 0, fn [] -> 12_345 end}])
+
+      env = Environment.new(libraries: [lib])
+      refute Map.has_key?(env.registry, [])
+      assert Schooner.eval!("(now-ms)", env) == 12_345
+    end
+
+    test "anonymous + named libraries can coexist" do
+      anon =
+        Host.library(primitives: [{"now-ms", 0, fn [] -> 0 end}])
+
+      named =
+        Host.library(
+          name: ["myapp", "log"],
+          primitives: [{"info", 1, fn [_] -> :unspecified end}]
+        )
+
+      env = Environment.new(libraries: [anon, named])
+
+      assert Schooner.eval!(
+               "(import (myapp log)) (info (now-ms))",
+               env
+             ) == :unspecified
+    end
+
+    test "multiple anonymous libraries compose; later wins on collision" do
+      first = Host.library(primitives: [{"f", 0, fn [] -> 1 end}])
+      second = Host.library(primitives: [{"f", 0, fn [] -> 2 end}])
+
+      env = Environment.new(libraries: [first, second])
+      assert Schooner.eval!("(f)", env) == 2
+    end
+  end
+
+  describe "new/1 — :pre_imports" do
+    test "pre-imports a named library so the script does not need to" do
+      lib =
+        Host.library(
+          name: ["myapp", "util"],
+          primitives: [{"identity", 1, fn [v] -> v end}]
+        )
+
+      env =
+        Environment.new(
+          libraries: [lib],
+          pre_imports: [["myapp", "util"]]
+        )
+
+      # No (import (myapp util)) in the source.
+      assert Schooner.eval!("(identity 42)", env) == 42
+    end
+
+    test "raises if a pre-import refers to a missing library" do
+      assert_raise NotFoundError, fn ->
+        Environment.new(pre_imports: [["myapp", "missing"]])
+      end
+    end
+
+    test "non-list pre_imports raises ArgumentError" do
+      assert_raise ArgumentError, ~r/:pre_imports must be a list/, fn ->
+        Environment.new(pre_imports: :all)
+      end
+    end
+
+    test "non-canonical pre_imports entry raises ArgumentError" do
+      assert_raise ArgumentError, ~r/canonical name list/, fn ->
+        Environment.new(pre_imports: [:base])
+      end
+    end
+  end
+
+  describe "new/1 — :libraries validation" do
+    test "non-list raises" do
+      assert_raise ArgumentError, ~r/:libraries must be a list/, fn ->
+        Environment.new(libraries: %{})
+      end
+    end
+
+    test "non-Library entry raises" do
+      assert_raise ArgumentError, ~r/must be a Schooner.Library/, fn ->
+        Environment.new(libraries: [:not_a_lib])
+      end
+    end
+  end
+
+  describe "re-use across evaluations" do
+    test "top-level defines persist across eval! calls" do
+      env = Environment.new()
+      Schooner.eval!("(import (scheme base)) (define x 100)", env)
+      assert Schooner.eval!("(import (scheme base)) (* x 2)", env) == 200
+    end
+  end
+end

--- a/test/schooner/eval_derived_test.exs
+++ b/test/schooner/eval_derived_test.exs
@@ -10,7 +10,7 @@ defmodule Schooner.EvalDerivedTest do
   alias Schooner.Eval.Error
   alias Schooner.Value
 
-  defp run(source), do: Schooner.run(source)
+  defp run(source), do: Schooner.run!(source)
 
   describe "and / or" do
     test "(and) returns #t and (or) returns #f" do

--- a/test/schooner/eval_internal_defines_test.exs
+++ b/test/schooner/eval_internal_defines_test.exs
@@ -13,7 +13,7 @@ defmodule Schooner.EvalInternalDefinesTest do
   alias Schooner.Eval.Error
   alias Schooner.Value
 
-  defp run(source), do: Schooner.run(source)
+  defp run(source), do: Schooner.run!(source)
 
   defp assert_no_slot_leak(fun) do
     before = count_rec_slots()
@@ -256,19 +256,19 @@ defmodule Schooner.EvalInternalDefinesTest do
   describe "rec-frame slot lifecycle" do
     test "letrec* releases its process-dictionary slot when the body returns" do
       assert_no_slot_leak(fn ->
-        assert Schooner.run("(letrec* ((x 1) (y 2)) (+ x y))") == 3
+        assert Schooner.run!("(letrec* ((x 1) (y 2)) (+ x y))") == 3
       end)
     end
 
     test "letrec* releases its slot even when the body raises" do
       assert_no_slot_leak(fn ->
-        assert_raise Error, fn -> Schooner.run("(letrec* ((x 1)) (undefined-name))") end
+        assert_raise Error, fn -> Schooner.run!("(letrec* ((x 1)) (undefined-name))") end
       end)
     end
 
     test "named let releases its slot when the body returns" do
       assert_no_slot_leak(fn ->
-        assert Schooner.run("""
+        assert Schooner.run!("""
                (let loop ((n 5) (acc 1))
                  (if (= n 0) acc (loop (- n 1) (* acc n))))
                """) == 120
@@ -278,7 +278,7 @@ defmodule Schooner.EvalInternalDefinesTest do
     test "many sequential letrec*s do not leak slots" do
       assert_no_slot_leak(fn ->
         for _ <- 1..50 do
-          Schooner.run("(letrec* ((x 1) (y 2)) (+ x y))")
+          Schooner.run!("(letrec* ((x 1) (y 2)) (+ x y))")
         end
       end)
     end
@@ -302,7 +302,7 @@ defmodule Schooner.EvalInternalDefinesTest do
        100000)
       """
 
-      assert Schooner.eval(source, env) == Value.bool(true)
+      assert Schooner.eval!(source, env) == Value.bool(true)
       {:total_heap_size, heap} = Process.info(self(), :total_heap_size)
       assert heap < 5_000_000
     end
@@ -329,7 +329,7 @@ defmodule Schooner.EvalInternalDefinesTest do
       (loop 100000)
       """
 
-      assert Schooner.eval(source, env) == Value.symbol("done")
+      assert Schooner.eval!(source, env) == Value.symbol("done")
       {:stack_size, stack} = Process.info(self(), :stack_size)
       # 100k frames stacked unoptimised would push tens of thousands of
       # words; a healthy TCO leaves stack_size in low triple digits.
@@ -356,7 +356,7 @@ defmodule Schooner.EvalInternalDefinesTest do
     test "closure escape leaves exactly one rec slot per escaping letrec" do
       before = count_rec_slots()
 
-      Schooner.run("""
+      Schooner.run!("""
       (define escaped
         (letrec ((helper (lambda () 42))
                  (caller (lambda () (helper))))
@@ -371,7 +371,7 @@ defmodule Schooner.EvalInternalDefinesTest do
       before = count_rec_slots()
 
       for _ <- 1..50 do
-        Schooner.run("(letrec ((x 1)) x)")
+        Schooner.run!("(letrec ((x 1)) x)")
       end
 
       assert count_rec_slots() == before, "non-escaping letrecs should not leak"
@@ -379,7 +379,7 @@ defmodule Schooner.EvalInternalDefinesTest do
       base = count_rec_slots()
 
       for _ <- 1..50 do
-        Schooner.run("(letrec ((f (lambda () 1))) f)")
+        Schooner.run!("(letrec ((f (lambda () 1))) f)")
       end
 
       assert count_rec_slots() == base + 50, "each escaping letrec leaves one slot"

--- a/test/schooner/eval_tagged_test.exs
+++ b/test/schooner/eval_tagged_test.exs
@@ -1,0 +1,74 @@
+defmodule Schooner.EvalTaggedTest do
+  use ExUnit.Case, async: true
+
+  alias Schooner.Env
+  alias Schooner.Environment
+  alias Schooner.Error, as: SchemeError
+  alias Schooner.Eval.Error, as: EvalError
+  alias Schooner.Library.NotFoundError
+  alias Schooner.Reader.Error, as: ReaderError
+
+  describe "run/1 tagged-tuple wrapper" do
+    test "returns {:ok, value} on success" do
+      assert Schooner.run("(+ 1 2)") == {:ok, 3}
+    end
+
+    test "returns {:error, _} when the script errors at runtime" do
+      assert {:error, %EvalError{}} =
+               Schooner.run("(import (only (scheme base) +)) (sin 0)")
+    end
+
+    test "returns {:error, _} for a script that raises (uncaught Scheme error)" do
+      assert {:error, %SchemeError{}} =
+               Schooner.run("(raise \"oops\")")
+    end
+
+    test "returns {:error, _} on a parse-level failure" do
+      assert {:error, %ReaderError{}} = Schooner.run("(")
+    end
+  end
+
+  describe "eval/2 tagged-tuple wrapper" do
+    test "with an Env returns {:ok, value}" do
+      assert Schooner.eval("(import (scheme base)) (+ 1 2)", Env.new()) ==
+               {:ok, 3}
+    end
+
+    test "with an Environment returns {:ok, value}" do
+      env = Environment.new()
+      assert Schooner.eval("(import (scheme base)) (+ 1 2)", env) == {:ok, 3}
+    end
+
+    test "returns {:error, _} for an unbound variable on a fresh strict env" do
+      assert {:error, %EvalError{}} = Schooner.eval("(+ 1 2)", Env.new())
+    end
+
+    test "returns {:error, NotFoundError} for an import of a missing library" do
+      assert {:error, %NotFoundError{}} =
+               Schooner.eval("(import (no such lib)) 1", Env.new())
+    end
+  end
+
+  describe "eval/3 tagged-tuple wrapper" do
+    test "with implicit_imports: :all returns {:ok, value}" do
+      assert Schooner.eval("(+ 1 2)", Env.new(), implicit_imports: :all) ==
+               {:ok, 3}
+    end
+
+    test "ArgumentError on a bad option does NOT become {:error, _} — it is an embedder bug" do
+      assert_raise ArgumentError, fn ->
+        Schooner.eval("(+ 1 2)", Env.new(), implicit_imports: :everything)
+      end
+    end
+  end
+
+  describe "bang form raises (preserves prior contract)" do
+    test "run! raises on script-level failure" do
+      assert_raise SchemeError, fn -> Schooner.run!("(raise \"oops\")") end
+    end
+
+    test "eval! raises on script-level failure" do
+      assert_raise EvalError, fn -> Schooner.eval!("(+ 1 2)", Env.new()) end
+    end
+  end
+end

--- a/test/schooner/eval_tco_test.exs
+++ b/test/schooner/eval_tco_test.exs
@@ -24,7 +24,7 @@ defmodule Schooner.EvalTcoTest do
     |> Env.define("sub1", Value.primitive("sub1", 1, fn [n] -> n - 1 end))
   end
 
-  defp run!(source), do: Schooner.eval(source, env_with_int_prims())
+  defp run!(source), do: Schooner.eval!(source, env_with_int_prims())
 
   defp assert_bounded_heap(fun) do
     fun.()
@@ -72,7 +72,7 @@ defmodule Schooner.EvalTcoTest do
     """
 
     assert_bounded_heap(fn ->
-      assert Schooner.eval(source, env) == Value.symbol("done")
+      assert Schooner.eval!(source, env) == Value.symbol("done")
     end)
   end
 

--- a/test/schooner/eval_test.exs
+++ b/test/schooner/eval_test.exs
@@ -8,7 +8,7 @@ defmodule Schooner.EvalTest do
   alias Schooner.Library.Import, as: LibImport
   alias Schooner.Value
 
-  defp run(source), do: Schooner.run(source)
+  defp run(source), do: Schooner.run!(source)
 
   # Build an env populated with every variable export from
   # `(scheme base)`. Used by tests that synthesise malformed AST
@@ -158,13 +158,13 @@ defmodule Schooner.EvalTest do
   describe "define" do
     test "simple define returns :unspecified and binds globally" do
       env = Env.new()
-      assert Schooner.eval("(define x 7)", env) == :unspecified
+      assert Schooner.eval!("(define x 7)", env) == :unspecified
       assert Env.lookup(env, "x") == {:ok, 7}
     end
 
     test "function-form define binds a named closure" do
       env = Env.new()
-      Schooner.eval("(define (f x) x)", env)
+      Schooner.eval!("(define (f x) x)", env)
       assert {:ok, {:closure, {:fixed, 1, ["x"]}, _, _, "f"}} = Env.lookup(env, "f")
     end
 
@@ -215,7 +215,7 @@ defmodule Schooner.EvalTest do
   describe "application" do
     test "primitive procedure" do
       env = Env.new() |> Env.define("inc", primitive_inc())
-      assert Schooner.eval("(inc 41)", env) == 42
+      assert Schooner.eval!("(inc 41)", env) == 42
     end
 
     test "calling a non-procedure raises" do
@@ -225,7 +225,7 @@ defmodule Schooner.EvalTest do
 
     test "primitive arity mismatch raises" do
       env = Env.new() |> Env.define("inc", primitive_inc())
-      e = assert_raise Error, fn -> Schooner.eval("(inc 1 2)", env) end
+      e = assert_raise Error, fn -> Schooner.eval!("(inc 1 2)", env) end
       assert match?({:arity_mismatch, "inc", {:exact, 1}, 2}, e.reason)
     end
 
@@ -304,7 +304,7 @@ defmodule Schooner.EvalTest do
       )
       |> Env.define("sub1", Value.primitive("sub1", 1, fn [n] -> n - 1 end))
 
-    Schooner.eval(source, env)
+    Schooner.eval!(source, env)
   end
 
   describe "primitive arity_mismatch surfaces on under-supply to {:at_least, n}" do
@@ -344,7 +344,7 @@ defmodule Schooner.EvalTest do
     # `(scheme base)` primitive without an explicit `(import ...)`.
     defp run_with_foreign(source, term) do
       env = base_env() |> Env.define("host", Value.foreign(term))
-      Schooner.eval(source, env)
+      Schooner.eval!(source, env)
     end
 
     test "self-evaluates: a bare reference returns the foreign unchanged" do

--- a/test/schooner/expander/record_test.exs
+++ b/test/schooner/expander/record_test.exs
@@ -12,7 +12,7 @@ defmodule Schooner.Expander.RecordTest do
   alias Schooner.Primitive.Error, as: PError
   alias Schooner.Value
 
-  defp run(source), do: Schooner.run(source)
+  defp run(source), do: Schooner.run!(source)
 
   describe "constructor / predicate / accessors" do
     test "the constructor returns a record; the predicate is #t for own type and #f otherwise" do
@@ -151,7 +151,7 @@ defmodule Schooner.Expander.RecordTest do
       env = Env.new()
 
       _ =
-        Schooner.eval(
+        Schooner.eval!(
           """
           (import (scheme base))
           (define-record-type pt (mk-pt x y) pt? (x pt-x) (y pt-y))
@@ -160,7 +160,7 @@ defmodule Schooner.Expander.RecordTest do
           env
         )
 
-      record = Schooner.eval("p", env)
+      record = Schooner.eval!("p", env)
       assert is_tuple(record) and elem(record, 0) == :record
       assert Value.write(record) == "#<record pt>"
     end

--- a/test/schooner/expander_test.exs
+++ b/test/schooner/expander_test.exs
@@ -8,7 +8,7 @@ defmodule Schooner.ExpanderTest do
   alias Schooner.Eval.Error
   alias Schooner.Value
 
-  defp run(source), do: Schooner.run(source)
+  defp run(source), do: Schooner.run!(source)
 
   describe "define-syntax" do
     test "user-defined macro expands at top level" do

--- a/test/schooner/import_only_path_test.exs
+++ b/test/schooner/import_only_path_test.exs
@@ -6,31 +6,31 @@ defmodule Schooner.ImportOnlyPathTest do
 
   describe "Schooner.run/1 implicit imports" do
     test "auto-imports standard libraries when none are explicit" do
-      assert Schooner.run("(+ 1 2)") == 3
-      assert Schooner.run("(sin 0)") == 0.0
-      assert Schooner.run("(car '(1 2 3))") == 1
+      assert Schooner.run!("(+ 1 2)") == 3
+      assert Schooner.run!("(sin 0)") == 0.0
+      assert Schooner.run!("(car '(1 2 3))") == 1
     end
 
     test "skips the implicit import when the script declares its own" do
       # An explicit import of (only (scheme base) +) means the script
       # opted in to a tighter surface. Without the implicit injection,
       # `sin` should be unbound.
-      assert Schooner.run("(import (only (scheme base) +)) (+ 1 2)") == 3
+      assert Schooner.run!("(import (only (scheme base) +)) (+ 1 2)") == 3
 
       assert_raise EvalError, fn ->
-        Schooner.run("(import (only (scheme base) +)) (sin 0)")
+        Schooner.run!("(import (only (scheme base) +)) (sin 0)")
       end
     end
   end
 
   describe "Schooner.eval/2 strict path" do
     test "bindings come exclusively from imports + the supplied env" do
-      assert Schooner.eval("(import (scheme base)) (+ 1 2)", Env.new()) == 3
+      assert Schooner.eval!("(import (scheme base)) (+ 1 2)", Env.new()) == 3
     end
 
     test "without an import, even '+' is unbound on a fresh env" do
       assert_raise EvalError, fn ->
-        Schooner.eval("(+ 1 2)", Env.new())
+        Schooner.eval!("(+ 1 2)", Env.new())
       end
     end
 
@@ -44,28 +44,28 @@ defmodule Schooner.ImportOnlyPathTest do
       # the literal symbol regardless of imports.
       for binding <- ~w(+ - * / car cdr cons list display) do
         assert_raise EvalError, fn ->
-          Schooner.eval("(#{binding})", Env.new())
+          Schooner.eval!("(#{binding})", Env.new())
         end
       end
     end
 
     test "explicit (only (scheme base) car) hides '+' from the script" do
-      assert Schooner.eval(
+      assert Schooner.eval!(
                "(import (only (scheme base) car)) (car '(1 2 3))",
                Env.new()
              ) == 1
 
       assert_raise EvalError, fn ->
-        Schooner.eval("(import (only (scheme base) car)) (+ 1 2)", Env.new())
+        Schooner.eval!("(import (only (scheme base) car)) (+ 1 2)", Env.new())
       end
     end
 
     test "(scheme inexact) needs to be imported to use sin" do
       assert_raise EvalError, fn ->
-        Schooner.eval("(import (scheme base)) (sin 0)", Env.new())
+        Schooner.eval!("(import (scheme base)) (sin 0)", Env.new())
       end
 
-      assert Schooner.eval(
+      assert Schooner.eval!(
                "(import (scheme base) (scheme inexact)) (sin 0)",
                Env.new()
              ) == 0.0
@@ -75,32 +75,32 @@ defmodule Schooner.ImportOnlyPathTest do
   describe "Schooner.eval/3 :implicit_imports option" do
     test ":implicit_imports defaults to :none" do
       assert_raise EvalError, fn ->
-        Schooner.eval("(+ 1 2)", Env.new(), [])
+        Schooner.eval!("(+ 1 2)", Env.new(), [])
       end
     end
 
     test ":implicit_imports: :none matches the eval/2 strict default" do
       assert_raise EvalError, fn ->
-        Schooner.eval("(+ 1 2)", Env.new(), implicit_imports: :none)
+        Schooner.eval!("(+ 1 2)", Env.new(), implicit_imports: :none)
       end
     end
 
     test ":implicit_imports: :all auto-imports the standard libraries" do
-      assert Schooner.eval("(+ 1 2)", Env.new(), implicit_imports: :all) == 3
-      assert Schooner.eval("(sin 0)", Env.new(), implicit_imports: :all) == 0.0
+      assert Schooner.eval!("(+ 1 2)", Env.new(), implicit_imports: :all) == 3
+      assert Schooner.eval!("(sin 0)", Env.new(), implicit_imports: :all) == 0.0
     end
 
     test ":implicit_imports: :all is suppressed by an explicit import" do
       # Same opt-in semantics run/1 has: a single explicit import
       # disables the injection.
-      assert Schooner.eval(
+      assert Schooner.eval!(
                "(import (only (scheme base) +)) (+ 1 2)",
                Env.new(),
                implicit_imports: :all
              ) == 3
 
       assert_raise EvalError, fn ->
-        Schooner.eval(
+        Schooner.eval!(
           "(import (only (scheme base) +)) (sin 0)",
           Env.new(),
           implicit_imports: :all
@@ -110,14 +110,14 @@ defmodule Schooner.ImportOnlyPathTest do
 
     test "run/1 is equivalent to eval/3 with implicit_imports: :all on a fresh env" do
       for source <- ["(+ 1 2)", "(sin 0)", "(import (only (scheme base) +)) (+ 1 2)"] do
-        assert Schooner.run(source) ==
-                 Schooner.eval(source, Env.new(), implicit_imports: :all)
+        assert Schooner.run!(source) ==
+                 Schooner.eval!(source, Env.new(), implicit_imports: :all)
       end
     end
 
     test "an unknown :implicit_imports value raises ArgumentError" do
       assert_raise ArgumentError, ~r/:implicit_imports/, fn ->
-        Schooner.eval("(+ 1 2)", Env.new(), implicit_imports: :everything)
+        Schooner.eval!("(+ 1 2)", Env.new(), implicit_imports: :everything)
       end
     end
   end

--- a/test/schooner/library/import_test.exs
+++ b/test/schooner/library/import_test.exs
@@ -145,27 +145,27 @@ defmodule Schooner.Library.ImportTest do
 
   describe "Schooner.eval/2 with imports" do
     test "(import (scheme base)) does not error on a regular program" do
-      assert Schooner.run("(import (scheme base)) (+ 1 2)") == 3
+      assert Schooner.run!("(import (scheme base)) (+ 1 2)") == 3
     end
 
     test "macros remain available after an import (additive on top of bootstrap)" do
       # cond comes from base.scm via the bootstrap env. Adding an import
       # of (scheme base) is additive in 13.4 — the macro stays
       # resolvable. (13.6 will tighten this to "import-or-nothing".)
-      assert Schooner.run("(import (scheme base)) (cond (#t 'yes))") ==
+      assert Schooner.run!("(import (scheme base)) (cond (#t 'yes))") ==
                Schooner.Value.symbol("yes")
     end
 
     test "renamed import binds the new name" do
       result =
-        Schooner.run("(import (rename (only (scheme base) car) (car head))) (head '(1 2 3))")
+        Schooner.run!("(import (rename (only (scheme base) car) (car head))) (head '(1 2 3))")
 
       assert result == 1
     end
 
     test "missing library raises NotFoundError" do
       assert_raise NotFoundError, fn ->
-        Schooner.run("(import (scheme nope)) 1")
+        Schooner.run!("(import (scheme nope)) 1")
       end
     end
   end

--- a/test/schooner/primitives/base_numeric_extra_test.exs
+++ b/test/schooner/primitives/base_numeric_extra_test.exs
@@ -4,7 +4,7 @@ defmodule Schooner.Primitives.BaseNumericExtraTest do
   alias Schooner.Primitive.Error, as: PError
   alias Schooner.Value
 
-  defp run(source), do: Schooner.run(source)
+  defp run(source), do: Schooner.run!(source)
 
   # ---------------------------------------------------------------------------
   # Issue #86 — floor / ceiling / truncate / round

--- a/test/schooner/primitives/base_pairs_property_test.exs
+++ b/test/schooner/primitives/base_pairs_property_test.exs
@@ -15,7 +15,7 @@ defmodule Schooner.Primitives.BasePairsPropertyTest do
     check all(xs <- small_int_list()) do
       src = render_int_list(xs)
 
-      assert Schooner.run("(list->vector (vector->list (list->vector #{src})))") ==
+      assert Schooner.run!("(list->vector (vector->list (list->vector #{src})))") ==
                Value.vector(xs)
     end
   end
@@ -23,7 +23,7 @@ defmodule Schooner.Primitives.BasePairsPropertyTest do
   property "vector->list ∘ list->vector ≡ identity (on lists)" do
     check all(xs <- small_int_list()) do
       src = render_int_list(xs)
-      assert Schooner.run("(vector->list (list->vector #{src}))") == Value.list(xs)
+      assert Schooner.run!("(vector->list (list->vector #{src}))") == Value.list(xs)
     end
   end
 
@@ -31,7 +31,7 @@ defmodule Schooner.Primitives.BasePairsPropertyTest do
     check all(s <- ascii_string()) do
       lit = "\"" <> s <> "\""
 
-      assert Schooner.run("(list->string (string->list #{lit}))") ==
+      assert Schooner.run!("(list->string (string->list #{lit}))") ==
                Value.string(s)
     end
   end
@@ -39,7 +39,7 @@ defmodule Schooner.Primitives.BasePairsPropertyTest do
   property "(length (reverse xs)) == (length xs)" do
     check all(xs <- small_int_list()) do
       src = render_int_list(xs)
-      assert Schooner.run("(length (reverse #{src}))") === length(xs)
+      assert Schooner.run!("(length (reverse #{src}))") === length(xs)
     end
   end
 
@@ -47,7 +47,7 @@ defmodule Schooner.Primitives.BasePairsPropertyTest do
     check all(xs <- small_int_list()) do
       src = render_int_list(xs)
 
-      assert Schooner.run("(length (map (lambda (x) (* x x)) #{src}))") ===
+      assert Schooner.run!("(length (map (lambda (x) (* x x)) #{src}))") ===
                length(xs)
     end
   end
@@ -55,7 +55,7 @@ defmodule Schooner.Primitives.BasePairsPropertyTest do
   property "reverse is its own inverse" do
     check all(xs <- small_int_list()) do
       src = render_int_list(xs)
-      assert Schooner.run("(reverse (reverse #{src}))") == Value.list(xs)
+      assert Schooner.run!("(reverse (reverse #{src}))") == Value.list(xs)
     end
   end
 end

--- a/test/schooner/primitives/base_pairs_test.exs
+++ b/test/schooner/primitives/base_pairs_test.exs
@@ -4,7 +4,7 @@ defmodule Schooner.Primitives.BasePairsTest do
   alias Schooner.Primitive.Error, as: PError
   alias Schooner.Value
 
-  defp run(source), do: Schooner.run(source)
+  defp run(source), do: Schooner.run!(source)
 
   describe "cons / car / cdr" do
     test "cons builds a pair, car/cdr destructure it" do

--- a/test/schooner/primitives/base_property_test.exs
+++ b/test/schooner/primitives/base_property_test.exs
@@ -2,7 +2,7 @@ defmodule Schooner.Primitives.BasePropertyTest do
   use ExUnit.Case, async: true
   use ExUnitProperties
 
-  defp run(source), do: Schooner.run(source)
+  defp run(source), do: Schooner.run!(source)
 
   defp small_int, do: integer(-100..100)
 

--- a/test/schooner/primitives/base_rationals_test.exs
+++ b/test/schooner/primitives/base_rationals_test.exs
@@ -4,7 +4,7 @@ defmodule Schooner.Primitives.BaseRationalsTest do
   alias Schooner.Primitive.Error, as: PError
   alias Schooner.Value
 
-  defp run(source), do: Schooner.run(source)
+  defp run(source), do: Schooner.run!(source)
 
   # ---------------------------------------------------------------------------
   # Reader / writer for the n/d external representation

--- a/test/schooner/primitives/base_strings_test.exs
+++ b/test/schooner/primitives/base_strings_test.exs
@@ -4,7 +4,7 @@ defmodule Schooner.Primitives.BaseStringsTest do
   alias Schooner.Primitive.Error, as: PError
   alias Schooner.Value
 
-  defp run(source), do: Schooner.run(source)
+  defp run(source), do: Schooner.run!(source)
 
   describe "string constructors" do
     test "(string ...) builds a string from chars" do

--- a/test/schooner/primitives/base_symbols_test.exs
+++ b/test/schooner/primitives/base_symbols_test.exs
@@ -4,7 +4,7 @@ defmodule Schooner.Primitives.BaseSymbolsTest do
   alias Schooner.Primitive.Error, as: PError
   alias Schooner.Value
 
-  defp run(source), do: Schooner.run(source)
+  defp run(source), do: Schooner.run!(source)
 
   describe "symbol identity" do
     test "two string->symbol calls on the same string are eq?" do

--- a/test/schooner/primitives/base_test.exs
+++ b/test/schooner/primitives/base_test.exs
@@ -5,7 +5,7 @@ defmodule Schooner.Primitives.BaseTest do
   alias Schooner.Primitive.Error, as: PError
   alias Schooner.Value
 
-  defp run(source), do: Schooner.run(source)
+  defp run(source), do: Schooner.run!(source)
 
   # ---------------------------------------------------------------------------
   # Arithmetic — exactness contamination matrix
@@ -208,7 +208,7 @@ defmodule Schooner.Primitives.BaseTest do
       for {literal, tags} <- @fixture, pred <- @predicates do
         tag = Map.fetch!(@pred_to_tag, pred)
         expected = Value.bool(tag in tags)
-        actual = Schooner.run("(#{pred} #{literal})")
+        actual = Schooner.run!("(#{pred} #{literal})")
 
         assert actual == expected,
                "(#{pred} #{literal}) => #{inspect(actual)} (want #{inspect(expected)})"

--- a/test/schooner/primitives/base_vectors_test.exs
+++ b/test/schooner/primitives/base_vectors_test.exs
@@ -4,7 +4,7 @@ defmodule Schooner.Primitives.BaseVectorsTest do
   alias Schooner.Primitive.Error, as: PError
   alias Schooner.Value
 
-  defp run(source), do: Schooner.run(source)
+  defp run(source), do: Schooner.run!(source)
 
   describe "constructors" do
     test "(vector ...) builds a vector" do

--- a/test/schooner/primitives/case_lambda_test.exs
+++ b/test/schooner/primitives/case_lambda_test.exs
@@ -4,7 +4,7 @@ defmodule Schooner.Primitives.CaseLambdaTest do
   alias Schooner.Env
   alias Schooner.Value
 
-  defp run(source), do: Schooner.run(source)
+  defp run(source), do: Schooner.run!(source)
 
   describe "clause shapes" do
     test "empty fixed-arity formals" do
@@ -143,7 +143,7 @@ defmodule Schooner.Primitives.CaseLambdaTest do
   describe "library surface" do
     test "case-lambda is unavailable in strict eval/2 without the import" do
       assert_raise Schooner.Eval.Error, fn ->
-        Schooner.eval(
+        Schooner.eval!(
           "(define f (case-lambda ((x) x))) (f 1)",
           Env.new()
         )
@@ -157,7 +157,7 @@ defmodule Schooner.Primitives.CaseLambdaTest do
       (list (f 4) (f 4 5))
       """
 
-      assert Schooner.eval(source, Env.new()) == Value.list([12, 9])
+      assert Schooner.eval!(source, Env.new()) == Value.list([12, 9])
     end
   end
 end

--- a/test/schooner/primitives/char_test.exs
+++ b/test/schooner/primitives/char_test.exs
@@ -4,7 +4,7 @@ defmodule Schooner.Primitives.CharTest do
   alias Schooner.Primitive.Error, as: PError
   alias Schooner.Value
 
-  defp run(source), do: Schooner.run(source)
+  defp run(source), do: Schooner.run!(source)
 
   describe "char->integer / integer->char" do
     test "ASCII round-trip" do

--- a/test/schooner/primitives/complex_test.exs
+++ b/test/schooner/primitives/complex_test.exs
@@ -4,7 +4,7 @@ defmodule Schooner.Primitives.ComplexTest do
   alias Schooner.Primitive.Error, as: PError
   alias Schooner.Value
 
-  defp run(source), do: Schooner.run(source)
+  defp run(source), do: Schooner.run!(source)
   defp pi, do: :math.pi()
 
   # ---------------------------------------------------------------------------

--- a/test/schooner/primitives/continuations_test.exs
+++ b/test/schooner/primitives/continuations_test.exs
@@ -20,7 +20,7 @@ defmodule Schooner.Primitives.ContinuationsTest do
   @recorder_key {__MODULE__, :record}
   @imports "(import (scheme base) (scheme cxr) (scheme char))\n"
 
-  defp run(source), do: Schooner.eval(@imports <> source, recording_env())
+  defp run(source), do: Schooner.eval!(@imports <> source, recording_env())
 
   # The standard libraries get pulled in via the `@imports` line that
   # `run/1` prepends to every test source. The env returned here only

--- a/test/schooner/primitives/cxr_test.exs
+++ b/test/schooner/primitives/cxr_test.exs
@@ -5,7 +5,7 @@ defmodule Schooner.Primitives.CxrTest do
   alias Schooner.Primitive.Error, as: PError
   alias Schooner.Value
 
-  defp run(source), do: Schooner.run(source)
+  defp run(source), do: Schooner.run!(source)
 
   describe "depth-2 accessors" do
     test "caar / cadr / cdar / cddr" do

--- a/test/schooner/primitives/exceptions_test.exs
+++ b/test/schooner/primitives/exceptions_test.exs
@@ -3,7 +3,7 @@ defmodule Schooner.Primitives.ExceptionsTest do
 
   alias Schooner.Value
 
-  defp run(source), do: Schooner.run(source)
+  defp run(source), do: Schooner.run!(source)
 
   describe "error object construction" do
     test "(error msg) constructs and raises an error object" do

--- a/test/schooner/primitives/inexact_test.exs
+++ b/test/schooner/primitives/inexact_test.exs
@@ -5,7 +5,7 @@ defmodule Schooner.Primitives.InexactTest do
   alias Schooner.Primitive.Error, as: PError
   alias Schooner.Value
 
-  defp run(source), do: Schooner.run(source)
+  defp run(source), do: Schooner.run!(source)
 
   describe "exp" do
     test "exp 0 = 1.0" do

--- a/test/schooner/primitives/lazy_test.exs
+++ b/test/schooner/primitives/lazy_test.exs
@@ -3,7 +3,7 @@ defmodule Schooner.Primitives.LazyTest do
 
   alias Schooner.Value
 
-  defp run(source), do: Schooner.run(source)
+  defp run(source), do: Schooner.run!(source)
 
   describe "make-promise + force" do
     test "force on an eager make-promise returns the wrapped value" do

--- a/test/schooner/primitives/parameters_test.exs
+++ b/test/schooner/primitives/parameters_test.exs
@@ -3,7 +3,7 @@ defmodule Schooner.Primitives.ParametersTest do
 
   alias Schooner.Value
 
-  defp run(source), do: Schooner.run(source)
+  defp run(source), do: Schooner.run!(source)
 
   describe "make-parameter" do
     test "without converter, initial value is the supplied init" do

--- a/test/schooner/primitives/read_test.exs
+++ b/test/schooner/primitives/read_test.exs
@@ -4,7 +4,7 @@ defmodule Schooner.Primitives.ReadTest do
   alias Schooner.Primitive.Error, as: PError
   alias Schooner.Value
 
-  defp run(source), do: Schooner.run(source)
+  defp run(source), do: Schooner.run!(source)
 
   describe "read" do
     test "reads an integer" do

--- a/test/schooner/primitives/record_test.exs
+++ b/test/schooner/primitives/record_test.exs
@@ -20,7 +20,7 @@ defmodule Schooner.Primitives.RecordTest do
     env
   end
 
-  defp run(source, env), do: Schooner.eval(source, env)
+  defp run(source, env), do: Schooner.eval!(source, env)
 
   test "%record-instance constructs a record value with the given type id and fields" do
     env = env()

--- a/test/schooner/primitives/write_test.exs
+++ b/test/schooner/primitives/write_test.exs
@@ -5,7 +5,7 @@ defmodule Schooner.Primitives.WriteTest do
   alias Schooner.Primitive.Error, as: PError
   alias Schooner.Value
 
-  defp run(source), do: Schooner.run(source)
+  defp run(source), do: Schooner.run!(source)
 
   describe "write" do
     test "renders strings with quotes" do


### PR DESCRIPTION
## Summary

Builds on #94. Two big shifts:

1. **`Schooner.Environment`** — the embedding-friendly bundle of `Env` + `SyntaxEnv` + library registry. Hosts now compose their sandbox via `Schooner.Environment.new/1` and pass the result to `eval`.
2. **Bang/tagged-tuple split** — bare-name `eval/2,3` and `run/1` now return `{:ok, _} | {:error, _}` (Elixir convention). The raising forms are `eval!/2,3` and `run!/1`.

## `Schooner.Environment.new/1`

Options:
- **`:standard_libraries`** — `:default` (all shipped, default), `:none` (empty registry), or a list mixing atom shortcuts (`:base`, `:char`, `:inexact`, …) and canonical names.
- **`:libraries`** — list of host-built `%Library{}`. **Named** libraries (`name: ["myapp", "log"]`) join the registry; the script must `(import (myapp log))` to see them. **Anonymous** libraries (`name: []`) bypass the registry and have their bindings applied directly to the runtime env — sandbox-loosening, but explicitly listed.
- **`:pre_imports`** — canonical names to auto-import at construction time, so the script doesn't have to repeat the import.

The runtime env's globals slot persists across `eval` calls against the same `Environment`, so a host can load rule definitions once and evaluate many trigger scripts that call them. Per-call exception/continuation/parameter state is still snapshot-and-restored, so an escaping `raise` doesn't leak into the next call.

## Bang/tagged-tuple split

| Before | After |
|---|---|
| `Schooner.run/1` (raising) | `Schooner.run!/1` (raising) |
| `Schooner.eval/2,3` (raising) | `Schooner.eval!/2,3` (raising) |
| — | `Schooner.run/1` (`{:ok, _} \| {:error, _}`) |
| — | `Schooner.eval/2,3` (`{:ok, _} \| {:error, _}`) |

The tagged-tuple wrappers catch script-level exceptions only (`Schooner.Error`, `Eval.Error`, `Primitive.Error`, `Library.NotFoundError`, `Lexer.Error`, `Reader.Error`, `Expander.Error`) and surface them as `{:error, exception}`. `ArgumentError` on bad options **propagates** — that's an embedder bug, not a script-level failure.

`eval/2` and `eval!/2` now overload on the second argument: passing a `%Env{}` keeps the existing low-level path; passing an `%Environment{}` runs against the bundled registry + syntax env.

All existing tests were mechanically renamed via `Schooner.run( -> Schooner.run!(` and `Schooner.eval( -> Schooner.eval!(` — they expect bare values, which the bang form returns, so semantics are preserved.

## Sub-phase context

This is **15.3 of 5** in the Phase 15 plan:
- 15.1 — `Schooner.Host` conversion helpers + `TypeError` (#93, merged)
- 15.2 — `Schooner.Host.library/1` builder + anonymous library names (#94, merged)
- 15.3 (this PR) — `%Schooner.Environment{}` + bang/tagged-tuple split
- 15.4 — `Schooner.apply/2,!`, `Schooner.compile/2,!`, `%Schooner.Compiled{}`
- 15.5 — ExDoc dep + four guides

## Test plan

- [x] 21 new tests for `Schooner.Environment` — defaults, `:standard_libraries` selection, named/anonymous host libraries, `:pre_imports`, validation of malformed options, re-use across evaluations
- [x] 12 new tests for the tagged-tuple wrappers — `{:ok, _}` happy path, `{:error, _}` for each script-level exception family, `ArgumentError` propagation, bang-form raises preserved
- [x] All 1410 pre-existing call sites mechanically renamed to bang form; no test logic changes
- [x] `mix precommit` green — 1478 tests, 0 failures, credo --strict clean