### PR TITLE
fix: clear dialyzer warnings across eval, reader, and Schooner API

### DIFF
--- a/lib/schooner.ex
+++ b/lib/schooner.ex
@@ -276,7 +276,7 @@ defmodule Schooner do
   """
   @spec compile(binary(), Environment.t()) ::
           {:ok, Compiled.t()} | {:error, Exception.t()}
-  def compile(source, %Environment{} = env_struct) when is_binary(source) do
+  def compile(source, env_struct) when is_binary(source) do
     {:ok, compile!(source, env_struct)}
   rescue
     e -> rescue_script_error(e, __STACKTRACE__)
@@ -291,13 +291,17 @@ defmodule Schooner do
   Bang form of `compile/2` — raises on source-level failure.
   """
   @spec compile!(binary(), Environment.t()) :: Compiled.t()
-  def compile!(source, %Environment{} = env_struct) when is_binary(source) do
+  def compile!(source, env_struct) when is_binary(source) do
     forms = Reader.read_string(source)
     {import_specs, body} = LibImport.extract_program_imports(forms)
-    bindings = LibImport.resolve(import_specs, env_struct.registry)
+    bindings = LibImport.resolve(import_specs, Environment.registry(env_struct))
 
     {_compile_env, compile_syntax_env} =
-      LibImport.apply_bindings(bindings, env_struct.env, env_struct.syntax_env)
+      LibImport.apply_bindings(
+        bindings,
+        Environment.env(env_struct),
+        Environment.syntax_env(env_struct)
+      )
 
     expanded = Expander.expand_program(body, compile_syntax_env)
 
@@ -307,7 +311,7 @@ defmodule Schooner do
         _, acc -> acc
       end)
 
-    %Compiled{program: expanded, var_bindings: var_bindings}
+    Compiled.new(expanded, var_bindings)
   end
 
   @spec compile!(binary()) :: Compiled.t()
@@ -330,7 +334,7 @@ defmodule Schooner do
   """
   @spec run_compiled(Compiled.t(), Environment.t()) ::
           {:ok, Value.t()} | {:error, Exception.t()}
-  def run_compiled(%Compiled{} = compiled, %Environment{} = env_struct) do
+  def run_compiled(compiled, env_struct) do
     {:ok, run_compiled!(compiled, env_struct)}
   rescue
     e -> rescue_script_error(e, __STACKTRACE__)
@@ -340,11 +344,13 @@ defmodule Schooner do
   Bang form of `run_compiled/2` — raises on script-level failure.
   """
   @spec run_compiled!(Compiled.t(), Environment.t()) :: Value.t()
-  def run_compiled!(%Compiled{program: program, var_bindings: bindings}, %Environment{
-        env: env,
-        syntax_env: syntax_env
-      }) do
-    do_run_program(program, bindings, env, syntax_env)
+  def run_compiled!(compiled, env_struct) do
+    do_run_program(
+      Compiled.program(compiled),
+      Compiled.var_bindings(compiled),
+      Environment.env(env_struct),
+      Environment.syntax_env(env_struct)
+    )
   end
 
   defp do_run_program(program, var_bindings, env, syntax_env) do

--- a/lib/schooner/compiled.ex
+++ b/lib/schooner/compiled.ex
@@ -45,4 +45,18 @@ defmodule Schooner.Compiled do
             program: [Value.t()],
             var_bindings: %{binary() => Library.export()}
           }
+
+  @doc false
+  @spec new([Value.t()], %{binary() => Library.export()}) :: t()
+  def new(program, var_bindings) when is_list(program) and is_map(var_bindings) do
+    %__MODULE__{program: program, var_bindings: var_bindings}
+  end
+
+  @doc false
+  @spec program(t()) :: [Value.t()]
+  def program(%__MODULE__{program: program}), do: program
+
+  @doc false
+  @spec var_bindings(t()) :: %{binary() => Library.export()}
+  def var_bindings(%__MODULE__{var_bindings: var_bindings}), do: var_bindings
 end

--- a/lib/schooner/environment.ex
+++ b/lib/schooner/environment.ex
@@ -73,6 +73,18 @@ defmodule Schooner.Environment do
             registry: Library.registry()
           }
 
