### PR TITLE
Doc cleanup: README, ExDoc filter, autolinks, warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,29 +7,9 @@ to one of the entry points below, get back an Elixir term, and
 resource-bound the work with the standard process tools
 (`:max_heap_size`, `Task.shutdown/2`).
 
-## Choosing an entry point
-
-Schooner has two top-level evaluation entry points. **The trust posture
-differs — picking the wrong one for untrusted input is a sandbox-shaped
-hole.** The naming is the opposite of what reflex suggests: `run/1` is
-the lax convenience, `eval/2` is the strict embedding path.
-
-| Entry point        | Auto-imports                                                                              | Trust posture                                       | Use for                                                            |
-| ---                | ---                                                                                       | ---                                                 | ---                                                                |
-| `Schooner.run/1`   | injects `(import ...)` of every shipped standard library when the script declares none    | **Not sandbox-safe.** Every primitive is in scope.  | tests, REPL-style use, your own scripts where you control the source |
-| `Schooner.eval/2`  | none — bindings come exclusively from `env` and the script's own `(import ...)`           | **Sandbox-safe.** The embedder controls the surface.| embedding untrusted or semi-trusted scripts                        |
-
-The implicit-import behaviour of `run/1` is opt-in via
-`Schooner.eval(source, env, implicit_imports: :all)`; `run/1` is just
-that call with a fresh `Schooner.Env`. Use `eval/2` (no options) for
-anything you would not paste into your own REPL — a script that omits
-`(import ...)` cannot reach any primitive, so the host gets to set the
-surface deliberately.
-
 ## Installation
 
