### PR TITLE
chore: add CHANGELOG.md and RELEASE.md for first release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+<!-- %% CHANGELOG_ENTRIES %% -->

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+### Added
+
+- Initial release.

--- a/mix.exs
+++ b/mix.exs
@@ -29,7 +29,7 @@ defmodule Schooner.MixProject do
     [
       licenses: ["MIT"],
       links: %{"GitHub" => @source_url},
-      files: ~w(lib priv guides .formatter.exs mix.exs README.md LICENSE)
+      files: ~w(lib priv guides .formatter.exs mix.exs README.md CHANGELOG.md LICENSE)
     ]
   end
 
@@ -67,7 +67,8 @@ defmodule Schooner.MixProject do
         "guides/embedding.md",
         "guides/host-functions.md",
         "guides/sandbox.md",
-        "guides/deviations.md"
+        "guides/deviations.md",
+        "CHANGELOG.md"
       ],
       groups_for_extras: [
         Guides: ~r/guides\/.*/


### PR DESCRIPTION
## Summary
- Add `CHANGELOG.md` with the Keep a Changelog / SemVer preamble and the `<!-- %% CHANGELOG_ENTRIES %% -->` placeholder for `mix publisho`.
- Add `RELEASE.md` seeded with an `Added` entry for the initial release.
- Wire `CHANGELOG.md` into `mix.exs` — `:extras` (so it appears in the published docs) and `:files` (so it ships in the hex package).

## Test plan
- [ ] `mix docs` builds and CHANGELOG appears in the sidebar
- [ ] `mix hex.build` includes `CHANGELOG.md` in the tarball