### PR TITLE
docs: bump README install snippet to ~> 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Add `schooner` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:schooner, "~> 0.1.0"}
+    {:schooner, "~> 1.0"}
   ]
 end
 ```


### PR DESCRIPTION
## Summary

- The `mix.exs` install example in `README.md` pinned `~> 0.1.0`, but the latest tag and `@version` in `mix.exs` are both `1.0.0`.
- Update the snippet to `~> 1.0` so copy-paste installs resolve to the published release.

Fixes #106

## Test plan

- [x] `git diff` shows only the README dependency line changes.

https://claude.ai/code/session_01S1Hm9rdoBxvJ99UH6kvTz4

---
_Generated by [Claude Code](https://claude.ai/code/session_01S1Hm9rdoBxvJ99UH6kvTz4)_