-If [available in Hex](https://hex.pm/docs/publish), the package can be installed
-by adding `schooner` to your list of dependencies in `mix.exs`:
+Add `schooner` to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do
@@ -39,16 +19,36 @@ def deps do
 end
 ```
 
-Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
-and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
-be found at <https://hexdocs.pm/schooner>.
+Documentation is published at <https://hexdocs.pm/schooner>.
+
+## Choosing an entry point
+
+Schooner has two top-level evaluation entry points. They differ in
+**what's in scope when the script starts**, and picking the wrong one
+for untrusted input is a sandbox hole.
+
+| Entry point        | Auto-imports                                                                              | Trust posture                                       | Use for                                                            |
+| ---                | ---                                                                                       | ---                                                 | ---                                                                |
+| `Schooner.run/1`   | injects `(import ...)` of every shipped standard library when the script declares none    | **Not sandbox-safe.** Every primitive is in scope.  | tests, REPL-style use, your own scripts                              |
+| `Schooner.eval/2`  | none — bindings come from `env` and the script's own `(import ...)` declarations          | **Sandbox-safe.** The embedder controls the surface.| embedding scripts you do not control                                |
+
+For untrusted input, use `Schooner.eval/2`. A script that omits
+`(import ...)` cannot reach any primitive, so the embedder sets the
+surface deliberately.
+
+Both functions also have raising bang variants (`run!/1`, `eval!/2,3`)
+and a richer environment-construction path via
+`Schooner.Environment.new/1` — see the [Embedding](guides/embedding.md)
+guide.
 
 ## Deviations from r7rs-small
 
 Schooner targets r7rs-small but deliberately ships a smaller surface.
 The table below summarises every intentional gap; conformance tests
 under `test/conformance/` cover the surface that *is* shipped, with
-each excluded upstream case annotated inline.
+each excluded upstream case annotated inline. The
+[Deviations](guides/deviations.md) guide expands every row with a
+runnable example and a workaround.
 
 | Area                         | Schooner                                                                                                                                                  |
 | ---                          | ---                                                                                                                                                       |

--- a/guides/host-functions.md
+++ b/guides/host-functions.md
@@ -88,15 +88,17 @@ libraries deliberately.
 ## Conversion helpers
 
 Schooner does not auto-marshal across the host boundary. Host
-functions consume `Schooner.Value.t/0` and return
-`Schooner.Value.t/0`. To go between Scheme values and idiomatic
+functions consume `t:Schooner.Value.t/0` and return
+`t:Schooner.Value.t/0`. To go between Scheme values and idiomatic
 Elixir terms, use the helpers on `Schooner.Host`.
 
 ### Naming convention
 
 - `to_*!/2` — **asserting**: raises `Schooner.Host.TypeError` on
   shape mismatch. Takes a keyword list with `:op` so the error
-  points at the host call site.
+  points at the host call site. The bang in the name is the
+  Elixir convention for "raises rather than returns a tagged
+  result".
 - `to_*/1` — **total**: returns `{:ok, term} | :error`. Use for
   the "branch on shape" case.
 
@@ -113,32 +115,32 @@ end
 
 ### Avoid `import Schooner.Host`
 
-Several helper names (`to_string`, `to_string!`) shadow
-`Kernel.to_string/1`. **Use `alias Schooner.Host`** and call the
-helpers as `Host.to_string!(value, op: "...")`. Don't `import`
-the module.
+Several helper names — `Schooner.Host.to_string/1` and
+`Schooner.Host.to_string!/2` — shadow `Kernel.to_string/1`.
+**Use `alias Schooner.Host`** and call the helpers as
+`Host.to_string!(value, op: "...")`. Don't `import` the module.
 
 ### Available accessors
 
 | Helper | Accepts | Returns |
 | --- | --- | --- |
-| `to_integer!/2` | bare exact integer | Elixir integer |
-| `to_float!/2` | bare Elixir float | Elixir float |
-| `to_real!/2` | integer / float / rational | Elixir number (rationals coerced to float) |
-| `to_string!/2` | bare binary (Scheme string) | Elixir binary |
-| `to_symbol_name!/2` | `{:sym, name}` | Elixir binary (the name) |
-| `to_char!/2` | `{:char, cp}` | non-negative integer codepoint |
-| `to_bool!/2` | `true \| false` | Elixir bool |
-| `to_list!/2` | proper Scheme list | Elixir list |
-| `to_vector!/2` | `{:vector, tuple}` | Elixir list |
-| `to_bytevector!/2` | `{:bytevector, binary}` | Elixir binary |
-| `to_foreign_ref!/2` | `{:foreign, term}` | the wrapped host term |
-| `to_proc!/2` | closure / primitive / parameter | the value unchanged (callable assertion) |
+| `Schooner.Host.to_integer!/2` | bare exact integer | Elixir integer |
+| `Schooner.Host.to_float!/2` | bare Elixir float | Elixir float |
+| `Schooner.Host.to_real!/2` | integer / float / rational | Elixir number (rationals coerced to float) |
+| `Schooner.Host.to_string!/2` | bare binary (Scheme string) | Elixir binary |
+| `Schooner.Host.to_symbol_name!/2` | `{:sym, name}` | Elixir binary (the name) |
+| `Schooner.Host.to_char!/2` | `{:char, cp}` | non-negative integer codepoint |
+| `Schooner.Host.to_bool!/2` | `true \| false` | Elixir bool |
+| `Schooner.Host.to_list!/2` | proper Scheme list | Elixir list |
+| `Schooner.Host.to_vector!/2` | `{:vector, tuple}` | Elixir list |
+| `Schooner.Host.to_bytevector!/2` | `{:bytevector, binary}` | Elixir binary |
+| `Schooner.Host.to_foreign_ref!/2` | `{:foreign, term}` | the wrapped host term |
+| `Schooner.Host.to_proc!/2` | closure / primitive / parameter | the value unchanged (callable assertion) |
 
-The `to_real!/2` vs `to_float!/2` split is deliberate:
-`to_float!/2` rejects integers (the host should say what it
-wants), `to_real!/2` is the lenient "give me whatever number it
-is" form.
+The `Schooner.Host.to_real!/2` vs `Schooner.Host.to_float!/2`
+split is deliberate: `to_float!` rejects integers (the host
+should say what it wants), `to_real!` is the lenient "give me
+whatever number it is" form.
 
 ### Constructors
 

--- a/guides/sandbox.md
+++ b/guides/sandbox.md
@@ -167,8 +167,8 @@ host code that manipulates them is unsupported:
   knows the type. Use `Schooner.Host.foreign/1` to wrap host data
   you want to pass through Scheme; don't define record types in
   Scheme expecting the host to use them as Elixir structs.
-- **Parameters** — `Schooner.Value.parameter_v/0` shape is an
-  internal detail. Treat them like closures: invoke via
+- **Parameters** — the `t:Schooner.Value.parameter_v/0` shape is
+  an internal detail. Treat them like closures: invoke via
   `Schooner.apply/2`, don't move across processes.
 - **Continuations** — already covered above. Even within v1's
   escape-only model, do not try to capture and re-invoke a

--- a/lib/schooner.ex
+++ b/lib/schooner.ex
@@ -3,12 +3,11 @@ defmodule Schooner do
   An embeddable, sandboxed Scheme interpreter for the BEAM, targeting
   the r7rs-small language minus its mutable operations.
 
-  The pipeline is `Schooner.Lexer` → `Schooner.Reader` →
-  `Schooner.Expander` → `Schooner.Eval`, with `Schooner.Value` providing
-  the tagged-term value model and `Schooner.Env` the
-  immutable-with-mutable-globals runtime environment. Macro bindings
-  live in a separate `Schooner.Expander.SyntaxEnv` threaded through
-  expansion only.
+  The pipeline is Lexer → Reader → Expander → Eval. The
+  `Schooner.Value` module provides the tagged-term value model and
+  `Schooner.Env` the immutable-with-mutable-globals runtime
+  environment. Macro bindings live in a separate expansion-time
+  syntax env threaded through expansion only.
 
   ## Choosing an entry point
 
@@ -234,7 +233,7 @@ defmodule Schooner do
 
   `proc` may be any procedure value — a closure (returned by
   evaluating a `lambda` or a `define` form), a primitive, or a
-  parameter. `args` is a list of `Schooner.Value.t/0` arguments.
+  parameter. `args` is a list of `t:Schooner.Value.t/0` arguments.
 
   This is the host-side hook for callback patterns: pass a Scheme
   procedure into a host function, capture it, and invoke it later

--- a/lib/schooner/compiled.ex
+++ b/lib/schooner/compiled.ex
@@ -41,8 +41,8 @@ defmodule Schooner.Compiled do
   @enforce_keys [:program, :var_bindings]
   defstruct [:program, :var_bindings]
 
-  @type t :: %__MODULE__{
-          program: [Value.t()],
-          var_bindings: %{binary() => Library.export()}
-        }
+  @opaque t :: %__MODULE__{
+            program: [Value.t()],
+            var_bindings: %{binary() => Library.export()}
+          }
 end

--- a/lib/schooner/env.ex
+++ b/lib/schooner/env.ex
@@ -14,7 +14,7 @@ defmodule Schooner.Env do
 
   Globals are stored as a Map on the process heap, not in `:ets`, so
   consecutive lookups of the same name return the *same* heap term.
-  This preserves `:erts_debug.same/2` identity for aggregates bound
+  This preserves `erts_debug.same/2` identity for aggregates bound
   at top level — `(eq? x x)` answers `#t` for vectors, pairs,
   parameters, and other aggregates, matching the lexical case.
 

--- a/lib/schooner/environment.ex
+++ b/lib/schooner/environment.ex
@@ -67,11 +67,11 @@ defmodule Schooner.Environment do
   @enforce_keys [:env, :syntax_env, :registry]
   defstruct [:env, :syntax_env, :registry]
 
-  @type t :: %__MODULE__{
-          env: Env.t(),
-          syntax_env: SyntaxEnv.t(),
-          registry: Library.registry()
-        }
+  @opaque t :: %__MODULE__{
+            env: Env.t(),
+            syntax_env: SyntaxEnv.t(),
+            registry: Library.registry()
+          }
 
   @standard_shortcuts %{
     base: ["scheme", "base"],
@@ -101,7 +101,7 @@ defmodule Schooner.Environment do
           `:cxr`, `:write`, `:read`, `:lazy`, `:case_lambda` /
           `:"case-lambda"`).
 
-    * `:libraries` — list of `Schooner.Library.t/0` (typically
+    * `:libraries` — list of `t:Schooner.Library.t/0` (typically
       built via `Schooner.Host.library/1`). Named libraries join
       the registry; anonymous libraries (`name: []`) have their
       bindings applied directly to the runtime env.

--- a/lib/schooner/eval/error.ex
+++ b/lib/schooner/eval/error.ex
@@ -1,6 +1,6 @@
 defmodule Schooner.Eval.Error do
   @moduledoc """
-  Exception raised by `Schooner.Eval` for runtime and syntactic failures.
+  Exception raised by the evaluator for runtime and syntactic failures.
 
   The `:reason` field is a structured term — atom or tagged tuple — meant
   to be machine-matchable in tests. The pretty `:message` is generated

--- a/lib/schooner/expander/error.ex
+++ b/lib/schooner/expander/error.ex
@@ -1,7 +1,7 @@
 defmodule Schooner.Expander.Error do
   @moduledoc """
-  Exception raised by `Schooner.Expander` for malformed macro forms,
-  failed pattern matches, and other expansion-time failures.
+  Exception raised by the expander for malformed macro forms, failed
+  pattern matches, and other expansion-time failures.
   """
 
   defexception [:reason, :message]

--- a/lib/schooner/host.ex
+++ b/lib/schooner/host.ex
@@ -4,8 +4,8 @@ defmodule Schooner.Host do
 
   Schooner does not auto-marshal across the host boundary. A host
   function has the same shape as a built-in primitive — it consumes a
-  list of `Schooner.Value.t/0` arguments and returns a
-  `Schooner.Value.t/0` — and uses the helpers in this module to move
+  list of `t:Schooner.Value.t/0` arguments and returns a
+  `t:Schooner.Value.t/0` — and uses the helpers in this module to move
   between Scheme values and idiomatic Elixir terms. The named
   constructors and accessors form the seam that future
   representation changes pivot on; even when the underlying impl is
@@ -25,10 +25,11 @@ defmodule Schooner.Host do
 
   ## Recommended use pattern
 
-  Several accessor names — `to_string/1`, `to_string!/2` — collide
-  with `Kernel.to_string/1`. **Don't `import Schooner.Host`.** Use
-  `alias Schooner.Host` and call the accessors as `Host.to_string!`
-  etc.; the alias is one line and the call sites stay explicit.
+  Several accessor names — `Schooner.Host.to_string/1` and
+  `Schooner.Host.to_string!/2` — collide with `Kernel.to_string/1`.
+  **Don't `import Schooner.Host`.** Use `alias Schooner.Host` and
+  call the accessors as `Host.to_string!` etc.; the alias is one
+  line and the call sites stay explicit.
 
   ## Worked example
 
@@ -120,7 +121,7 @@ defmodule Schooner.Host do
       underlying primitive ABI.
 
     * `:values` — list of `{name, value}` pairs for arbitrary
-      `Schooner.Value.t/0` bindings (constants, foreign-wrapped
+      `t:Schooner.Value.t/0` bindings (constants, foreign-wrapped
       service handles, pre-built closures). Useful when the host
       wants to expose data, not just procedures.
 

--- a/lib/schooner/lexer/error.ex
+++ b/lib/schooner/lexer/error.ex
@@ -1,6 +1,6 @@
 defmodule Schooner.Lexer.Error do
   @moduledoc """
-  Exception raised by `Schooner.Lexer` on malformed source.
+  Exception raised by the lexer on malformed source.
 
   Each error carries:
 

--- a/lib/schooner/library.ex
+++ b/lib/schooner/library.ex
@@ -21,11 +21,10 @@ defmodule Schooner.Library do
 
   A *registry* is a plain map of `name => %Schooner.Library{}`.
   `register/2` and `lookup/2` are pure and operate on a map the caller
-  owns. The standard library registry — built once by
-  `Schooner.Library.Standard.boot/0` at OTP application start — is
-  stashed under the persistent term key `{Schooner.Library,
-  :standard}`. `standard/0` reads it without copying, so spawned
-  evaluator processes pay no cost to access it.
+  owns. The standard library registry is built once at OTP
+  application start and stashed under the persistent term key
+  `{Schooner.Library, :standard}`. `standard/0` reads it without
+  copying, so spawned evaluator processes pay no cost to access it.
   """
 
   alias Schooner.Library.NotFoundError
@@ -109,8 +108,8 @@ defmodule Schooner.Library do
 
   @doc """
   Read the standard registry from persistent term storage. Returns
-  `%{}` when the key is unset, which lets `Schooner.Library.Standard`
-  build the first registry on top of an empty default.
+  `%{}` when the key is unset, which lets the standard-library
+  bootstrapper build the first registry on top of an empty default.
   """
   @spec standard() :: registry()
   def standard, do: :persistent_term.get(@persistent_key, %{})

--- a/lib/schooner/primitives/inexact.ex
+++ b/lib/schooner/primitives/inexact.ex
@@ -202,9 +202,9 @@ defmodule Schooner.Primitives.Inexact do
   # the underlying transcendentals are inherently inexact.
 
   @doc """
-  `expt(z, w) = exp(w * log z)` on the complex tower. Public so
-  `Schooner.Primitives.Base.expt/1` can defer the non-integer-exponent
-  path here without exposing the underlying complex `exp`/`log`.
+  `expt(z, w) = exp(w * log z)` on the complex tower. Public so the
+  base-library `expt` primitive can defer the non-integer-exponent
+  path here without exposing the underlying complex `exp` / `log`.
   """
   @spec generic_expt(Value.complex_v() | Value.real_v(), Value.complex_v() | Value.real_v()) ::
           Value.t()

--- a/lib/schooner/reader/error.ex
+++ b/lib/schooner/reader/error.ex
@@ -1,6 +1,6 @@
 defmodule Schooner.Reader.Error do
   @moduledoc """
-  Exception raised by `Schooner.Reader` on malformed source.
+  Exception raised by the reader on malformed source.
 
   Each error carries:
 

--- a/lib/schooner/value.ex
+++ b/lib/schooner/value.ex
@@ -56,8 +56,8 @@ defmodule Schooner.Value do
       `(error msg irritant ...)` and reachable via `error?`,
       `error-object?`, `read-error?`, `file-error?`.
     * Parameter — `{:parameter, id, init, converter}`. `id` is a
-      process-monotonic unique integer used as the lookup key in the
-      `Schooner.Eval.ParameterState` dynamic-binding stack. `init` is
+      process-monotonic unique integer used as the lookup key in
+      the per-process dynamic-binding stack. `init` is
       the post-converter initial value (returned when no
       `parameterize` is currently shadowing the parameter).
       `converter` is either `nil` or a Scheme procedure applied to
@@ -464,13 +464,13 @@ defmodule Schooner.Value do
   `()`, `:eof`, `:unspecified`) compare by content, with exactness preserved
   for numbers — `(eqv? 1 1.0)` is `#f`. Aggregates (pairs, vectors, strings,
   bytevectors, records, procedures, promises, parameters, error objects)
-  compare by physical identity via `:erts_debug.same/2` — two
+  compare by physical identity via `erts_debug.same/2` — two
   structurally-equal aggregates built independently are *not* `eqv?`. This
   is r7rs's "denote different locations in the store" semantics, recovered
   for an immutable value model by leaning on the BEAM's heap layout instead
   of explicit identity tags.
 
-  `:erts_debug.same/2` is an unofficial OTP BIF; it has been stable across
+  `erts_debug.same/2` is an unofficial OTP BIF; it has been stable across
   many releases and is used by the Erlang/OTP test suite. Compiler / loader
   literal sharing means two source-level literals like `'(1 2)` written in
   the same module *may* be deduplicated and report `same` — r7rs explicitly
@@ -486,14 +486,14 @@ defmodule Schooner.Value do
   # refs, and atoms have meaningful identity equality; structurally
   # equal heap terms (tuples, maps) also collapse, which is the price
   # of not walking a Scheme-opaque payload. Bypasses the
-  # `:erts_debug.same/2` aggregate path so two foreigns that wrap the
+  # `erts_debug.same/2` aggregate path so two foreigns that wrap the
   # same pid (but live in distinct outer tuples) still compare equal.
   def eqv?({:foreign, a}, {:foreign, b}), do: a === b
   def eqv?(a, b), do: :erts_debug.same(a, b) or (atomic?(a) and a === b)
 
   # Values for which r7rs requires `eqv?` (and therefore `eq?`) to compare
   # by content rather than by location. Bare integers / floats / atoms are
-  # immediates on the BEAM and already collapse under `:erts_debug.same/2`,
+  # immediates on the BEAM and already collapse under `erts_debug.same/2`,
   # but listing them here keeps the predicate self-contained against future
   # boxing changes and means callers can rely on it independently.
   defp atomic?(n) when is_integer(n) or is_float(n), do: true

--- a/mix.exs
+++ b/mix.exs
@@ -54,9 +54,55 @@ defmodule Schooner.MixProject do
       ],
       groups_for_extras: [
         Guides: ~r/guides\/.*/
+      ],
+      filter_modules: &public_module?/2,
+      groups_for_modules: [
+        "Embedding API": [
+          Schooner,
+          Schooner.Environment,
+          Schooner.Compiled,
+          Schooner.Host,
+          Schooner.Value,
+          Schooner.Env,
+          Schooner.Library
+        ],
+        Errors: [
+          Schooner.Error,
+          Schooner.Eval.Error,
+          Schooner.Primitive.Error,
+          Schooner.Host.TypeError,
+          Schooner.Library.NotFoundError,
+          Schooner.Lexer.Error,
+          Schooner.Reader.Error,
+          Schooner.Expander.Error
+        ]
       ]
     ]
   end
