### PR TITLE
fix: remove unreachable integer clause in parse_complex_part/5

### DIFF
--- a/lib/schooner/lexer.ex
+++ b/lib/schooner/lexer.ex
@@ -583,9 +583,6 @@ defmodule Schooner.Lexer do
   defp lift_int(n, :inexact), do: n / 1
   defp lift_int(n, _), do: n
 
-  defp parse_complex_part(raw, exactness, _whole, _line, _col) when is_integer(raw),
-    do: lift_int(raw, exactness)
-
   defp parse_complex_part("+inf.0", _exactness, _whole, _line, _col),
     do: {:float_special, :pos_inf}
 


### PR DESCRIPTION
## Summary

Elixir 1.20.0-rc.6 tightens exhaustiveness analysis and flags the `when is_integer(raw)` clause of `defp parse_complex_part/5` in the lexer as never reached, breaking the build under `warnings_as_errors`.

```
warning: this clause of defp parse_complex_part/5 is never used
 │
 586 │   defp parse_complex_part(raw, exactness, _whole, _line, _col) when is_integer(raw),
 │        ~
 │
 └─ lib/schooner/lexer.ex:586:8: Schooner.Lexer.parse_complex_part/5
```

The clause is genuinely dead. `parse_complex_part/5` has three call sites, all inside `complex_token/5`:

- The `{real_raw, imag_raw}` clause is guarded `when is_binary(real_raw) and is_binary(imag_raw)`, so both halves are binaries before they reach `parse_complex_part`.
- The `{real_part, imag_int}` clause routes integers through `lift_int/2` directly via a `cond`; `parse_complex_part/5` is only called inside the `is_binary(real_part)` branch.

So `parse_complex_part/5` only ever sees binaries; the `is_integer(raw)` clause has been unreachable since complex support landed in 15b19c8c. Elixir 1.20 can now infer this from the other clauses and flags it.

No behaviour change — the runtime never took that path.

## Test plan

- [x] `mix precommit` on baseline (Elixir 1.19.5 / OTP 28.3) — format, credo strict, 1511 tests + 27 properties + 1 doctest, 0 failures.
- [x] `mix compile` on Elixir 1.20.0-rc.6 / OTP 28.3 — clean with `warnings_as_errors: true`.