### PR TITLE
Phase 15.4: Schooner.apply + compile + %Compiled{}

### DIFF
--- a/lib/schooner.ex
+++ b/lib/schooner.ex
@@ -60,10 +60,12 @@ defmodule Schooner do
   `Schooner.Environment.new/1` and pass it to `eval/2`.
   """
 
+  alias Schooner.Compiled
   alias Schooner.Env
   alias Schooner.Environment
   alias Schooner.Eval
   alias Schooner.Eval.ContinuationState
+  alias Schooner.Eval.Error, as: EvalError
   alias Schooner.Eval.ExceptionState
   alias Schooner.Eval.ParameterState
   alias Schooner.Expander
@@ -222,6 +224,148 @@ defmodule Schooner do
         raise ArgumentError,
               "invalid value for :implicit_imports — expected :none or :all, got: " <>
                 inspect(other)
+    end
+  end
+
+  @doc """
+  Invoke a Scheme procedure value from Elixir. Returns
+  `{:ok, value}` on success, `{:error, exception}` for any
+  script-level failure. Use `apply!/2` for the raising variant.
+
+  `proc` may be any procedure value — a closure (returned by
+  evaluating a `lambda` or a `define` form), a primitive, or a
+  parameter. `args` is a list of `Schooner.Value.t/0` arguments.
+
+  This is the host-side hook for callback patterns: pass a Scheme
+  procedure into a host function, capture it, and invoke it later
+  via `apply/2`.
+  """
+  @spec apply(Value.t(), [Value.t()]) :: {:ok, Value.t()} | {:error, Exception.t()}
+  def apply(proc, args) when is_list(args) do
+    {:ok, apply!(proc, args)}
+  rescue
+    e -> rescue_script_error(e, __STACKTRACE__)
+  end
+
+  @doc """
+  Bang form of `apply/2` — raises on script-level failure. See
+  `apply/2` for arguments.
+  """
+  @spec apply!(Value.t(), [Value.t()]) :: Value.t()
+  def apply!(proc, args) when is_list(args) do
+    if Value.procedure?(proc) do
+      proc |> Eval.apply_proc(args) |> Eval.single_value!()
+    else
+      raise EvalError, reason: {:not_a_procedure, proc}
+    end
+  end
+
+  @doc """
+  Read, expand, and pre-resolve `source` against `env_struct`'s
+  registry. Returns `{:ok, %Schooner.Compiled{}}` on success,
+  `{:error, exception}` on any source-level failure. Use
+  `compile!/1,2` for the raising variant.
+
+  The compiled artifact can be passed to `run_compiled/2`
+  repeatedly against any compatible environment. Macros are
+  expanded at compile time; variable bindings from `(import ...)`
+  declarations are pre-resolved and baked into the artifact.
+
+  When called without an environment, defaults to a fresh
+  `Schooner.Environment.new/0` (every shipped standard library
+  available).
+  """
+  @spec compile(binary(), Environment.t()) ::
+          {:ok, Compiled.t()} | {:error, Exception.t()}
+  def compile(source, %Environment{} = env_struct) when is_binary(source) do
+    {:ok, compile!(source, env_struct)}
+  rescue
+    e -> rescue_script_error(e, __STACKTRACE__)
+  end
+
+  @spec compile(binary()) :: {:ok, Compiled.t()} | {:error, Exception.t()}
+  def compile(source) when is_binary(source) do
+    compile(source, Environment.new())
+  end
+
+  @doc """
+  Bang form of `compile/2` — raises on source-level failure.
+  """
+  @spec compile!(binary(), Environment.t()) :: Compiled.t()
+  def compile!(source, %Environment{} = env_struct) when is_binary(source) do
+    forms = Reader.read_string(source)
+    {import_specs, body} = LibImport.extract_program_imports(forms)
+    bindings = LibImport.resolve(import_specs, env_struct.registry)
+
+    {_compile_env, compile_syntax_env} =
+      LibImport.apply_bindings(bindings, env_struct.env, env_struct.syntax_env)
+
+    expanded = Expander.expand_program(body, compile_syntax_env)
+
+    var_bindings =
+      Enum.reduce(bindings, %{}, fn
+        {name, {:var, _} = binding}, acc -> Map.put(acc, name, binding)
+        _, acc -> acc
+      end)
+
+    %Compiled{program: expanded, var_bindings: var_bindings}
+  end
+
+  @spec compile!(binary()) :: Compiled.t()
+  def compile!(source) when is_binary(source) do
+    compile!(source, Environment.new())
+  end
+
+  @doc """
+  Evaluate a `%Schooner.Compiled{}` against `env_struct`. Returns
+  `{:ok, value}` on success, `{:error, exception}` for any
+  script-level failure. Use `run_compiled!/2` for the raising
+  variant.
+
+  The compiled program's pre-resolved variable bindings are
+  re-applied to `env_struct.env` on every call, so the
+  `(import ...)` surface the program was compiled against is
+  always in scope regardless of `env_struct`'s registry. Macros
+  are not re-expanded — the program's macro shape is frozen at
+  compile time.
+  """
+  @spec run_compiled(Compiled.t(), Environment.t()) ::
+          {:ok, Value.t()} | {:error, Exception.t()}
+  def run_compiled(%Compiled{} = compiled, %Environment{} = env_struct) do
+    {:ok, run_compiled!(compiled, env_struct)}
+  rescue
+    e -> rescue_script_error(e, __STACKTRACE__)
+  end
+
+  @doc """
+  Bang form of `run_compiled/2` — raises on script-level failure.
+  """
+  @spec run_compiled!(Compiled.t(), Environment.t()) :: Value.t()
+  def run_compiled!(%Compiled{program: program, var_bindings: bindings}, %Environment{
+        env: env,
+        syntax_env: syntax_env
+      }) do
+    do_run_program(program, bindings, env, syntax_env)
+  end
+
+  defp do_run_program(program, var_bindings, env, syntax_env) do
+    prev_handlers = ExceptionState.snapshot()
+    prev_conts = ContinuationState.snapshot()
+    prev_params = ParameterState.snapshot()
+    ExceptionState.reset()
+    ContinuationState.reset()
+    ParameterState.reset()
+
+    try do
+      {env, _syntax_env} = LibImport.apply_bindings(var_bindings, env, syntax_env)
+
+      program
+      |> Enum.reduce(:unspecified, fn form, _acc -> Eval.eval(form, env) end)
+      |> Eval.single_value!()
+    after
+      ExceptionState.restore(prev_handlers)
+      ContinuationState.restore(prev_conts)
+      ParameterState.restore(prev_params)
     end
   end
 

--- a/lib/schooner/compiled.ex
+++ b/lib/schooner/compiled.ex
@@ -1,0 +1,48 @@
+defmodule Schooner.Compiled do
+  @moduledoc """
+  Opaque artifact produced by `Schooner.compile/2` and consumed by
+  `Schooner.run_compiled/2`.
+
+  A `%Compiled{}` holds the **post-expansion core AST** of a program
+  together with the **runtime variable bindings** that the program's
+  `(import ...)` declarations resolved to at compile time. Macros are
+  already gone from the AST — `let`, `cond`, `when`, `case`, etc.
+  have been rewritten into `quote` / `if` / `lambda` / `define` /
+  `define-values` / `begin` / `letrec*` / `quasiquote` / application
+  / variable references.
+
+  ## Reuse semantics
+
+  The same `%Compiled{}` can be passed to `Schooner.run_compiled/2`
+  many times against many `Schooner.Environment`s — that is the
+  embedding cache win. The captured `var_bindings` are re-applied
+  to the runtime env on every call; macros expanded at compile
+  time stay expanded.
+
+  Compatibility constraint: a compiled program is valid against
+  any environment whose **macro environment is compatible** with
+  the registry passed to `compile`. Variable sets can differ
+  freely — host primitives can be swapped, and the compiled
+  program's `(import ...)` bindings are baked in so they shadow
+  any same-named runtime overrides. Macro additions made *after*
+  compile (via a different `Environment` at run time) will not
+  re-expand the program.
+
+  ## Opacity
+
+  Embedders must treat the struct as opaque — pattern-matching on
+  internals is unsupported and reserved for evaluator changes
+  (the v2.0 evaluator rewrite is the seam this opacity protects).
+  """
+
+  alias Schooner.Library
+  alias Schooner.Value
+
+  @enforce_keys [:program, :var_bindings]
+  defstruct [:program, :var_bindings]
+
+  @type t :: %__MODULE__{
+          program: [Value.t()],
+          var_bindings: %{binary() => Library.export()}
+        }
+end

--- a/test/schooner/apply_test.exs
+++ b/test/schooner/apply_test.exs
@@ -1,0 +1,87 @@
+defmodule Schooner.ApplyTest do
+  use ExUnit.Case, async: true
+
+  alias Schooner.Environment
+  alias Schooner.Eval.Error, as: EvalError
+  alias Schooner.Host
+  alias Schooner.Value
+
+  describe "apply!/2" do
+    test "invokes a closure returned from eval!" do
+      env = Environment.new()
+      doubler = Schooner.eval!("(import (scheme base)) (lambda (x) (* x 2))", env)
+      assert Schooner.apply!(doubler, [21]) == 42
+    end
+
+    test "invokes a primitive directly" do
+      env = Environment.new()
+      plus = Schooner.eval!("(import (scheme base)) +", env)
+      assert Schooner.apply!(plus, [1, 2, 3]) == 6
+    end
+
+    test "invokes a parameter (zero-arg call returns current value)" do
+      env = Environment.new()
+      param = Schooner.eval!("(import (scheme base)) (make-parameter 42)", env)
+      assert Schooner.apply!(param, []) == 42
+    end
+
+    test "non-procedure value raises Eval.Error" do
+      assert_raise EvalError, fn -> Schooner.apply!(42, []) end
+      assert_raise EvalError, fn -> Schooner.apply!("not-a-proc", [1, 2]) end
+    end
+
+    test "arity mismatch in closure raises Eval.Error" do
+      env = Environment.new()
+      f = Schooner.eval!("(import (scheme base)) (lambda (x y) (+ x y))", env)
+
+      assert_raise EvalError, fn -> Schooner.apply!(f, [1]) end
+      assert_raise EvalError, fn -> Schooner.apply!(f, [1, 2, 3]) end
+    end
+
+    test "callback pattern: host fn passes Scheme proc, then calls it" do
+      called = self()
+
+      lib =
+        Host.library(
+          primitives: [
+            {"call-twice", 2,
+             fn [proc, arg] ->
+               first = Schooner.apply!(proc, [arg])
+               second = Schooner.apply!(proc, [first])
+               send(called, {:results, first, second})
+               second
+             end}
+          ]
+        )
+
+      env = Environment.new(libraries: [lib])
+
+      result =
+        Schooner.eval!(
+          "(import (scheme base)) (call-twice (lambda (x) (* x 2)) 5)",
+          env
+        )
+
+      assert result == 20
+      assert_received {:results, 10, 20}
+    end
+  end
+
+  describe "apply/2 tagged-tuple wrapper" do
+    test "returns {:ok, value} on success" do
+      env = Environment.new()
+      f = Schooner.eval!("(import (scheme base)) (lambda (x) x)", env)
+      assert Schooner.apply(f, [Value.string("hi")]) == {:ok, "hi"}
+    end
+
+    test "returns {:error, _} for non-procedures" do
+      assert {:error, %EvalError{}} = Schooner.apply(42, [])
+    end
+
+    test "returns {:error, _} for arity mismatches" do
+      env = Environment.new()
+      f = Schooner.eval!("(import (scheme base)) (lambda (x) x)", env)
+      assert {:error, %EvalError{}} = Schooner.apply(f, [1, 2])
+    end
+  end
+end

--- a/test/schooner/compile_test.exs
+++ b/test/schooner/compile_test.exs
@@ -1,0 +1,125 @@
+defmodule Schooner.CompileTest do
+  use ExUnit.Case, async: true
+
+  alias Schooner.Compiled
+  alias Schooner.Environment
+  alias Schooner.Host
+  alias Schooner.Reader.Error, as: ReaderError
+
+  describe "compile!/1 default environment" do
+    test "compiles + runs against the default standard registry" do
+      compiled = Schooner.compile!("(import (scheme base)) (+ 1 2)")
+      assert %Compiled{} = compiled
+      assert is_list(compiled.program)
+      assert is_map(compiled.var_bindings)
+      assert Schooner.run_compiled!(compiled, Environment.new()) == 3
+    end
+  end
+
+  describe "compile!/2 with explicit environment" do
+    test "honours the registry for import resolution" do
+      env = Environment.new(standard_libraries: [:base])
+      compiled = Schooner.compile!("(import (scheme base)) (+ 1 2)", env)
+      assert Schooner.run_compiled!(compiled, env) == 3
+    end
+
+    test "compile-time error surfaces (e.g. import of a missing library)" do
+      env = Environment.new(standard_libraries: [:base])
+
+      assert_raise Schooner.Library.NotFoundError, fn ->
+        Schooner.compile!("(import (scheme inexact)) (sin 0)", env)
+      end
+    end
+
+    test "captures imported macros — let etc. survive expansion" do
+      env = Environment.new()
+      compiled = Schooner.compile!("(import (scheme base)) (let ((x 5)) (* x 2))", env)
+      assert Schooner.run_compiled!(compiled, env) == 10
+    end
+  end
+
+  describe "compile then run multiple times" do
+    test "compiled program is reusable; defines are applied to the runtime env on each run" do
+      env = Environment.new()
+
+      compiled =
+        Schooner.compile!(
+          "(import (scheme base)) (define x 7) (* x 6)",
+          env
+        )
+
+      assert Schooner.run_compiled!(compiled, env) == 42
+      assert Schooner.run_compiled!(compiled, env) == 42
+    end
+
+    test "two distinct envs produce independent runs (defines do not bleed)" do
+      a = Environment.new()
+      b = Environment.new()
+
+      compiled =
+        Schooner.compile!(
+          "(import (scheme base)) (define counter 0) (define (next) counter) (next)",
+          a
+        )
+
+      Schooner.run_compiled!(compiled, a)
+      # define `counter` was applied to a's env, not b's. Run against b
+      # should still complete successfully because the define re-runs
+      # against b's globals.
+      assert Schooner.run_compiled!(compiled, b) == 0
+    end
+  end
+
+  describe "host primitives in compiled programs" do
+    test "host library bindings resolved at compile time are baked in" do
+      lib =
+        Host.library(
+          name: ["myapp"],
+          primitives: [{"answer", 0, fn [] -> 42 end}]
+        )
+
+      env = Environment.new(libraries: [lib])
+
+      compiled = Schooner.compile!("(import (myapp)) (answer)", env)
+      assert Schooner.run_compiled!(compiled, env) == 42
+    end
+
+    test "anonymous host library bindings live on env, not in the artifact" do
+      lib = Host.library(primitives: [{"answer", 0, fn [] -> 42 end}])
+      env = Environment.new(libraries: [lib])
+
+      compiled = Schooner.compile!("(answer)", env)
+      assert Schooner.run_compiled!(compiled, env) == 42
+    end
+  end
+
+  describe "compile/2 tagged-tuple wrapper" do
+    test "returns {:ok, %Compiled{}} on success" do
+      env = Environment.new()
+      assert {:ok, %Compiled{}} = Schooner.compile("(import (scheme base)) 1", env)
+    end
+
+    test "returns {:error, _} on a parse error" do
+      env = Environment.new()
+      assert {:error, %ReaderError{}} = Schooner.compile("(", env)
+    end
+
+    test "compile/1 default-env wrapper works" do
+      assert {:ok, %Compiled{}} = Schooner.compile("(import (scheme base)) 1")
+    end
+  end
+
+  describe "run_compiled/2 tagged-tuple wrapper" do
+    test "returns {:ok, value} on success" do
+      env = Environment.new()
+      compiled = Schooner.compile!("(import (scheme base)) (+ 1 2)", env)
+      assert Schooner.run_compiled(compiled, env) == {:ok, 3}
+    end
+
+    test "returns {:error, _} for a runtime failure" do
+      env = Environment.new()
+      compiled = Schooner.compile!(~s|(import (scheme base)) (raise "oops")|, env)
+      assert {:error, %Schooner.Error{}} = Schooner.run_compiled(compiled, env)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Builds on #95. Adds the procedure-invocation seam and the compile-then-run cache path.

### `Schooner.apply!/2` and `apply/2`

Invoke any Scheme procedure value — closure, primitive, or parameter — from Elixir. The two host-side use cases:

1. **Closure-as-eval-result**: a script returns a closure; the host stashes it and invokes it later.
2. **Callback pattern**: a host primitive receives a closure as an argument and invokes it during its body.

```elixir
env = Schooner.Environment.new()
double = Schooner.eval!("(import (scheme base)) (lambda (x) (* x 2))", env)
Schooner.apply!(double, [21])   # => 42
```

No snapshot/restore at this seam — nested calls from inside a host function should inherit the outer eval's exception/parameter state, which is what re-using `Eval.apply_proc/2` directly delivers.

### `Schooner.compile!/1,2` and `Schooner.run_compiled!/2`

Option A from the design plan: full macro expansion at compile time, runtime variable bindings pre-resolved and baked into the artifact.

```elixir
env = Schooner.Environment.new(libraries: [my_log_lib])
compiled = Schooner.compile!("(import (myapp log)) (info \"start\") (run-rule)", env)

# Run many times against the same env (defines persist on env's globals)
# or against differently-shaped envs (host primitives can vary).
Schooner.run_compiled!(compiled, env)
Schooner.run_compiled!(compiled, env)
```

`%Schooner.Compiled{}` is opaque. The reuse contract: valid against any `%Environment{}` whose macro environment is compatible with the compile-time registry. Variable sets can differ freely — the script's `(import ...)` bindings are baked in, so they shadow any same-named runtime overrides.

`compile/1` defaults to a fresh `Environment.new()` (every shipped standard library available).

### Tagged-tuple wrappers

Following the established convention: `apply/2`, `compile/1,2`, `run_compiled/2` return `{:ok, _} | {:error, exception}`; bang forms raise. Same exception set as `eval/run`.

## Sub-phase context

This is **15.4 of 5** in the Phase 15 plan:
- 15.1 — `Schooner.Host` conversion helpers + `TypeError` (#93, merged)
- 15.2 — `Schooner.Host.library/1` builder + anonymous library names (#94, merged)
- 15.3 — `%Schooner.Environment{}` + bang/tagged-tuple split (#95, merged)
- 15.4 (this PR) — `Schooner.apply/2,!`, `Schooner.compile/1,2,!`, `%Schooner.Compiled{}`
- 15.5 — ExDoc dep + four guides

## Test plan

- [x] `apply!/2`: closure / primitive / parameter happy paths, non-procedure raises, arity-mismatch raises, callback round-trip (host fn → Scheme proc → host fn → Scheme proc)
- [x] `apply/2`: tagged `{:ok, _}` / `{:error, _}` for the same shapes
- [x] `compile!/1`: default env happy path, bare wrapper builds artifact
- [x] `compile!/2`: explicit env honours the registry; missing-import raises at compile time; macros (`let`) survive expansion
- [x] Compile then run multiple times: same env reuses (defines persist), distinct envs are independent (defines don't bleed)
- [x] Host primitives in compiled programs: named lib via import, anonymous lib via auto-apply
- [x] Tagged-tuple wrappers: `{:ok, %Compiled{}}` / `{:error, %ReaderError{}}` for compile, `{:ok, value}` / `{:error, %SchemeError{}}` for run_compiled
- [x] `mix precommit` green — 1500 tests, 0 failures, credo --strict clean