+  @doc false
+  @spec env(t()) :: Env.t()
+  def env(%__MODULE__{env: env}), do: env
+
+  @doc false
+  @spec syntax_env(t()) :: SyntaxEnv.t()
+  def syntax_env(%__MODULE__{syntax_env: syntax_env}), do: syntax_env
+
+  @doc false
+  @spec registry(t()) :: Library.registry()
+  def registry(%__MODULE__{registry: registry}), do: registry
+
   @standard_shortcuts %{
     base: ["scheme", "base"],
     cxr: ["scheme", "cxr"],

--- a/lib/schooner/eval.ex
+++ b/lib/schooner/eval.ex
@@ -42,7 +42,15 @@ defmodule Schooner.Eval do
   every single-value context — `call-with-values`'s producer return
   path is the only deliberate exception.
   """
-  @spec single_value!(Value.t() | {:values, [Value.t()]}) :: Value.t()
+  @typedoc """
+  Result of `eval/2` and `apply_proc/2`: either a regular value or
+  the multi-value transit marker `{:values, vs}` produced by
+  `(values ...)` and consumed only by `call-with-values` /
+  `single_value!/1`.
+  """
+  @type eval_result :: Value.t() | {:values, [Value.t()]}
+
+  @spec single_value!(eval_result()) :: Value.t()
   def single_value!({:values, [v]}), do: v
 
   def single_value!({:values, vs}) when is_list(vs) do
@@ -51,7 +59,7 @@ defmodule Schooner.Eval do
 
   def single_value!(other), do: other
 
-  @spec eval(Value.t(), Env.t()) :: Value.t()
+  @spec eval(Value.t(), Env.t()) :: eval_result()
 
   def eval({:sym, name}, env) do
     case Env.lookup(env, name) do
@@ -232,7 +240,7 @@ defmodule Schooner.Eval do
 
   defp eval_args(_, _env, _acc), do: raise(Error, reason: :improper_application)
 
-  @spec apply_proc(Value.t(), [Value.t()]) :: Value.t()
+  @spec apply_proc(Value.t(), [Value.t()]) :: eval_result()
   def apply_proc({:closure, params, body, env, name}, args) do
     new_env = Env.extend(env, bind_params(params, args, name))
     eval_sequence(body, new_env)

--- a/lib/schooner/reader.ex
+++ b/lib/schooner/reader.ex
@@ -45,12 +45,17 @@ defmodule Schooner.Reader do
     * `{:vector, pos, [item_tree]}` — `#(...)` literal.
     * `{:bytevector, pos}` — `#u8(...)` literal; bytes are atoms with no
       individual sub-trees.
+
+  Position slots are `nil` when the tree was built synthetically
+  (e.g. by `Schooner.Library.Loader` from a raw datum with no
+  reader-tracked positions). Real reader output always carries a
+  concrete `Lexer.position()`.
   """
   @type pos_tree ::
-          {:atom, Lexer.position()}
-          | {:pair, Lexer.position(), pos_tree(), pos_tree()}
-          | {:vector, Lexer.position(), [pos_tree()]}
-          | {:bytevector, Lexer.position()}
+          {:atom, Lexer.position() | nil}
+          | {:pair, Lexer.position() | nil, pos_tree(), pos_tree()}
+          | {:vector, Lexer.position() | nil, [pos_tree()]}
+          | {:bytevector, Lexer.position() | nil}
 
   @doc "Read a binary of source into a list of top-level datums."
   @spec read_string(binary()) :: [Value.t()]
@@ -79,7 +84,7 @@ defmodule Schooner.Reader do
   # ---------------------------------------------------------------------------
 
   @doc "Start position of the datum the position tree describes."
-  @spec position_of(pos_tree()) :: Lexer.position()
+  @spec position_of(pos_tree()) :: Lexer.position() | nil
   def position_of({:atom, pos}), do: pos
   def position_of({:pair, pos, _, _}), do: pos
   def position_of({:vector, pos, _}), do: pos


### PR DESCRIPTION
## Summary

Clears all 9 dialyzer warnings reported by ElixirLS — type-level changes only, no runtime behaviour change. Verified with `mix precommit` (1500 tests, 0 failures) and a fresh ElixirLS diagnostics run (no warnings).

- **Eval**: widen `eval/2` and `apply_proc/2` specs to include the `{:values, vs}` multi-value transit marker via a new `eval_result` type. The marker was always part of the contract (see `single_value!/1`'s existing input spec); the producer-side patterns in `values_to_list/1` and `call-with-values` were being flagged as unreachable because the spec didn't say so.
- **Reader**: allow `nil` in `pos_tree` position slots and update `position_of/1` to return `Lexer.position() | nil`. `Library.Loader.synthetic_pos_tree/1` already constructs trees with `nil` positions for raw-datum entry points; the type now matches that reality.
- **Compiled / Environment**: add internal accessors (`new/2`, `program/1`, `var_bindings/1` and `env/1`, `syntax_env/1`, `registry/1`, all `@doc false`). These preserve the `@opaque` contract while giving callers in the same package a way to read the internals without leaking the struct shape into Dialyzer's view.
- **Schooner**: route `compile!/2` and `run_compiled!/2` through the new accessors and `Compiled.new/2`. Drop the now-redundant `%Compiled{}` / `%Environment{}` guards on the wrapper functions — those were what was triggering the "opaque term" violations in the first place.

## Test plan

- [x] `mix precommit` (compile --warnings-as-errors, format, credo --strict, test) passes
- [x] ElixirLS diagnostics show no warnings on the previously-flagged files (`lib/schooner.ex`, `lib/schooner/eval.ex`, `lib/schooner/library/loader.ex`, `lib/schooner/primitives/base.ex`)
- [ ] CI green