+
+  # Modules that should appear in the API Reference. Anything else is
+  # an implementation detail — evaluator internals, primitive backing
+  # modules, expander helpers, library plumbing — and is hidden from
+  # the generated docs even when its individual @moduledoc is set.
+  @public_modules MapSet.new([
+                    Schooner,
+                    Schooner.Environment,
+                    Schooner.Compiled,
+                    Schooner.Host,
+                    Schooner.Host.TypeError,
+                    Schooner.Value,
+                    Schooner.Env,
+                    Schooner.Library,
+                    Schooner.Library.NotFoundError,
+                    Schooner.Error,
+                    Schooner.Eval.Error,
+                    Schooner.Primitive.Error,
+                    Schooner.Lexer.Error,
+                    Schooner.Reader.Error,
+                    Schooner.Expander.Error
+                  ])
+
+  defp public_module?(module, _metadata), do: MapSet.member?(@public_modules, module)
 
   defp aliases do
     [


### PR DESCRIPTION
## Summary

Four threads of doc cleanup in one PR.

### README (`README.md`)
- **Installation** moved above **Choosing an entry point** so the install snippet is the first concrete thing readers see.
- Trust-posture text simplified — dropped the "reflex" framing; replaced with a plain table + a one-paragraph pointer to the Embedding guide for the richer construction path.

### ExDoc filter (`mix.exs`)
- Added `filter_modules` so the API Reference shows only the embedding surface (`Schooner`, `Environment`, `Compiled`, `Host`, `Value`, `Env`, `Library`) plus the user-visible exception types under an **Errors** group.
- Internal modules (evaluator, expander, lexer, reader, primitives, library plumbing) are hidden from the sidebar.
- Added `groups_for_modules` to organise the public surface as **Embedding API** + **Errors**.

### `to_*!` Kernel autolinks
- The host-functions guide and `Schooner.Host` moduledoc had bare `to_string`/`to_string!` references in backticks that ExDoc autolinked to `Kernel.to_string/1`. Qualified them as `Schooner.Host.to_string!` etc. in the discussion paragraphs and the helpers table so the autolink targets the right module.

### `mix docs` warnings (now zero)
Previously emitted ~9 distinct warnings; now clean. Fixes:
- Type references use the `t:` prefix (`t:Schooner.Value.t/0`, `t:Schooner.Library.t/0`, `t:Schooner.Value.parameter_v/0`).
- `%Schooner.Environment{}` and `%Schooner.Compiled{}` marked `@opaque` so the typespec doesn't expose references to filtered `Env`/`SyntaxEnv` types.
- Cross-references in public moduledocs to internal modules (`Schooner.Lexer`, `Reader`, `Expander`, `Eval`, `Library.Standard`, `Eval.ParameterState`) rephrased as plain text — they were informational, not navigable.
- `:erts_debug.same/2` references stripped of the leading colon so ExDoc doesn't try to resolve the Erlang BIF.
- `Primitives.Base.expt/1` cross-ref dropped from `Primitives.Inexact` moduledoc; the function is private.

## Test plan

- [x] `mix docs` builds clean — no warnings
- [x] `mix precommit` green — 1500 tests, 0 failures, credo --strict clean
- [x] Manual review of generated `doc/index.html` — sidebar shows only public modules grouped under Embedding API / Errors