### PR TITLE
chore: prepare package metadata for hex publishing

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Nick Gunn
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/mix.exs
+++ b/mix.exs
@@ -14,7 +14,22 @@ defmodule Schooner.MixProject do
       aliases: aliases(),
       elixirc_paths: elixirc_paths(Mix.env()),
       elixirc_options: [warnings_as_errors: true],
+      package: package(),
+      description: description(),
       docs: docs()
+    ]
+  end
+
+  defp description do
+    "An embeddable, sandboxed Scheme interpreter for the BEAM, targeting " <>
+      "the r7rs-small language minus its mutable operations."
+  end
+
+  defp package do
+    [
+      licenses: ["MIT"],
+      links: %{"GitHub" => @source_url},
+      files: ~w(lib priv guides .formatter.exs mix.exs README.md LICENSE)
     ]
   end
 
@@ -37,7 +52,8 @@ defmodule Schooner.MixProject do
       {:nimble_options, "~> 1.1"},
       {:stream_data, "~> 1.1", only: [:dev, :test]},
       {:credo, "~> 1.7", only: [:dev, :test], runtime: false},
-      {:ex_doc, "~> 0.34", only: :dev, runtime: false}
+      {:ex_doc, "~> 0.34", only: :dev, runtime: false},
+      {:publisho, "~> 1.0", only: :dev, runtime: false}
     ]
   end
 
@@ -45,6 +61,7 @@ defmodule Schooner.MixProject do
     [
       main: "readme",
       source_url: @source_url,
+      source_ref: @version,
       extras: [
         "README.md",
         "guides/embedding.md",
@@ -64,7 +81,8 @@ defmodule Schooner.MixProject do
           Schooner.Host,
           Schooner.Value,
           Schooner.Env,
-          Schooner.Library
+          Schooner.Library,
+          Schooner.Time
         ],
         Errors: [
           Schooner.Error,
@@ -94,6 +112,7 @@ defmodule Schooner.MixProject do
                     Schooner.Env,
                     Schooner.Library,
                     Schooner.Library.NotFoundError,
+                    Schooner.Time,
                     Schooner.Error,
                     Schooner.Eval.Error,
                     Schooner.Primitive.Error,

--- a/mix.lock
+++ b/mix.lock
@@ -10,5 +10,6 @@
   "makeup_erlang": {:hex, :makeup_erlang, "1.0.3", "4252d5d4098da7415c390e847c814bad3764c94a814a0b4245176215615e1035", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "953297c02582a33411ac6208f2c6e55f0e870df7f80da724ed613f10e6706afd"},
   "nimble_options": {:hex, :nimble_options, "1.1.1", "e3a492d54d85fc3fd7c5baf411d9d2852922f66e69476317787a7b2bb000a61b", [:mix], [], "hexpm", "821b2470ca9442c4b6984882fe9bb0389371b8ddec4d45a9504f00a66f650b44"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.4.2", "8efba0122db06df95bfaa78f791344a89352ba04baedd3849593bfce4d0dc1c6", [:mix], [], "hexpm", "4b21398942dda052b403bbe1da991ccd03a053668d147d53fb8c4e0efe09c973"},
+  "publisho": {:hex, :publisho, "1.0.2", "c65f597a3ad0bd1487ab63c09167fe258287c9ace687a25a9cbb5e58d237e97b", [:mix], [], "hexpm", "9a48538ea978a4645a4a00e76c220b580dda28174f039184bf053e5fe37171eb"},
   "stream_data": {:hex, :stream_data, "1.3.0", "bde37905530aff386dea1ddd86ecbf00e6642dc074ceffc10b7d4e41dfd6aac9", [:mix], [], "hexpm", "3cc552e286e817dca43c98044c706eec9318083a1480c52ae2688b08e2936e3c"},
 }


### PR DESCRIPTION
## Summary
- Add MIT `LICENSE` (Copyright 2026 Nick Gunn) and wire it into the package files list.
- Add `package/0` + `description/0` in `mix.exs` (license `MIT`, GitHub link, explicit files list).
- Pin `source_ref: @version` in the docs config so generated source links resolve to the published tag instead of `main`.
- Promote `Schooner.Time` into the public docs surface (added to `@public_modules` and the `Embedding API` group).
- Add `{:publisho, "~> 1.0", only: :dev, runtime: false}` for tagging/releasing.

## Test plan
- [x] `mix deps.get` resolves `publisho 1.0.2`.
- [x] `mix hex.build` produces `schooner-0.1.0.tar` with the expected contents (`lib`, `priv/scheme/*.scm`, `guides`, `README.md`, `LICENSE`, `mix.exs`, `.formatter.exs`).
- [x] Extracted tarball compiles standalone under `MIX_ENV=prod` with `warnings_as_errors: true` (only `nimble_options` pulled as a runtime dep).
- [ ] Reviewer: confirm package metadata reads correctly in `mix hex.build` output.